### PR TITLE
Prevent infinite retry for proctored exam status check errors

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.4.5'
+__version__ = '2.4.6'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This will prevent us from hitting e.g. https://github.com/edx/edx-proctoring/blob/b3b1406aebb79b511c1feae06853eda8ac277a95/edx_proctoring/views.py#L339 over and over again large numbers of times.

Somewhat unclear why, in practice, we have been seeing that occur. It's a bit pathological for learner behavior, and it's happened remarkably often lately, but it's possible for that to've been happenstance.

Been checking the scope of the issue being addressed with this NRQL query: ```SELECT count(1), max(timestamp) - min(timestamp) FROM TransactionError facet error.message, request_user_id WHERE error.class = 'edx_proctoring.exceptions:ProctoredExamPermissionDenied'  SINCE 7 DAYS AGO```