### PR TITLE
fix: practice exam updates should trigger grade and credit updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.1.3] - 2021-10-15
+~~~~~~~~~~~~~~~~~~~~
+* Always allow practice attempts to trigger grade/credit/certificate updates
+
 [4.1.2] - 2021-10-07
 ~~~~~~~~~~~~~~~~~~~~
 * Instructor dashboard view should redirect to review url for PSI exam attempts

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.1.2'
+__version__ = '4.1.3'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/management/commands/tests/test_update_attempts_for_exam.py
+++ b/edx_proctoring/management/commands/tests/test_update_attempts_for_exam.py
@@ -1,0 +1,62 @@
+"""
+Tests for the update_attempts_for_exam management command
+"""
+
+from mock import patch
+
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+
+from edx_proctoring.api import create_exam, create_exam_attempt, update_attempt_status
+from edx_proctoring.models import ProctoredExamStudentAttempt
+from edx_proctoring.runtime import set_runtime_service
+from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
+from edx_proctoring.tests.test_services import MockCertificateService, MockCreditService, MockGradesService
+from edx_proctoring.tests.utils import LoggedInTestCase
+
+User = get_user_model()
+
+
+class TestUpdateAttemptsForExam(LoggedInTestCase):
+    """
+    Coverage of the update_attempts_for_exam.py file
+    """
+
+    def setUp(self):
+        """
+        Build up test data
+        """
+        super().setUp()
+        set_runtime_service('credit', MockCreditService())
+        set_runtime_service('grades', MockGradesService())
+        set_runtime_service('certificates', MockCertificateService())
+
+    def test_run_command(self):
+        """
+        Run the management command
+        """
+        exam_id = create_exam(
+            course_id='foo',
+            content_id='bar',
+            exam_name='Test Exam 1',
+            time_limit_mins=90
+        )
+
+        # create three users and three exam attempts
+        for i in range(3):
+            other_user = User.objects.create(username='otheruser'+str(i), password='test')
+            attempt_id = create_exam_attempt(exam_id, other_user.id, taking_as_proctored=True)
+            update_attempt_status(attempt_id, ProctoredExamStudentAttemptStatus.verified)
+
+        with patch.object(MockCreditService, 'set_credit_requirement_status') as mock_credit:
+            call_command(
+                'update_attempts_for_exam',
+                batch_size=2,
+                sleep_time=0,
+                exam_id=exam_id
+            )
+            mock_credit.assert_called()
+
+        # make sure status stays the same
+        attempts = ProctoredExamStudentAttempt.objects.filter(status=ProctoredExamStudentAttemptStatus.verified)
+        self.assertEqual(len(attempts), 3)

--- a/edx_proctoring/management/commands/update_attempts_for_exam.py
+++ b/edx_proctoring/management/commands/update_attempts_for_exam.py
@@ -1,0 +1,78 @@
+"""
+Django management command to re-trigger the status update of a ProctoredExamStudentAttempt
+for a specific proctored exam.
+"""
+
+import logging
+import time
+
+from django.core.management.base import BaseCommand
+
+from edx_proctoring.api import update_attempt_status
+from edx_proctoring.models import ProctoredExamStudentAttempt
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Django Management command to update is_attempt_active field on review models
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--batch_size',
+            action='store',
+            dest='batch_size',
+            type=int,
+            default=300,
+            help='Maximum number of attempts to process. '
+                 'This helps avoid overloading the database while updating large amount of data.'
+        )
+        parser.add_argument(
+            '--sleep_time',
+            action='store',
+            dest='sleep_time',
+            type=int,
+            default=10,
+            help='Sleep time in seconds between update of batches'
+        )
+
+        parser.add_argument(
+            '--exam_id',
+            action='store',
+            dest='exam_id',
+            type=int,
+            help='Exam ID to process attempts for.'
+        )
+
+    def handle(self, *args, **options):
+        """
+        Management command entry point, simply call into the signal firing
+        """
+
+        batch_size = options['batch_size']
+        sleep_time = options['sleep_time']
+        exam_id = options['exam_id']
+
+        # get all attempts for specific exam id
+        exam_attempts = ProctoredExamStudentAttempt.objects.filter(proctored_exam_id=exam_id)
+
+        attempt_count = 0
+
+        # for each of those attempts, get id and status
+        for attempt in exam_attempts:
+            current_status = attempt.status
+            current_id = attempt.id
+
+            log.info(
+                'Triggering attempt status update for attempt_id=%(attempt_id)s with status=%(status)s',
+                {'attempt_id': current_id, 'status': current_status}
+            )
+            # need to use update_attempt_status because this function will trigger grade + credit updates
+            update_attempt_status(current_id, current_status)
+            attempt_count += 1
+
+            if attempt_count == batch_size:
+                attempt_count = 0
+                time.sleep(sleep_time)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

Status updates to a practice exam should always be allowed to trigger grade and credit updates, as opposed to the cumulative approach that is taken for non-practice proctored exams (i.e. all attempts for an exam must be verified to trigger a status update). 

A management command has also been added to re-trigger credit/grade/certificate updates through the `update_attempt_status` API function. 

**JIRA:**

[MST-1049](https://openedx.atlassian.net/browse/MST-1049)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.