### PR TITLE
fix: timed exams should still be visible after course end date

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.2.0] - 2021-10-20
+~~~~~~~~~~~~~~~~~~~~
+* Timed exams should remain visible after the course end date has passed
+
 [4.1.3] - 2021-10-15
 ~~~~~~~~~~~~~~~~~~~~
 * Always allow practice attempts to trigger grade/credit/certificate updates

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.1.3'
+__version__ = '4.2.0'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -67,6 +67,7 @@ from edx_proctoring.utils import (
     get_time_remaining_for_attempt,
     get_user_course_outline_details,
     has_due_date_passed,
+    has_end_date_passed,
     humanized_time,
     is_reattempting_exam,
     obscured_user_id,
@@ -881,7 +882,13 @@ def is_exam_passed_due(exam, user=None):
     Return whether the due date has passed.
     Uses edx_when to lookup the date for the subsection.
     """
-    return has_due_date_passed(get_exam_due_date(exam, user=user))
+    return (
+        has_due_date_passed(get_exam_due_date(exam, user=user))
+        # if the exam is timed and passed the course end date, it should also be considered passed due
+        or (
+            not exam['is_proctored'] and not exam['is_practice_exam'] and has_end_date_passed(exam['course_id'])
+        )
+    )
 
 
 def _was_review_status_acknowledged(is_status_acknowledged, exam):

--- a/edx_proctoring/management/commands/tests/test_set_is_attempt_active.py
+++ b/edx_proctoring/management/commands/tests/test_set_is_attempt_active.py
@@ -25,7 +25,7 @@ class SetAttemptActiveFieldTests(LoggedInTestCase):
         set_runtime_service('grades', MockGradesService())
         set_runtime_service('certificates', MockCertificateService())
         self.exam_id = create_exam(
-            course_id='foo',
+            course_id='a/b/c',
             content_id='bar',
             exam_name='Test Exam',
             time_limit_mins=90

--- a/edx_proctoring/management/commands/tests/test_update_attempt_status_from_review.py
+++ b/edx_proctoring/management/commands/tests/test_update_attempt_status_from_review.py
@@ -29,13 +29,13 @@ class SetAttemptActiveFieldTests(LoggedInTestCase):
         set_runtime_service('grades', MockGradesService())
         set_runtime_service('certificates', MockCertificateService())
         self.first_exam_id = create_exam(
-            course_id='foo',
+            course_id='a/b/c',
             content_id='bar',
             exam_name='Test Exam 1',
             time_limit_mins=90
         )
         self.second_exam_id = create_exam(
-            course_id='foo',
+            course_id='a/b/c',
             content_id='baz',
             exam_name='Test Exam 2',
             time_limit_mins=90

--- a/edx_proctoring/management/commands/tests/test_update_attempts_for_exam.py
+++ b/edx_proctoring/management/commands/tests/test_update_attempts_for_exam.py
@@ -36,7 +36,7 @@ class TestUpdateAttemptsForExam(LoggedInTestCase):
         Run the management command
         """
         exam_id = create_exam(
-            course_id='foo',
+            course_id='a/b/c',
             content_id='bar',
             exam_name='Test Exam 1',
             time_limit_mins=90

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

As outlined in the [Desired Exam Visiblity Doc](https://openedx.atlassian.net/wiki/spaces/PT/pages/3087041108/Desired+Behavior+Support), timed exams should be visible after the course end date has passed if the user has submitted the exam. This is to ensure that exam visibility remains consistent within self paced courses (i.e. an exam is visible after the self-paced due date has passed, and should remain visible after the course end date passes), and also to more closely align visibility behavior between instructor and self-paced courses. 

**JIRA:**

[MST-979](https://openedx.atlassian.net/browse/MST-979)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.