### PR TITLE
fix: video_url should be excluded from software secure review admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.3.2] - 2021-10-29
+~~~~~~~~~~~~~~~~~~~~
+* Video url field should be excluded from review admin
+
 [4.3.1] - 2021-10-28
 ~~~~~~~~~~~~~~~~~~~~
 * Set the to be retired column video_url on ProctoredExamSoftwareSecureReview to be nullable.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.3.1'
+__version__ = '4.3.2'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/admin.py
+++ b/edx_proctoring/admin.py
@@ -260,6 +260,7 @@ class ProctoredExamSoftwareSecureReviewAdmin(admin.ModelAdmin):
     search_fields = ['student__username', 'attempt_code']
     ordering = ['-modified']
     form = ProctoredExamSoftwareSecureReviewForm
+    exclude = ['video_url']
 
     def _get_exam_from_attempt_code(self, code):
         """Get exam from attempt code. Note that the attempt code could be an archived one"""

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

The video_url is currently required on the django admin form for reviews. This field should not be included in the form. I confirmed on devstack that this change removes the video_url from the form, allowing reviewers to save their changes.

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.