### PR TITLE
fix: unreference the ProctoredExamSoftwareSecureReview.video_url

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+[4.3.2] - 2021-10-28
+~~~~~~~~~~~~~~~~~~~~
+* Remove video_url reference from ProctoredExamSoftwareSecureReview.
 
 [4.3.1] - 2021-10-28
 ~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.3.1'
+__version__ = '4.3.2'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -771,11 +771,6 @@ class ProctoredExamSoftwareSecureReview(TimeStampedModel):
     # reviewing service
     raw_data = models.TextField()
 
-    # URL for the exam video that had been reviewed
-    # NOTE: To be deleted in future release, once the code that depends on it
-    # has been removed
-    video_url = models.TextField(null=True)
-
     # Encrypted URL for the exam video that had been reviewed
     encrypted_video_url = models.BinaryField(null=True)
 
@@ -848,9 +843,6 @@ class ProctoredExamSoftwareSecureReviewHistory(TimeStampedModel):
     # The raw payload that was received back from the
     # reviewing service
     raw_data = models.TextField()
-
-    # URL for the exam video that had been reviewed
-    video_url = models.TextField(null=True)
 
     # user_id of person who did the review (can be None if submitted via server-to-server API)
     reviewed_by = models.ForeignKey(USER_MODEL, null=True, related_name='+', on_delete=models.CASCADE)

--- a/edx_proctoring/tests/test_reviews.py
+++ b/edx_proctoring/tests/test_reviews.py
@@ -141,7 +141,6 @@ class ReviewTests(LoggedInTestCase):
 
             self.assertIsNotNone(review)
             self.assertEqual(review.review_status, review_status)
-            self.assertFalse(review.video_url)
             self.assertTrue(review.encrypted_video_url)
 
             self.assertIsNotNone(review.raw_data)
@@ -301,7 +300,6 @@ class ReviewTests(LoggedInTestCase):
 
         self.assertIsNotNone(review)
         self.assertEqual(review.review_status, SoftwareSecureReviewStatus.clean)
-        self.assertFalse(review.video_url)
 
         self.assertIsNotNone(review.raw_data)
 
@@ -347,7 +345,6 @@ class ReviewTests(LoggedInTestCase):
 
         self.assertIsNotNone(review)
         self.assertEqual(review.review_status, SoftwareSecureReviewStatus.suspicious)
-        self.assertFalse(review.video_url)
 
         self.assertIsNotNone(review.raw_data)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

No longer have anywhere in the code to reference video_url of the ProctoredExamSoftwareSecureReview model. Set it to be removed from the model
**JIRA:**

[MST-1100](https://openedx.atlassian.net/browse/mst-1100)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.