### PR TITLE
[MST-1275] Exclude 'denied' verified names when registering attempt

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.8.3] - 2022-01-12
+~~~~~~~~~~~~~~~~~~~~
+* Exclude verified name results with a "denied" status when registering a proctored
+  exam attempt.
+
 [4.8.2] - 2021-12-21
 ~~~~~~~~~~~~~~~~~~~~
 * Fix timeout value not getting passed to worker handler

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.8.2'
+__version__ = '4.8.3'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1023,14 +1023,19 @@ def _register_proctored_exam_attempt(user_id, exam_id, exam, attempt_code, revie
 
 def _get_verified_name(user_id, name_affirmation_service):
     """
-    Get the user's verified name if one exists.
+    Get the user's verified name if one exists. This will ignore verified names
+    which have a "denied" status.
 
     Returns a verified name object (or None)
     """
     verified_name = None
 
     user = USER_MODEL.objects.get(id=user_id)
-    verified_name_obj = name_affirmation_service.get_verified_name(user)
+
+    # Only use verified name if it is approved or pending approval
+    verified_name_obj = name_affirmation_service.get_verified_name(
+        user, is_verified=False, statuses_to_exclude=['denied']
+    )
 
     if verified_name_obj:
         verified_name = verified_name_obj.verified_name

--- a/edx_proctoring/tests/test_services.py
+++ b/edx_proctoring/tests/test_services.py
@@ -405,7 +405,7 @@ class MockNameAffirmationService:
     def __init__(self):
         self.verified_name = None
 
-    def get_verified_name(self, user, is_verified=False):
+    def get_verified_name(self, user, is_verified=False, statuses_to_exclude=None):
         """ Return mock VerifiedName """
         return self.verified_name
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

When a user has at least one verified name linked to their account, it will be used instead of their profile name when registering an exam attempt with the proctoring provider. We want to exclude verified names that have a "denied" status; only verified names that are already approved or are pending approval should be used.

**JIRA:**

[MST-1275](https://openedx.atlassian.net/browse/MST-1275)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.