### PR TITLE
fix: Proper handling to review callback on Non-proctored exam attempts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.8.4] - 2022-01-12
+~~~~~~~~~~~~~~~~~~~~
+* Return better http status when review callback resulted in the original
+  exam no longer being proctored 
+
 [4.8.3] - 2022-01-12
 ~~~~~~~~~~~~~~~~~~~~
 * Exclude verified name results with a "denied" status when registering a proctored

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.8.3'
+__version__ = '4.8.4'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

Sometimes, Verificient would send attempt reviewed status back to edX, but the exam associated with the attempts would be updated to be no longer a proctored exam. In this case, the review callback endpoint on edX would return 500 errors. This is not desired. Instead, we should log and return 200 to acknowledge we have received the event.

**JIRA:**

[MST-1301](https://openedx.atlassian.net/browse/MST-1301)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.