### PR TITLE
test: old github link in npm requirements for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "karma-chrome-launcher": "^0.2.0",
     "karma-coverage": "^1.1.1",
     "karma-jasmine": "^0.3.6",
-    "karma-jasmine-jquery": "0.1.1",
+    "karma-jasmine-jquery": "github:bessdsv/karma-jasmine-jquery#c1579f7bc8e98dd7b225367dbe52b49e75c9bfaf",
     "karma-phantomjs-launcher": "^1.0.4",
     "karma-sinon": "^1.0.5",
     "phantomjs-prebuilt": "^2.1.14",


### PR DESCRIPTION
Diff in the dependency:
https://github.com/bessdsv/karma-jasmine-jquery/compare/1.1...c1579f7bc8e98dd7b225367dbe52b49e75c9bfaf
This was causing builds to fail with messages like

```
npm ERR! Error while executing:
npm ERR! /usr/bin/git ls-remote -h -t git://github.com/bessdsv/bower-installer.git
npm ERR!
npm ERR! fatal: remote error:
npm ERR!   The unauthenticated git protocol on port 9418 is no longer supported.
npm ERR! Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
npm ERR!
npm ERR! exited with error code: 128
```

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [ ] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.