### PR TITLE
fix: add an api endpoint to retrieve exam histories

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.9.1] - 2022-03-09
+~~~~~~~~~~~~~~~~~~~~
+* Added a python API endpoint to retrieve serialized exam history records
+
 [4.9.0] - 2022-01-25
 ~~~~~~~~~~~~~~~~~~~~
 * Dropped Django22, 30 and 31

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.9.0'
+__version__ = '4.9.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -481,6 +481,33 @@ def get_exam_by_content_id(course_id, content_id):
     serialized_exam_object = ProctoredExamSerializer(proctored_exam)
     return serialized_exam_object.data
 
+def get_exam_histories_by_content_id(course_id, content_id):
+    """
+    Get all the historical records associated with the content_id.
+    If the exam is not found on content_id, raise not found exception
+
+    Returns a list of dictionary version of the Exam Django ORM object
+    
+    e.g.
+    [{
+        "course_id": "edX/DemoX/Demo_Course",
+        "content_id": "123",
+        "external_id": "",
+        "exam_name": "Midterm",
+        "time_limit_mins": 90,
+        "is_proctored": true,
+        "is_active": true
+    }]
+    """
+    proctored_exam = ProctoredExam.get_exam_by_content_id(course_id, content_id)
+    if proctored_exam is None:
+        err_msg = (
+            f'Cannot find proctored exam in course_id={course_id} with content_id={content_id}'
+        )
+        raise ProctoredExamNotFoundException(err_msg)
+    serialized_exam_history_object = ProctoredExamSerializer(proctored_exam.history.order_by('modified'), many=True)
+    return serialized_exam_history_object.data
+
 
 def add_allowance_for_user(exam_id, user_info, key, value):
     """

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -40,6 +40,7 @@ from edx_proctoring.api import (
     get_exam_attempt_by_id,
     get_exam_attempt_data,
     get_exam_by_content_id,
+    get_exam_histories_by_content_id,
     get_exam_by_id,
     get_exam_configuration_dashboard_url,
     get_exam_violation_report,
@@ -440,6 +441,32 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
 
         with self.assertRaises(ProctoredExamNotFoundException):
             get_exam_by_content_id('teasd', 'tewasda')
+
+    def test_get_exam_histories_by_content_id(self):
+        exam_histories = get_exam_histories_by_content_id(self.course_id, self.content_id)
+        self.assertEqual(len(exam_histories), 1)
+        exam_history = exam_histories[0]
+        self.assertEqual(exam_history['course_id'], self.course_id)
+        self.assertEqual(exam_history['content_id'], self.content_id)
+        self.assertEqual(exam_history['is_proctored'], True)
+
+
+    def test_get_multiple_exam_histories_by_content_id(self):
+        update_exam(self.proctored_exam_id, is_proctored=False)
+        exam_histories = get_exam_histories_by_content_id(self.course_id, self.content_id)
+        self.assertEqual(len(exam_histories), 2)
+        is_proctored = True
+        for exam_history in exam_histories:
+            self.assertEqual(exam_history['course_id'], self.course_id)
+            self.assertEqual(exam_history['content_id'], self.content_id)
+            self.assertEqual(exam_history['is_proctored'], is_proctored)
+            is_proctored = False
+
+
+    def test_get_exam_histories_by_content_id_not_found(self):
+        with self.assertRaises(ProctoredExamNotFoundException):
+            get_exam_histories_by_content_id('teasd', 'tewasda')
+
 
     def test_add_allowance_for_user(self):
         """

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

Add a python API endpoint to allow retrieval of serialized exam history records

**JIRA:**

[MST-1392](https://openedx.atlassian.net/browse/MST-1392)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.