### PR TITLE
Revert eslint migration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@edx/eslint-config",
+  "extends": "eslint-config-edx-es5",
   "globals": {
     "sinon": false,
     "setFixtures": false,
@@ -8,13 +8,6 @@
     "Backbone": false,
     "gettext": false,
     "Promise": false,
-    "edx": true,
-    "$": true,
-    "jQuery": true,
-    "spyOn": true,
-    "jasmine": true
-  },
-  "rules": {
-    "object-shorthand": [0, "always", { "ignoreConstructors": true }]
+    "edx": true
   }
 }

--- a/.eslintrc.worker.json
+++ b/.eslintrc.worker.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@edx/eslint-config",
+  "extends": "eslint-config-edx",
   "env": {
     "worker": true
   }

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.12.1] - 2022-09-15
+~~~~~~~~~~~~~~~~~~~~~
+* Revert Phantom JS and eslint migration made in version 4.11.0
+
 [4.12.0] - 2022-08-29
 ~~~~~~~~~~~~~~~~~~~~~
 * Improved ``developing.rst`` docs for installing and running the mockprock proctoring provider.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.12.0'
+__version__ = '4.12.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/static/proctoring/js/collections/proctored_exam_allowance_collection.js
+++ b/edx_proctoring/static/proctoring/js/collections/proctored_exam_allowance_collection.js
@@ -1,15 +1,15 @@
 edx = edx || {};
-(Backbone => {
-  'use strict';
+(function(Backbone) {
+    'use strict';
 
-  edx.instructor_dashboard = edx.instructor_dashboard || {};
-  edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
 
-  edx.instructor_dashboard.proctoring.ProctoredExamAllowanceCollection = Backbone.Collection.extend({
-    /* model for a collection of ProctoredExamAllowance */
-    model: edx.instructor_dashboard.proctoring.ProctoredExamAllowanceModel,
-    url: '/api/edx_proctoring/v1/proctored_exam/',
-  });
-  const proctoredExamAllowanceCollection = edx.instructor_dashboard.proctoring.ProctoredExamAllowanceCollection;
-  this.edx.instructor_dashboard.proctoring.ProctoredExamAllowanceCollection = proctoredExamAllowanceCollection;
+    edx.instructor_dashboard.proctoring.ProctoredExamAllowanceCollection = Backbone.Collection.extend({
+        /* model for a collection of ProctoredExamAllowance */
+        model: edx.instructor_dashboard.proctoring.ProctoredExamAllowanceModel,
+        url: '/api/edx_proctoring/v1/proctored_exam/'
+    });
+    this.edx.instructor_dashboard.proctoring.ProctoredExamAllowanceCollection =
+        edx.instructor_dashboard.proctoring.ProctoredExamAllowanceCollection;
 }).call(this, Backbone);

--- a/edx_proctoring/static/proctoring/js/collections/proctored_exam_attempt_grouped_collection.js
+++ b/edx_proctoring/static/proctoring/js/collections/proctored_exam_attempt_grouped_collection.js
@@ -1,15 +1,15 @@
 edx = edx || {};
-(Backbone => {
-  'use strict';
+(function(Backbone) {
+    'use strict';
 
-  edx.instructor_dashboard = edx.instructor_dashboard || {};
-  edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
 
-  edx.instructor_dashboard.proctoring.ProctoredExamAttemptGroupedCollection = Backbone.Collection.extend({
-    /* model for a collection of ProctoredExamAttempt */
-    model: edx.instructor_dashboard.proctoring.ProctoredExamAttemptModel,
-    url: '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/',
-  });
-  const groupedCollection = edx.instructor_dashboard.proctoring.ProctoredExamAttemptGroupedCollection;
-  this.edx.instructor_dashboard.proctoring.ProctoredExamAttemptGroupedCollection = groupedCollection;
+    edx.instructor_dashboard.proctoring.ProctoredExamAttemptGroupedCollection = Backbone.Collection.extend({
+        /* model for a collection of ProctoredExamAttempt */
+        model: edx.instructor_dashboard.proctoring.ProctoredExamAttemptModel,
+        url: '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/'
+    });
+    this.edx.instructor_dashboard.proctoring.ProctoredExamAttemptGroupedCollection =
+      edx.instructor_dashboard.proctoring.ProctoredExamAttemptGroupedCollection;
 }).call(this, Backbone);

--- a/edx_proctoring/static/proctoring/js/collections/proctored_exam_collection.js
+++ b/edx_proctoring/static/proctoring/js/collections/proctored_exam_collection.js
@@ -1,16 +1,16 @@
 /* globals ProctoredExamModel:false */
 edx = edx || {};
-(Backbone => {
-  'use strict';
+(function(Backbone) {
+    'use strict';
 
-  edx.instructor_dashboard = edx.instructor_dashboard || {};
-  edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
 
-  edx.instructor_dashboard.proctoring.ProctoredExamCollection = Backbone.Collection.extend({
-    /* model for a collection of ProctoredExamAllowance */
-    model: ProctoredExamModel,
-    url: '/api/edx_proctoring/v1/proctored_exam/exam/course_id/',
-  });
-  const proctoredExamCollection = edx.instructor_dashboard.proctoring.ProctoredExamCollection;
-  this.edx.instructor_dashboard.proctoring.ProctoredExamCollection = proctoredExamCollection;
+    edx.instructor_dashboard.proctoring.ProctoredExamCollection = Backbone.Collection.extend({
+        /* model for a collection of ProctoredExamAllowance */
+        model: ProctoredExamModel,
+        url: '/api/edx_proctoring/v1/proctored_exam/exam/course_id/'
+    });
+    this.edx.instructor_dashboard.proctoring.ProctoredExamCollection =
+      edx.instructor_dashboard.proctoring.ProctoredExamCollection;
 }).call(this, Backbone);

--- a/edx_proctoring/static/proctoring/js/collections/proctored_exam_onboarding_collection.js
+++ b/edx_proctoring/static/proctoring/js/collections/proctored_exam_onboarding_collection.js
@@ -1,13 +1,13 @@
 edx = edx || {};
-(Backbone => {
-  'use strict';
+(function(Backbone) {
+    'use strict';
 
-  edx.instructor_dashboard = edx.instructor_dashboard || {};
-  edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
 
-  edx.instructor_dashboard.proctoring.ProctoredExamOnboardingCollection = Backbone.Collection.extend({
-    url: '/api/edx_proctoring/v1/user_onboarding/status/course_id/',
-  });
-  const proctoredExamOnboardingCollection = edx.instructor_dashboard.proctoring.ProctoredExamOnboardingCollection;
-  this.edx.instructor_dashboard.proctoring.ProctoredExamOnboardingCollection = proctoredExamOnboardingCollection;
+    edx.instructor_dashboard.proctoring.ProctoredExamOnboardingCollection = Backbone.Collection.extend({
+        url: '/api/edx_proctoring/v1/user_onboarding/status/course_id/'
+    });
+    this.edx.instructor_dashboard.proctoring.ProctoredExamOnboardingCollection =
+      edx.instructor_dashboard.proctoring.ProctoredExamOnboardingCollection;
 }).call(this, Backbone);

--- a/edx_proctoring/static/proctoring/js/dropdown.js
+++ b/edx_proctoring/static/proctoring/js/dropdown.js
@@ -3,95 +3,95 @@
 // It has been slightly modified to fit the needs of the edx-proctoring library.
 edx = edx || {};
 
-($ => {
-  'use strict';
+(function($) {
+    'use strict';
 
-  const keyCodes = {
-    TAB: 9,
-    ESCAPE: 27,
-    SPACE: 32,
-    ARROWUP: 38,
-    ARROWDOWN: 40,
-  };
-
-  edx.dashboard = edx.dashboard || {};
-  edx.dashboard.dropdown = {};
-
-  edx.dashboard.dropdown.toggleExamAttemptActionDropdownMenu = event => {
-    const $target = $(event.currentTarget);
-    const { dashboardIndex } = $target.data();
-    const $dropdown = $($target.data('dropdownSelector') || `#actions-dropdown-${dashboardIndex}`);
-    const $dropdownButton = $($target.data('dropdownButtonSelector') || `#actions-dropdown-link-${dashboardIndex}`);
-    const ariaExpandedState = ($dropdownButton.attr('aria-expanded') === 'true');
-    const menuItems = $dropdown.find('a');
-
-    const catchKeyPress = (object, keyPressEvent) => {
-      // get currently focused item
-      const $focusedItem = $(':focus');
-
-      // get the index of the currently focused item
-      const focusedItemIndex = menuItems.index($focusedItem);
-
-      // var to store next focused item index
-      let itemToFocusIndex;
-
-      // if space or escape key pressed
-      if (keyPressEvent.which === keyCodes.SPACE || keyPressEvent.which === keyCodes.ESCAPE) {
-        $dropdownButton.click();
-        keyPressEvent.preventDefault();
-      } else if (keyPressEvent.which === keyCodes.AWRROWUP
-                || (keyPressEvent.which === keyCodes.TAB && keyPressEvent.shiftKey)) {
-        // if up arrow key pressed or shift+tab
-        // if first item go to last
-        if (focusedItemIndex === 0 || focusedItemIndex === -1) {
-          menuItems.last().focus();
-        } else {
-          itemToFocusIndex = focusedItemIndex - 1;
-          menuItems.get(itemToFocusIndex).focus();
-        }
-        keyPressEvent.preventDefault();
-      } else if (keyPressEvent.which === keyCodes.ARROWDOWN || keyPressEvent.which === keyCodes.TAB) {
-        // if down arrow key pressed or tab key
-        // if last item go to first
-        if (focusedItemIndex === menuItems.length - 1 || focusedItemIndex === -1) {
-          menuItems.first().focus();
-        } else {
-          itemToFocusIndex = focusedItemIndex + 1;
-          menuItems.get(itemToFocusIndex).focus();
-        }
-        keyPressEvent.preventDefault();
-      }
+    var keyCodes = {
+        TAB: 9,
+        ESCAPE: 27,
+        SPACE: 32,
+        ARROWUP: 38,
+        ARROWDOWN: 40
     };
 
-    // Toggle the visibility control for the selected element and set the focus
-    $dropdown.toggleClass('is-visible');
-    if ($dropdown.hasClass('is-visible')) {
-      $dropdown.attr('tabindex', -1);
-      $dropdown.focus();
-    } else {
-      $dropdown.removeAttr('tabindex');
-      $dropdownButton.focus();
-    }
+    edx.dashboard = edx.dashboard || {};
+    edx.dashboard.dropdown = {};
 
-    // Inform the ARIA framework that the dropdown has been expanded
-    $dropdownButton.attr('aria-expanded', !ariaExpandedState);
+    edx.dashboard.dropdown.toggleExamAttemptActionDropdownMenu = function(event) {
+        var $target = $(event.currentTarget),
+            dashboardIndex = $target.data().dashboardIndex,
+            $dropdown = $($target.data('dropdownSelector') || '#actions-dropdown-' + dashboardIndex),
+            $dropdownButton = $($target.data('dropdownButtonSelector') || '#actions-dropdown-link-' + dashboardIndex),
+            ariaExpandedState = ($dropdownButton.attr('aria-expanded') === 'true'),
+            menuItems = $dropdown.find('a');
 
-    // catch keypresses when inside dropdownMenu (we want to catch spacebar;
-    // escape; up arrow or shift+tab; and down arrow or tab)
-    $dropdown.on('keydown', e => {
-      catchKeyPress($(this), e);
+        var catchKeyPress = function(object, keyPressEvent) {
+            // get currently focused item
+            var $focusedItem = $(':focus');
+
+            // get the index of the currently focused item
+            var focusedItemIndex = menuItems.index($focusedItem);
+
+            // var to store next focused item index
+            var itemToFocusIndex;
+
+            // if space or escape key pressed
+            if (keyPressEvent.which === keyCodes.SPACE || keyPressEvent.which === keyCodes.ESCAPE) {
+                $dropdownButton.click();
+                keyPressEvent.preventDefault();
+            } else if (keyPressEvent.which === keyCodes.AWRROWUP ||
+                (keyPressEvent.which === keyCodes.TAB && keyPressEvent.shiftKey)) {
+                // if up arrow key pressed or shift+tab
+                // if first item go to last
+                if (focusedItemIndex === 0 || focusedItemIndex === -1) {
+                    menuItems.last().focus();
+                } else {
+                    itemToFocusIndex = focusedItemIndex - 1;
+                    menuItems.get(itemToFocusIndex).focus();
+                }
+                keyPressEvent.preventDefault();
+            } else if (keyPressEvent.which === keyCodes.ARROWDOWN || keyPressEvent.which === keyCodes.TAB) {
+                // if down arrow key pressed or tab key
+                // if last item go to first
+                if (focusedItemIndex === menuItems.length - 1 || focusedItemIndex === -1) {
+                    menuItems.first().focus();
+                } else {
+                    itemToFocusIndex = focusedItemIndex + 1;
+                    menuItems.get(itemToFocusIndex).focus();
+                }
+                keyPressEvent.preventDefault();
+            }
+        };
+
+        // Toggle the visibility control for the selected element and set the focus
+        $dropdown.toggleClass('is-visible');
+        if ($dropdown.hasClass('is-visible')) {
+            $dropdown.attr('tabindex', -1);
+            $dropdown.focus();
+        } else {
+            $dropdown.removeAttr('tabindex');
+            $dropdownButton.focus();
+        }
+
+        // Inform the ARIA framework that the dropdown has been expanded
+        $dropdownButton.attr('aria-expanded', !ariaExpandedState);
+
+        // catch keypresses when inside dropdownMenu (we want to catch spacebar;
+        // escape; up arrow or shift+tab; and down arrow or tab)
+        $dropdown.on('keydown', function(e) {
+            catchKeyPress($(this), e);
+        });
+        event.stopPropagation();
+    };
+
+    edx.dashboard.dropdown.bindToggleButtons = function(selector) {
+        $(selector).bind(
+            'click',
+            edx.dashboard.dropdown.toggleExamAttemptActionDropdownMenu
+        );
+    };
+
+    $(document).ready(function() {
+        edx.dashboard.dropdown.bindToggleButtons('.action-more');
     });
-    event.stopPropagation();
-  };
-
-  edx.dashboard.dropdown.bindToggleButtons = selector => {
-    $(selector).bind(
-      'click',
-      edx.dashboard.dropdown.toggleExamAttemptActionDropdownMenu,
-    );
-  };
-
-  $(document).ready(() => {
-    edx.dashboard.dropdown.bindToggleButtons('.action-more');
-  });
-})(jQuery);
+}(jQuery));

--- a/edx_proctoring/static/proctoring/js/exam_action_handler.js
+++ b/edx_proctoring/static/proctoring/js/exam_action_handler.js
@@ -1,246 +1,252 @@
 /* globals accessible_modal:false */
 edx = edx || {};
 
-($ => {
-  'use strict';
+(function($) {
+    'use strict';
 
-  const actionToMessageTypesMap = {
-    submit: {
-      promptEventName: 'endExamAttempt',
-      successEventName: 'examAttemptEnded',
-      failureEventName: 'examAttemptEndFailed',
-    },
-    start: {
-      promptEventName: 'startExamAttempt',
-      successEventName: 'examAttemptStarted',
-      failureEventName: 'examAttemptStartFailed',
-    },
-    ping: {
-      promptEventName: 'ping',
-      successEventName: 'echo',
-      failureEventName: 'pingFailed',
+    var actionToMessageTypesMap = {
+        submit: {
+            promptEventName: 'endExamAttempt',
+            successEventName: 'examAttemptEnded',
+            failureEventName: 'examAttemptEndFailed'
+        },
+        start: {
+            promptEventName: 'startExamAttempt',
+            successEventName: 'examAttemptStarted',
+            failureEventName: 'examAttemptStartFailed'
+        },
+        ping: {
+            promptEventName: 'ping',
+            successEventName: 'echo',
+            failureEventName: 'pingFailed'
 
-    },
-  };
+        }
+    };
 
-  /**
+    /**
    * Launch modals, handling a11y focus behavior
    *
    * Note: don't try to leverage this for the heartbeat; the DOM
    * structure this depends on doesn't live everywhere that handler
    * needs to live
    */
-  function accessibleError(title, message) {
-    accessible_modal(
-      '#accessible-error-modal #confirm_open_button',
-      '#accessible-error-modal .close-modal',
-      '#accessible-error-modal',
-      '.content-wrapper',
-    );
-    $('#accessible-error-modal #confirm_open_button').click();
-    $('#accessible-error-modal .message-title').html(message);
-    $('#accessible-error-modal #acessible-error-title').html(title);
-    $('#accessible-error-modal .ok-button')
-      .html(gettext('OK'))
-      .off('click.closeModal')
-      .on('click.closeModal', () => {
-        $('#accessible-error-modal .close-modal').click();
-      });
-  }
+    function accessibleError(title, message) {
+        accessible_modal(
+            '#accessible-error-modal #confirm_open_button',
+            '#accessible-error-modal .close-modal',
+            '#accessible-error-modal',
+            '.content-wrapper'
+        );
+        $('#accessible-error-modal #confirm_open_button').click();
+        $('#accessible-error-modal .message-title').html(message);
+        $('#accessible-error-modal #acessible-error-title').html(title);
+        $('#accessible-error-modal .ok-button')
+            .html(gettext('OK'))
+            .off('click.closeModal')
+            .on('click.closeModal', function() {
+                $('#accessible-error-modal .close-modal').click();
+            });
+    }
 
-  function createWorker(url) {
-    const blob = new Blob([`importScripts('${url}');`], { type: 'application/javascript' });
-    const blobUrl = window.URL.createObjectURL(blob);
-    return new Worker(blobUrl);
-  }
+    function createWorker(url) {
+        var blob = new Blob(["importScripts('" + url + "');"], {type: 'application/javascript'});
+        var blobUrl = window.URL.createObjectURL(blob);
+        return new Worker(blobUrl);
+    }
 
-  function workerPromiseForEventNames(eventNames) {
-    return timeout => {
-      const proctoringBackendWorker = createWorker(edx.courseware.proctored_exam.configuredWorkerURL);
-      return new Promise((resolve, reject) => {
-        const responseHandler = e => {
-          if (e.data.type === eventNames.successEventName) {
-            proctoringBackendWorker.removeEventListener('message', responseHandler);
-            proctoringBackendWorker.terminate();
-            resolve();
-          } else {
-            reject(e.data.error);
-          }
+    function workerPromiseForEventNames(eventNames) {
+        return function(timeout) {
+            var proctoringBackendWorker = createWorker(edx.courseware.proctored_exam.configuredWorkerURL);
+            return new Promise(function(resolve, reject) {
+                var responseHandler = function(e) {
+                    if (e.data.type === eventNames.successEventName) {
+                        proctoringBackendWorker.removeEventListener('message', responseHandler);
+                        proctoringBackendWorker.terminate();
+                        resolve();
+                    } else {
+                        reject(e.data.error);
+                    }
+                };
+                proctoringBackendWorker.addEventListener('message', responseHandler);
+                proctoringBackendWorker.postMessage({type: eventNames.promptEventName, timeout: timeout});
+            });
         };
-        proctoringBackendWorker.addEventListener('message', responseHandler);
-        proctoringBackendWorker.postMessage({ type: eventNames.promptEventName, timeout });
-      });
-    };
-  }
-
-  function workerTimeoutPromise(timeoutMilliseconds) {
-    const message = `worker failed to respond after ${timeoutMilliseconds}ms`;
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        reject(Error(message));
-      }, timeoutMilliseconds);
-    });
-  }
-
-  // Update the state of the attempt
-  function updateExamAttemptStatusPromise(actionUrl, action) {
-    return () => Promise.resolve($.ajax({
-      url: actionUrl,
-      type: 'PUT',
-      data: {
-        action,
-      },
-    }));
-  }
-
-  function reloadPage() {
-    window.location.reload();
-  }
-
-  function setActionButtonLoadingState($button) {
-    $button.prop('disabled', true);
-    $button.html($button.data('loading-text'));
-  }
-
-  function setActionButtonSteadyState($button) {
-    $button.prop('disabled', false);
-    $button.html($button.data('cta-text'));
-  }
-
-  function errorHandlerGivenMessage($button, title, message) {
-    setActionButtonSteadyState($button);
-    return () => {
-      accessibleError(title, message);
-    };
-  }
-
-  edx.courseware = edx.courseware || {};
-  edx.courseware.proctored_exam = edx.courseware.proctored_exam || {};
-  edx.courseware.proctored_exam.updateStatusHandler = () => {
-    const $this = $(this);
-    const actionUrl = $this.data('change-state-url');
-    const action = $this.data('action');
-    updateExamAttemptStatusPromise(actionUrl, action)()
-      .then(reloadPage)
-      .catch(errorHandlerGivenMessage(
-        $this,
-        gettext('Error Ending Exam'),
-        gettext(
-          'Something has gone wrong ending your exam. '
-                    + 'Please reload the page and start again.',
-        ),
-      ));
-  };
-  edx.courseware.proctored_exam.examStartHandler = e => {
-    const $this = $(this);
-    const actionUrl = $this.data('change-state-url');
-    const action = $this.data('action');
-    const shouldUseWorker = window.Worker && edx.courseware.proctored_exam.configuredWorkerURL;
-    const pingInterval = edx.courseware.proctored_exam.ProctoringAppPingInterval;
-    let startIntervalInMilliseconds;
-    if (pingInterval) {
-      startIntervalInMilliseconds = pingInterval * 1000;
     }
 
-    e.preventDefault();
-    e.stopPropagation();
-
-    setActionButtonLoadingState($this);
-
-    if (shouldUseWorker) {
-      workerPromiseForEventNames(actionToMessageTypesMap[action])(startIntervalInMilliseconds)
-        .then(updateExamAttemptStatusPromise(actionUrl, action))
-        .then(reloadPage)
-        .catch(errorHandlerGivenMessage(
-          $this,
-          gettext('Error Starting Exam'),
-          gettext(
-            'Something has gone wrong starting your exam. '
-            + 'Please double-check that the application is running.',
-          ),
-        ));
-    } else {
-      updateExamAttemptStatusPromise(actionUrl, action)()
-        .then(reloadPage)
-        .catch(errorHandlerGivenMessage(
-          $this,
-          gettext('Error Starting Exam'),
-          gettext(
-            'Something has gone wrong starting your exam. '
-            + 'Please reload the page and start again.',
-          ),
-        ));
-    }
-  };
-  edx.courseware.proctored_exam.examEndHandler = () => {
-    const $this = $(this);
-    const actionUrl = $this.data('change-state-url');
-    const action = $this.data('action');
-    const shouldUseWorker = window.Worker
-                          && edx.courseware.proctored_exam.configuredWorkerURL
-                          && action === 'submit';
-    $(window).unbind('beforeunload');
-
-    setActionButtonLoadingState($this);
-
-    if (shouldUseWorker) {
-      updateExamAttemptStatusPromise(actionUrl, action)()
-        .then(workerPromiseForEventNames(actionToMessageTypesMap[action]))
-        .then(reloadPage)
-        .catch(errorHandlerGivenMessage(
-          $this,
-          gettext('Error Ending Exam'),
-          gettext(
-            'Something has gone wrong ending your exam. '
-                        + 'Please double-check that the application is running.',
-          ),
-        ));
-    } else {
-      updateExamAttemptStatusPromise(actionUrl, action)()
-        .then(reloadPage)
-        .catch(errorHandlerGivenMessage(
-          $this,
-          gettext('Error Ending Exam'),
-          gettext(
-            'Something has gone wrong ending your exam. '
-            + 'Please reload the page and start again.',
-          ),
-        ));
-    }
-  };
-  edx.courseware.proctored_exam.checkExamAttemptStatus = attemptStatusPollURL => new Promise((resolve, reject) => {
-    $.ajax(attemptStatusPollURL).success((data) => {
-      if (data.status) {
-        resolve(data.status);
-      } else {
-        reject();
-      }
-    }).fail(() => {
-      reject();
-    });
-  });
-  edx.courseware.proctored_exam.endExam = attemptStatusPollURL => {
-    const shouldUseWorker = window.Worker
-                          && edx.courseware.proctored_exam.configuredWorkerURL;
-    if (shouldUseWorker) {
-      // todo would like to double-check the exam is ended on the LMS before proceeding
-      return edx.courseware.proctored_exam.checkExamAttemptStatus(attemptStatusPollURL)
-        .then((status) => {
-          if (status === 'submitted') {
-            return workerPromiseForEventNames(actionToMessageTypesMap.submit)();
-          }
-          return Promise.reject();
+    function workerTimeoutPromise(timeoutMilliseconds) {
+        var message = 'worker failed to respond after ' + timeoutMilliseconds + 'ms';
+        return new Promise(function(resolve, reject) {
+            setTimeout(function() {
+                reject(Error(message));
+            }, timeoutMilliseconds);
         });
     }
-    return Promise.resolve();
-  };
-  edx.courseware.proctored_exam.pingApplication = timeoutInSeconds => {
-    const TIMEOUT_BUFFER_SECONDS = 10;
-    const workerPingTimeout = timeoutInSeconds - TIMEOUT_BUFFER_SECONDS; // 10s buffer for worker to respond
-    return Promise.race([
-      workerPromiseForEventNames(actionToMessageTypesMap.ping)(workerPingTimeout * 1000),
-      workerTimeoutPromise(timeoutInSeconds * 1000),
-    ]);
-  };
-  edx.courseware.proctored_exam.accessibleError = accessibleError;
+
+    // Update the state of the attempt
+    function updateExamAttemptStatusPromise(actionUrl, action) {
+        return function() {
+            return Promise.resolve($.ajax({
+                url: actionUrl,
+                type: 'PUT',
+                data: {
+                    action: action
+                }
+            }));
+        };
+    }
+
+    function reloadPage() {
+        location.reload();
+    }
+
+    function setActionButtonLoadingState($button) {
+        $button.prop('disabled', true);
+        $button.html($button.data('loading-text'));
+    }
+
+    function setActionButtonSteadyState($button) {
+        $button.prop('disabled', false);
+        $button.html($button.data('cta-text'));
+    }
+
+    function errorHandlerGivenMessage($button, title, message) {
+        setActionButtonSteadyState($button);
+        return function() {
+            accessibleError(title, message);
+        };
+    }
+
+
+    edx.courseware = edx.courseware || {};
+    edx.courseware.proctored_exam = edx.courseware.proctored_exam || {};
+    edx.courseware.proctored_exam.updateStatusHandler = function() {
+        var $this = $(this);
+        var actionUrl = $this.data('change-state-url');
+        var action = $this.data('action');
+        updateExamAttemptStatusPromise(actionUrl, action)()
+            .then(reloadPage)
+            .catch(errorHandlerGivenMessage(
+                $this,
+                gettext('Error Ending Exam'),
+                gettext(
+                    'Something has gone wrong ending your exam. ' +
+                    'Please reload the page and start again.'
+                )
+            ));
+    };
+    edx.courseware.proctored_exam.examStartHandler = function(e) {
+        var $this = $(this);
+        var actionUrl = $this.data('change-state-url');
+        var action = $this.data('action');
+        var shouldUseWorker = window.Worker && edx.courseware.proctored_exam.configuredWorkerURL;
+        var pingInterval = edx.courseware.proctored_exam.ProctoringAppPingInterval;
+        var startIntervalInMilliseconds;
+        if (pingInterval) {
+            startIntervalInMilliseconds = pingInterval * 1000;
+        }
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        setActionButtonLoadingState($this);
+
+        if (shouldUseWorker) {
+            workerPromiseForEventNames(actionToMessageTypesMap[action])(startIntervalInMilliseconds)
+                .then(updateExamAttemptStatusPromise(actionUrl, action))
+                .then(reloadPage)
+                .catch(errorHandlerGivenMessage(
+                    $this,
+                    gettext('Error Starting Exam'),
+                    gettext(
+                        'Something has gone wrong starting your exam. ' +
+            'Please double-check that the application is running.'
+                    )
+                ));
+        } else {
+            updateExamAttemptStatusPromise(actionUrl, action)()
+                .then(reloadPage)
+                .catch(errorHandlerGivenMessage(
+                    $this,
+                    gettext('Error Starting Exam'),
+                    gettext(
+                        'Something has gone wrong starting your exam. ' +
+            'Please reload the page and start again.'
+                    )
+                ));
+        }
+    };
+    edx.courseware.proctored_exam.examEndHandler = function() {
+        var $this = $(this);
+        var actionUrl = $this.data('change-state-url');
+        var action = $this.data('action');
+        var shouldUseWorker = window.Worker &&
+                          edx.courseware.proctored_exam.configuredWorkerURL &&
+                          action === 'submit';
+        $(window).unbind('beforeunload');
+
+        setActionButtonLoadingState($this);
+
+        if (shouldUseWorker) {
+            updateExamAttemptStatusPromise(actionUrl, action)()
+                .then(workerPromiseForEventNames(actionToMessageTypesMap[action]))
+                .then(reloadPage)
+                .catch(errorHandlerGivenMessage(
+                    $this,
+                    gettext('Error Ending Exam'),
+                    gettext(
+                        'Something has gone wrong ending your exam. ' +
+                        'Please double-check that the application is running.'
+                    )
+                ));
+        } else {
+            updateExamAttemptStatusPromise(actionUrl, action)()
+                .then(reloadPage)
+                .catch(errorHandlerGivenMessage(
+                    $this,
+                    gettext('Error Ending Exam'),
+                    gettext(
+                        'Something has gone wrong ending your exam. ' +
+            'Please reload the page and start again.'
+                    )
+                ));
+        }
+    };
+    edx.courseware.proctored_exam.checkExamAttemptStatus = function(attemptStatusPollURL) {
+        return new Promise(function(resolve, reject) {
+            $.ajax(attemptStatusPollURL).success(function(data) {
+                if (data.status) {
+                    resolve(data.status);
+                } else {
+                    reject();
+                }
+            }).fail(function() {
+                reject();
+            });
+        });
+    };
+    edx.courseware.proctored_exam.endExam = function(attemptStatusPollURL) {
+        var shouldUseWorker = window.Worker &&
+                          edx.courseware.proctored_exam.configuredWorkerURL;
+        if (shouldUseWorker) {
+            // todo would like to double-check the exam is ended on the LMS before proceeding
+            return edx.courseware.proctored_exam.checkExamAttemptStatus(attemptStatusPollURL)
+                .then(function(status) {
+                    if (status === 'submitted') {
+                        return workerPromiseForEventNames(actionToMessageTypesMap.submit)();
+                    }
+                    return Promise.reject();
+                });
+        } else {
+            return Promise.resolve();
+        }
+    };
+    edx.courseware.proctored_exam.pingApplication = function(timeoutInSeconds) {
+        var TIMEOUT_BUFFER_SECONDS = 10;
+        var workerPingTimeout = timeoutInSeconds - TIMEOUT_BUFFER_SECONDS; // 10s buffer for worker to respond
+        return Promise.race([
+            workerPromiseForEventNames(actionToMessageTypesMap.ping)(workerPingTimeout * 1000),
+            workerTimeoutPromise(timeoutInSeconds * 1000)
+        ]);
+    };
+    edx.courseware.proctored_exam.accessibleError = accessibleError;
 }).call(this, $);

--- a/edx_proctoring/static/proctoring/js/models/learner_onboarding_model.js
+++ b/edx_proctoring/static/proctoring/js/models/learner_onboarding_model.js
@@ -1,7 +1,9 @@
-(Backbone => {
-  'use strict';
+(function(Backbone) {
+    'use strict';
 
-  this.LearnerOnboardingModel = Backbone.Model.extend({
-    url: '/api/edx_proctoring/v1/user_onboarding/status',
-  });
+    var LearnerOnboardingModel = Backbone.Model.extend({
+        url: '/api/edx_proctoring/v1/user_onboarding/status'
+    });
+
+    this.LearnerOnboardingModel = LearnerOnboardingModel;
 }).call(this, Backbone);

--- a/edx_proctoring/static/proctoring/js/models/proctored_exam_allowance_model.js
+++ b/edx_proctoring/static/proctoring/js/models/proctored_exam_allowance_model.js
@@ -1,15 +1,15 @@
 edx = edx || {};
 
-(Backbone => {
-  'use strict';
+(function(Backbone) {
+    'use strict';
 
-  edx.instructor_dashboard = edx.instructor_dashboard || {};
-  edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
 
-  edx.instructor_dashboard.proctoring.ProctoredExamAllowanceModel = Backbone.Model.extend({
-    url: '/api/edx_proctoring/v1/proctored_exam/allowance',
+    edx.instructor_dashboard.proctoring.ProctoredExamAllowanceModel = Backbone.Model.extend({
+        url: '/api/edx_proctoring/v1/proctored_exam/allowance'
 
-  });
-  const proctoredExamAllowanceModel = edx.instructor_dashboard.proctoring.ProctoredExamAllowanceModel;
-  this.edx.instructor_dashboard.proctoring.ProctoredExamAllowanceModel = proctoredExamAllowanceModel;
+    });
+    this.edx.instructor_dashboard.proctoring.ProctoredExamAllowanceModel =
+      edx.instructor_dashboard.proctoring.ProctoredExamAllowanceModel;
 }).call(this, Backbone);

--- a/edx_proctoring/static/proctoring/js/models/proctored_exam_attempt_model.js
+++ b/edx_proctoring/static/proctoring/js/models/proctored_exam_attempt_model.js
@@ -1,15 +1,15 @@
 edx = edx || {};
 
-(Backbone => {
-  'use strict';
+(function(Backbone) {
+    'use strict';
 
-  edx.instructor_dashboard = edx.instructor_dashboard || {};
-  edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
 
-  edx.instructor_dashboard.proctoring.ProctoredExamAttemptModel = Backbone.Model.extend({
-    url: '/api/edx_proctoring/v1/proctored_exam/attempt/',
+    edx.instructor_dashboard.proctoring.ProctoredExamAttemptModel = Backbone.Model.extend({
+        url: '/api/edx_proctoring/v1/proctored_exam/attempt/'
 
-  });
-  const proctoredExamAttemptModel = edx.instructor_dashboard.proctoring.ProctoredExamAttemptModel;
-  this.edx.instructor_dashboard.proctoring.ProctoredExamAttemptModel = proctoredExamAttemptModel;
+    });
+    this.edx.instructor_dashboard.proctoring.ProctoredExamAttemptModel =
+      edx.instructor_dashboard.proctoring.ProctoredExamAttemptModel;
 }).call(this, Backbone);

--- a/edx_proctoring/static/proctoring/js/models/proctored_exam_bulk_allowance_model.js
+++ b/edx_proctoring/static/proctoring/js/models/proctored_exam_bulk_allowance_model.js
@@ -1,15 +1,15 @@
 edx = edx || {};
 
-(Backbone => {
-  'use strict';
+(function(Backbone) {
+    'use strict';
 
-  edx.instructor_dashboard = edx.instructor_dashboard || {};
-  edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
 
-  edx.instructor_dashboard.proctoring.ProctoredExamBulkAllowanceModel = Backbone.Model.extend({
-    url: '/api/edx_proctoring/v1/proctored_exam/bulk_allowance',
+    edx.instructor_dashboard.proctoring.ProctoredExamBulkAllowanceModel = Backbone.Model.extend({
+        url: '/api/edx_proctoring/v1/proctored_exam/bulk_allowance'
 
-  });
-  const bulkAllowanceModel = edx.instructor_dashboard.proctoring.ProctoredExamBulkAllowanceModel;
-  this.edx.instructor_dashboard.proctoring.ProctoredExamBulkAllowanceModel = bulkAllowanceModel;
+    });
+    this.edx.instructor_dashboard.proctoring.ProctoredExamBulkAllowanceModel =
+      edx.instructor_dashboard.proctoring.ProctoredExamBulkAllowanceModel;
 }).call(this, Backbone);

--- a/edx_proctoring/static/proctoring/js/models/proctored_exam_model.js
+++ b/edx_proctoring/static/proctoring/js/models/proctored_exam_model.js
@@ -1,52 +1,56 @@
-(Backbone => {
-  'use strict';
+(function(Backbone) {
+    'use strict';
 
-  this.ProctoredExamModel = Backbone.Model.extend({
-    /* we should probably pull this from a data attribute on the HTML */
-    url: '/api/edx_proctoring/v1/proctored_exam/attempt',
+    var ProctoredExamModel = Backbone.Model.extend({
+        /* we should probably pull this from a data attribute on the HTML */
+        url: '/api/edx_proctoring/v1/proctored_exam/attempt',
 
-    defaults: {
-      in_timed_exam: false,
-      attempt_id: 0,
-      attempt_status: 'started',
-      taking_as_proctored: false,
-      exam_display_name: '',
-      exam_url_path: '',
-      time_remaining_seconds: 0,
-      low_threshold_sec: 0,
-      critically_low_threshold_sec: 0,
-      course_id: null,
-      accessibility_time_string: '',
-      lastFetched: new Date(),
-    },
-    getFormattedRemainingTime(secondsLeft) {
-      let secsLeft = secondsLeft;
-      /* since we can have a small grace period, we can end in the negative numbers */
-      if (secondsLeft < 0) {
-        secsLeft = 0;
-      }
+        defaults: {
+            in_timed_exam: false,
+            attempt_id: 0,
+            attempt_status: 'started',
+            taking_as_proctored: false,
+            exam_display_name: '',
+            exam_url_path: '',
+            time_remaining_seconds: 0,
+            low_threshold_sec: 0,
+            critically_low_threshold_sec: 0,
+            course_id: null,
+            accessibility_time_string: '',
+            lastFetched: new Date()
+        },
+        getFormattedRemainingTime: function(secondsLeft) {
+            var secsLeft = secondsLeft,
+                hours, minutes, seconds;
+            /* since we can have a small grace period, we can end in the negative numbers */
+            if (secondsLeft < 0) {
+                secsLeft = 0;
+            }
 
-      const hours = Math.floor(secsLeft / 3600);
-      const minutes = Math.floor(secsLeft / 60) % 60;
-      const seconds = Math.floor(secsLeft % 60);
+            hours = Math.floor(secsLeft / 3600);
+            minutes = Math.floor(secsLeft / 60) % 60;
+            seconds = Math.floor(secsLeft % 60);
 
-      return `${hours}:${minutes < 10 ? `0${minutes}` : minutes
-      }:${seconds < 10 ? `0${seconds}` : seconds}`;
-    },
-    getRemainingTimeState(secondsLeft) {
-      if (secondsLeft > this.get('low_threshold_sec')) {
-        return null;
-      } if (secondsLeft <= this.get('low_threshold_sec')
-                       && secondsLeft > this.get('critically_low_threshold_sec')) {
-        // returns the class name that has some css properties
-        // and it displays the user with the waring message if
-        // total seconds is less than the low_threshold value.
-        return 'warning';
-      }
-      // returns the class name that has some css properties
-      // and it displays the user with the critical message if
-      // total seconds is less than the critically_low_threshold_sec value.
-      return 'critical';
-    },
-  });
+            return hours + ':' + (minutes < 10 ? '0' + minutes : minutes)
+                + ':' + (seconds < 10 ? '0' + seconds : seconds);
+        },
+        getRemainingTimeState: function(secondsLeft) {
+            if (secondsLeft > this.get('low_threshold_sec')) {
+                return null;
+            } else if (secondsLeft <= this.get('low_threshold_sec') &&
+                       secondsLeft > this.get('critically_low_threshold_sec')) {
+                // returns the class name that has some css properties
+                // and it displays the user with the waring message if
+                // total seconds is less than the low_threshold value.
+                return 'warning';
+            } else {
+                // returns the class name that has some css properties
+                // and it displays the user with the critical message if
+                // total seconds is less than the critically_low_threshold_sec value.
+                return 'critical';
+            }
+        }
+    });
+
+    this.ProctoredExamModel = ProctoredExamModel;
 }).call(this, Backbone);

--- a/edx_proctoring/static/proctoring/js/proctored_app.js
+++ b/edx_proctoring/static/proctoring/js/proctored_app.js
@@ -1,16 +1,16 @@
 /* globals ProctoredExamModel:false LearnerOnboardingModel:false */
-$(() => {
-  'use strict';
+$(function() {
+    'use strict';
 
-  const proctoredExamView = new edx.courseware.proctored_exam.ProctoredExamView({
-    el: $('.proctored_exam_status'),
-    proctored_template: '#proctored-exam-status-tpl',
-    model: new ProctoredExamModel(),
-  });
-  const proctoredExamInfoView = new edx.courseware.proctored_exam.ProctoredExamInfo({
-    el: $('.proctoring-info-panel'),
-    model: new LearnerOnboardingModel(),
-  });
-  proctoredExamView.render();
-  proctoredExamInfoView.render();
+    var proctoredExamView = new edx.courseware.proctored_exam.ProctoredExamView({
+        el: $('.proctored_exam_status'),
+        proctored_template: '#proctored-exam-status-tpl',
+        model: new ProctoredExamModel()
+    });
+    var proctoredExamInfoView = new edx.courseware.proctored_exam.ProctoredExamInfo({
+        el: $('.proctoring-info-panel'),
+        model: new LearnerOnboardingModel()
+    });
+    proctoredExamView.render();
+    proctoredExamInfoView.render();
 });

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_add_bulk_allowance_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_add_bulk_allowance_view.js
@@ -1,299 +1,300 @@
 edx = edx || {};
 
-((Backbone, $, _, gettext) => {
-  'use strict';
+(function(Backbone, $, _, gettext) {
+    'use strict';
 
-  edx.instructor_dashboard = edx.instructor_dashboard || {};
-  edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
 
-  edx.instructor_dashboard.proctoring.AddBulkAllowanceView = Backbone.ModalView.extend({
-    name: 'AddBulkAllowanceView',
-    template: null,
-    template_url: '/static/proctoring/templates/add-new-bulk-allowance.underscore',
-    initialize(options) {
-      this.all_exams = options.proctored_exams;
-      this.proctored_exams = [];
-      this.timed_exams = [];
-      this.proctored_exam_allowance_view = options.proctored_exam_allowance_view;
-      this.course_id = options.course_id;
-      this.allowance_types = options.allowance_types;
-      this.model = new edx.instructor_dashboard.proctoring.ProctoredExamBulkAllowanceModel();
-      _.bindAll(this, 'render');
-      this.loadTemplateData();
-      // Backbone.Validation.bind( this,  {valid:this.hideError, invalid:this.showError});
-    },
-    events: {
-      'submit form': 'addAllowance',
-      'change #proctored_exam': 'selectExam',
-      'change #timed_exam': 'selectExam',
-      'change #allowance_type': 'selectAllowance',
-      'change #exam_type': 'selectExamType',
-    },
-    loadTemplateData() {
-      const self = this;
-      $.ajax({ url: self.template_url, dataType: 'html' })
-        .done((templateData) => {
-          self.sortExamsByExamType();
-          self.template = _.template(templateData);
-          self.render();
-          self.showModal();
-          self.updateCss();
-        });
-    },
-    updateCss() {
-      const $el = $(this.el);
-      $el.find('.modal-header').css({
-        color: '#1580b0',
-        'font-size': '20px',
-        'font-weight': '600',
-        'line-height': 'normal',
-        padding: '10px 15px',
-        'border-bottom': '1px solid #ccc',
-      });
-      $el.find('form').css({
-        padding: '15px',
-      });
-      $el.find('form table.compact td').css({
-        'vertical-align': 'middle',
-        padding: '4px 8px',
-      });
-      $el.find('form label').css({
-        display: 'block',
-        'font-size': '14px',
-        margin: 0,
-        cursor: 'default',
-      });
-      $el.find('form #minutes_label').css({
-        display: 'inline-block',
-      });
-      $el.find('form input[type="text"]').css({
-        height: '26px',
-        padding: '1px 8px 2px',
-        'font-size': '14px',
-        width: '100%',
-      });
-      $el.find('form input[type="submit"]').css({
-        'margin-top': '10px',
-        float: 'right',
-      });
-      $el.find('.error-message').css({
-        color: '#ff0000',
-        'line-height': 'normal',
-        'font-size': '14px',
-      });
-      $el.find('.error-response').css({
-        color: '#ff0000',
-        'line-height': 'normal',
-        'font-size': '14px',
-        padding: '0px 10px 5px 7px',
-      });
-      $el.find('form select').css({
-        padding: '2px 0px 2px 2px',
-        'font-size': '16px',
-        width: '100%',
-      });
-      $el.find('#selected_exams').css({
-        background: '#fff',
-        display: 'flex',
-        'flex-wrap': 'wrap',
-        'align-content': 'flex-start',
-        'overflow-x': 'scroll',
-      });
-      $el.find('.tag').css({
-        'font-size': '14px',
-        height: '15px',
-        'margin-right': '5px',
-        padding: '5px 6px',
-        border: '1px solid #ccc',
-        'border-radius': '3px',
-        background: '#eee',
-        display: 'flex',
-        'align-items': 'center',
-        color: '#333',
-        'box-shadow': '0 0 4px rgba(0, 0, 0, 0.2), inset 0 1px 1px #fff',
-        cursor: 'default',
-      });
-      $el.find('.close-selected-exam').css({
-        'font-size': '16px',
-        margin: '5px',
-      });
-      $el.find('.exam_dropdown').css({
-        height: '60px',
-      });
-    },
-    getCurrentFormValues() {
-      return {
-        allowance_type: $('select#allowance_type').val(),
-        allowance_value: $('#allowance_value').val(),
-        user_info: $('#user_info').val(),
-      };
-    },
-    hideError(view, attr) {
-      const $element = view.$form[attr];
+    edx.instructor_dashboard.proctoring.AddBulkAllowanceView = Backbone.ModalView.extend({
+        name: 'AddBulkAllowanceView',
+        template: null,
+        template_url: '/static/proctoring/templates/add-new-bulk-allowance.underscore',
+        initialize: function(options) {
+            this.all_exams = options.proctored_exams;
+            this.proctored_exams = [];
+            this.timed_exams = [];
+            this.proctored_exam_allowance_view = options.proctored_exam_allowance_view;
+            this.course_id = options.course_id;
+            this.allowance_types = options.allowance_types;
+            this.model = new edx.instructor_dashboard.proctoring.ProctoredExamBulkAllowanceModel();
+            _.bindAll(this, 'render');
+            this.loadTemplateData();
+            // Backbone.Validation.bind( this,  {valid:this.hideError, invalid:this.showError});
+        },
+        events: {
+            'submit form': 'addAllowance',
+            'change #proctored_exam': 'selectExam',
+            'change #timed_exam': 'selectExam',
+            'change #allowance_type': 'selectAllowance',
+            'change #exam_type': 'selectExamType'
+        },
+        loadTemplateData: function() {
+            var self = this;
+            $.ajax({url: self.template_url, dataType: 'html'})
+                .done(function(templateData) {
+                    self.sortExamsByExamType();
+                    self.template = _.template(templateData);
+                    self.render();
+                    self.showModal();
+                    self.updateCss();
+                });
+        },
+        updateCss: function() {
+            var $el = $(this.el);
+            $el.find('.modal-header').css({
+                color: '#1580b0',
+                'font-size': '20px',
+                'font-weight': '600',
+                'line-height': 'normal',
+                padding: '10px 15px',
+                'border-bottom': '1px solid #ccc'
+            });
+            $el.find('form').css({
+                padding: '15px'
+            });
+            $el.find('form table.compact td').css({
+                'vertical-align': 'middle',
+                padding: '4px 8px'
+            });
+            $el.find('form label').css({
+                display: 'block',
+                'font-size': '14px',
+                margin: 0,
+                cursor: 'default'
+            });
+            $el.find('form #minutes_label').css({
+                display: 'inline-block'
+            });
+            $el.find('form input[type="text"]').css({
+                height: '26px',
+                padding: '1px 8px 2px',
+                'font-size': '14px',
+                width: '100%'
+            });
+            $el.find('form input[type="submit"]').css({
+                'margin-top': '10px',
+                float: 'right'
+            });
+            $el.find('.error-message').css({
+                color: '#ff0000',
+                'line-height': 'normal',
+                'font-size': '14px'
+            });
+            $el.find('.error-response').css({
+                color: '#ff0000',
+                'line-height': 'normal',
+                'font-size': '14px',
+                padding: '0px 10px 5px 7px'
+            });
+            $el.find('form select').css({
+                padding: '2px 0px 2px 2px',
+                'font-size': '16px',
+                width: '100%'
+            });
+            $el.find('#selected_exams').css({
+                background: '#fff',
+                display: 'flex',
+                'flex-wrap': 'wrap',
+                'align-content': 'flex-start',
+                'overflow-x': 'scroll'
+            });
+            $el.find('.tag').css({
+                'font-size': '14px',
+                height: '15px',
+                'margin-right': '5px',
+                padding: '5px 6px',
+                border: '1px solid #ccc',
+                'border-radius': '3px',
+                background: '#eee',
+                display: 'flex',
+                'align-items': 'center',
+                color: '#333',
+                'box-shadow': '0 0 4px rgba(0, 0, 0, 0.2), inset 0 1px 1px #fff',
+                cursor: 'default'
+            });
+            $el.find('.close-selected-exam').css({
+                'font-size': '16px',
+                margin: '5px'
+            });
+            $el.find('.exam_dropdown').css({
+                height: '60px'
+            });
+        },
+        getCurrentFormValues: function() {
+            return {
+                allowance_type: $('select#allowance_type').val(),
+                allowance_value: $('#allowance_value').val(),
+                user_info: $('#user_info').val()
+            };
+        },
+        hideError: function(view, attr) {
+            var $element = view.$form[attr];
 
-      $element.removeClass('error');
-      $element.parent().find('.error-message').empty();
-    },
-    showError(view, attr, errorMessage) {
-      const $element = view.$form[attr];
-      let $errorMessage;
+            $element.removeClass('error');
+            $element.parent().find('.error-message').empty();
+        },
+        showError: function(view, attr, errorMessage) {
+            var $element = view.$form[attr];
+            var $errorMessage;
 
-      $element.addClass('error');
-      $errorMessage = $element.parent().find('.error-message');
-      if ($errorMessage.length === 0) {
-        $errorMessage = $("<div class='error-message'></div>");
-        $element.parent().append($errorMessage);
-      }
+            $element.addClass('error');
+            $errorMessage = $element.parent().find('.error-message');
+            if ($errorMessage.length === 0) {
+                $errorMessage = $("<div class='error-message'></div>");
+                $element.parent().append($errorMessage);
+            }
 
-      $errorMessage.empty().append(errorMessage);
-      this.updateCss();
-    },
-    addAllowance(event) {
-      let examIdCollection;
-      const self = this;
-      event.preventDefault();
-      const $errorResponse = $('.error-response');
-      $errorResponse.html();
-      const formValues = this.getCurrentFormValues();
-      examIdCollection = '';
-
-      $('.close-selected-exam').each(() => {
-        examIdCollection += `${$(this).attr('data-item')},`;
-      });
-
-      const formHasErrors = this.checkFormErrors(formValues, examIdCollection);
-
-      if (!formHasErrors) {
-        self.model.fetch({
-          headers: {
-            'X-CSRFToken': self.proctored_exam_allowance_view.getCSRFToken(),
-          },
-          type: 'PUT',
-          data: {
-            course_id: self.course_id,
-            exam_ids: examIdCollection,
-            user_ids: formValues.user_info,
-            allowance_type: formValues.allowance_type,
-            value: formValues.allowance_value,
-          },
-          success() {
-            // fetch the allowances again.
+            $errorMessage.empty().append(errorMessage);
+            this.updateCss();
+        },
+        addAllowance: function(event) {
+            var $errorResponse, formValues, formHasErrors, examIdCollection;
+            var self = this;
+            event.preventDefault();
+            $errorResponse = $('.error-response');
             $errorResponse.html();
-            self.proctored_exam_allowance_view.collection.url = `${self.proctored_exam_allowance_view.initial_url + self.course_id}/allowance`;
-            self.proctored_exam_allowance_view.hydrate();
-            self.hideModal();
-          },
-          error(unused, response) {
-            const data = $.parseJSON(response.responseText);
-            self.showError(self, data.field, data.detail);
-          },
-        });
-      }
-    },
-    selectExamAtIndex(examID, examName) {
-      const createdTag = this.createTag(examName, examID);
-      $('.exam_dropdown:visible').val('default');
-      $(`.exam_dropdown:visible option[value=${examID}]`).remove();
-      $('#selected_exams').append(createdTag);
-      this.updateCss();
-    },
-    selectExam() {
-      this.selectExamAtIndex($('.exam_dropdown:visible').val(), $('.exam_dropdown:visible :selected').text());
-    },
-    selectAllowance() {
-      this.updateAllowanceLabels($('#allowance_type').val());
-    },
-    selectExamType() {
-      $('.close-selected-exam').each(() => {
-        $(this).trigger('click');
-      });
-      if ($('#proctored_exam').is(':visible')) {
-        $('#proctored_exam').hide();
-        $('#timed_exam').show();
-        $('#allowance_type option[value="review_policy_exception"]').remove();
-      } else {
-        $('#proctored_exam').show();
-        $('#timed_exam').hide();
-        $('#allowance_type').append(new Option(gettext('Review Policy Exception'), 'review_policy_exception'));
-      }
-      this.updateAllowanceLabels($('#allowance_type').val());
-    },
-    updateAllowanceLabels(selectedAllowanceType) {
-      if (selectedAllowanceType === 'additional_time_granted') {
-        $('#allowance_value_label').text(gettext('Add Time(Minutes)'));
-      } else if (selectedAllowanceType === 'time_multiplier') {
-        $('#allowance_value_label').text(gettext('Add Multiplier as a Number Greater Than 1'));
-      } else {
-        $('#allowance_value_label').text(gettext('Add Policy Exception'));
-      }
-    },
-    sortExamsByExamType() {
-      const self = this;
-      self.all_exams.forEach((exam) => {
-        if (exam.is_proctored) {
-          self.proctored_exams.push(exam);
-        } else {
-          self.timed_exams.push(exam);
+            formValues = this.getCurrentFormValues();
+            examIdCollection = '';
+
+            $('.close-selected-exam').each(function() {
+                examIdCollection += $(this).attr('data-item') + ',';
+            });
+
+            formHasErrors = this.checkFormErrors(formValues, examIdCollection);
+
+            if (!formHasErrors) {
+                self.model.fetch({
+                    headers: {
+                        'X-CSRFToken': self.proctored_exam_allowance_view.getCSRFToken()
+                    },
+                    type: 'PUT',
+                    data: {
+                        course_id: self.course_id,
+                        exam_ids: examIdCollection,
+                        user_ids: formValues.user_info,
+                        allowance_type: formValues.allowance_type,
+                        value: formValues.allowance_value
+                    },
+                    success: function() {
+                        // fetch the allowances again.
+                        $errorResponse.html();
+                        self.proctored_exam_allowance_view.collection.url =
+                            self.proctored_exam_allowance_view.initial_url + self.course_id + '/allowance';
+                        self.proctored_exam_allowance_view.hydrate();
+                        self.hideModal();
+                    },
+                    error: function(unused, response) {
+                        var data = $.parseJSON(response.responseText);
+                        self.showError(self, data.field, data.detail);
+                    }
+                });
+            }
+        },
+        selectExamAtIndex: function(examID, examName) {
+            var createdTag = this.createTag(examName, examID);
+            $('.exam_dropdown:visible').val('default');
+            $('.exam_dropdown:visible option[value=' + examID + ']').remove();
+            $('#selected_exams').append(createdTag);
+            this.updateCss();
+        },
+        selectExam: function() {
+            this.selectExamAtIndex($('.exam_dropdown:visible').val(), $('.exam_dropdown:visible :selected').text());
+        },
+        selectAllowance: function() {
+            this.updateAllowanceLabels($('#allowance_type').val());
+        },
+        selectExamType: function() {
+            $('.close-selected-exam').each(function() {
+                $(this).trigger('click');
+            });
+            if ($('#proctored_exam').is(':visible')) {
+                $('#proctored_exam').hide();
+                $('#timed_exam').show();
+                $('#allowance_type option[value="review_policy_exception"]').remove();
+            } else {
+                $('#proctored_exam').show();
+                $('#timed_exam').hide();
+                $('#allowance_type').append(new Option(gettext('Review Policy Exception'), 'review_policy_exception'));
+            }
+            this.updateAllowanceLabels($('#allowance_type').val());
+        },
+        updateAllowanceLabels: function(selectedAllowanceType) {
+            if (selectedAllowanceType === 'additional_time_granted') {
+                $('#allowance_value_label').text(gettext('Add Time(Minutes)'));
+            } else if (selectedAllowanceType === 'time_multiplier') {
+                $('#allowance_value_label').text(gettext('Add Multiplier as a Number Greater Than 1'));
+            } else {
+                $('#allowance_value_label').text(gettext('Add Policy Exception'));
+            }
+        },
+        sortExamsByExamType: function() {
+            var self = this;
+            self.all_exams.forEach(function(exam) {
+                if (exam.is_proctored) {
+                    self.proctored_exams.push(exam);
+                } else {
+                    self.timed_exams.push(exam);
+                }
+            });
+        },
+        createTag: function(examName, examID) {
+            var div = document.createElement('div');
+            var span = document.createElement('span');
+            var closeIcon = document.createElement('span');
+            div.setAttribute('class', 'tag');
+            span.innerHTML = examName;
+            closeIcon.innerHTML = 'x';
+            closeIcon.setAttribute('class', 'close-selected-exam');
+            closeIcon.setAttribute('data-item', examID);
+            closeIcon.setAttribute('data-name', examName);
+            closeIcon.onclick = this.deleteTag;
+            div.appendChild(span);
+            div.appendChild(closeIcon);
+            return div;
+        },
+        deleteTag: function() {
+            var examID = $(this).data('item');
+            var examName = $(this).data('name');
+            $(this).closest('div').remove();
+            $('.exam_dropdown:visible').append(new Option(examName, examID));
+        },
+        checkFormErrors: function(formValues, examIdCollection) {
+            var formHasErrors;
+            var self = this;
+            $.each(formValues, function(key, value) {
+                if (value === '') {
+                    formHasErrors = true;
+                    self.showError(self, key, gettext('Required field'));
+                } else {
+                    self.hideError(self, key);
+                }
+            });
+
+            if (examIdCollection === '') {
+                formHasErrors = true;
+                self.showError(self, 'proctored_exam', gettext('Required field'));
+            } else {
+                self.hideError(self, 'proctored_exam');
+            }
+            return formHasErrors;
+        },
+
+        render: function() {
+            $(this.el).html(this.template({
+                proctored_exams: this.proctored_exams,
+                timed_exams: this.timed_exams,
+                allowance_types: this.allowance_types
+            }));
+
+            this.$form = {
+                proctored_exam: this.$('select#proctored_exam'),
+                timed_exam: this.$('select#timed_exam'),
+                allowance_type: this.$('select#allowance_type'),
+                allowance_value: this.$('#allowance_value'),
+                user_info: this.$('#user_info')
+            };
+            return this;
         }
-      });
-    },
-    createTag(examName, examID) {
-      const div = document.createElement('div');
-      const span = document.createElement('span');
-      const closeIcon = document.createElement('span');
-      div.setAttribute('class', 'tag');
-      span.innerHTML = examName;
-      closeIcon.innerHTML = 'x';
-      closeIcon.setAttribute('class', 'close-selected-exam');
-      closeIcon.setAttribute('data-item', examID);
-      closeIcon.setAttribute('data-name', examName);
-      closeIcon.onclick = this.deleteTag;
-      div.appendChild(span);
-      div.appendChild(closeIcon);
-      return div;
-    },
-    deleteTag() {
-      const examID = $(this).data('item');
-      const examName = $(this).data('name');
-      $(this).closest('div').remove();
-      $('.exam_dropdown:visible').append(new Option(examName, examID));
-    },
-    checkFormErrors(formValues, examIdCollection) {
-      let formHasErrors;
-      const self = this;
-      $.each(formValues, (key, value) => {
-        if (value === '') {
-          formHasErrors = true;
-          self.showError(self, key, gettext('Required field'));
-        } else {
-          self.hideError(self, key);
-        }
-      });
-
-      if (examIdCollection === '') {
-        formHasErrors = true;
-        self.showError(self, 'proctored_exam', gettext('Required field'));
-      } else {
-        self.hideError(self, 'proctored_exam');
-      }
-      return formHasErrors;
-    },
-
-    render() {
-      $(this.el).html(this.template({
-        proctored_exams: this.proctored_exams,
-        timed_exams: this.timed_exams,
-        allowance_types: this.allowance_types,
-      }));
-
-      this.$form = {
-        proctored_exam: this.$('select#proctored_exam'),
-        timed_exam: this.$('select#timed_exam'),
-        allowance_type: this.$('select#allowance_type'),
-        allowance_value: this.$('#allowance_value'),
-        user_info: this.$('#user_info'),
-      };
-      return this;
-    },
-  });
+    });
 }).call(this, Backbone, $, _, gettext);

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_allowance_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_allowance_view.js
@@ -1,207 +1,204 @@
 edx = edx || {};
 
-((Backbone, $, _) => {
-  'use strict';
+(function(Backbone, $, _) {
+    'use strict';
 
-  edx.instructor_dashboard = edx.instructor_dashboard || {};
-  edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
 
-  edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView = Backbone.View.extend({
-    initialize() {
-      this.allowance_types = [
-        ['additional_time_granted', gettext('Additional Time (minutes)')],
-        ['review_policy_exception', gettext('Review Policy Exception')],
-        ['time_multiplier', gettext('Time Multiplier')],
-      ];
+    edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView = Backbone.View.extend({
+        initialize: function() {
+            this.allowance_types = [
+                ['additional_time_granted', gettext('Additional Time (minutes)')],
+                ['review_policy_exception', gettext('Review Policy Exception')],
+                ['time_multiplier', gettext('Time Multiplier')]
+            ];
 
-      this.collection = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceCollection();
-      this.proctoredExamCollection = new edx.instructor_dashboard.proctoring.ProctoredExamCollection();
-      /* unfortunately we have to make some assumptions about what is being set up in HTML */
-      this.setElement($('.special-allowance-container'));
-      this.course_id = this.$el.data('course-id');
-      /* this should be moved to a 'data' attribute in HTML */
-      this.template_url = '/static/proctoring/templates/course_grouped_allowances.underscore';
-      this.template = null;
-      this.initial_url = this.collection.url;
-      this.allowance_url = `${this.initial_url}allowance`;
-      /* re-render if the model changes */
-      this.listenTo(this.collection, 'change', this.collectionChanged);
+            this.collection = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceCollection();
+            this.proctoredExamCollection = new edx.instructor_dashboard.proctoring.ProctoredExamCollection();
+            /* unfortunately we have to make some assumptions about what is being set up in HTML */
+            this.setElement($('.special-allowance-container'));
+            this.course_id = this.$el.data('course-id');
+            /* this should be moved to a 'data' attribute in HTML */
+            this.template_url = '/static/proctoring/templates/course_grouped_allowances.underscore';
+            this.template = null;
+            this.initial_url = this.collection.url;
+            this.allowance_url = this.initial_url + 'allowance';
+            /* re-render if the model changes */
+            this.listenTo(this.collection, 'change', this.collectionChanged);
 
-      /* Load the static template for rendering. */
-      this.loadTemplateData();
+            /* Load the static template for rendering. */
+            this.loadTemplateData();
 
-      this.proctoredExamCollection.url += this.course_id;
-    },
-    events: {
-      'click #add-allowance': 'showAddModal',
-      'click .remove_allowance': 'removeAllowance',
-      'click .accordion-trigger': 'toggleAllowanceAccordion',
-      'click .edit_allowance': 'editAllowance',
-    },
-    getCSRFToken() {
-      let cookieValue = null;
-      const name = 'csrftoken';
-      let cookies; let cookie; let
-        i;
-      if (document.cookie && document.cookie !== '') {
-        cookies = document.cookie.split(';');
-        for (i = 0; i < cookies.length; i += 1) {
-          cookie = jQuery.trim(cookies[i]);
-          // Does this cookie string begin with the name we want?
-          if (cookie.substring(0, name.length + 1) === (`${name}=`)) {
-            cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-            break;
-          }
+            this.proctoredExamCollection.url = this.proctoredExamCollection.url + this.course_id;
+        },
+        events: {
+            'click #add-allowance': 'showAddModal',
+            'click .remove_allowance': 'removeAllowance',
+            'click .accordion-trigger': 'toggleAllowanceAccordion',
+            'click .edit_allowance': 'editAllowance'
+        },
+        getCSRFToken: function() {
+            var cookieValue = null;
+            var name = 'csrftoken';
+            var cookies, cookie, i;
+            if (document.cookie && document.cookie !== '') {
+                cookies = document.cookie.split(';');
+                for (i = 0; i < cookies.length; i += 1) {
+                    cookie = jQuery.trim(cookies[i]);
+                    // Does this cookie string begin with the name we want?
+                    if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                        break;
+                    }
+                }
+            }
+            return cookieValue;
+        },
+        removeAllowance: function(event) {
+            var $element = $(event.currentTarget);
+            var userID = $element.data('user-id');
+            var examID = $element.data('exam-id');
+            var key = $element.data('key-name');
+            var self = this;
+            self.collection.url = this.allowance_url;
+            self.collection.fetch(
+                {
+                    headers: {
+                        'X-CSRFToken': this.getCSRFToken()
+                    },
+                    type: 'DELETE',
+                    data: {
+                        exam_id: examID,
+                        user_id: userID,
+                        key: key
+                    },
+                    success: function() {
+                        // fetch the allowances again.
+                        self.hydrate();
+                    }
+                }
+            );
+            event.stopPropagation();
+            event.preventDefault();
+        },
+        /*
+         This entry point is required for Instructor Dashboard
+         See setup_instructor_dashboard_sections() in
+         instructor_dashboard.coffee (in edx-platform)
+         */
+        constructor: function(section) {
+            /* the Instructor Dashboard javascript expects this to be set up */
+            $(section).data('wrapper', this);
+
+            this.initialize({});
+        },
+        onClickTitle: function() {
+            // called when this is selected in the instructor dashboard
+
+        },
+        loadTemplateData: function() {
+            var self = this;
+            $.ajax({url: self.template_url, dataType: 'html'})
+                .done(function(templateData) {
+                    self.template = _.template(templateData);
+                    self.hydrate();
+                });
+        },
+        hydrate: function() {
+            /* This function will load the bound collection */
+
+            /* add and remove a class when we do the initial loading */
+            /* we might - at some point - add a visual element to the */
+            /* loading, like a spinner */
+            var self = this;
+            self.collection.url = self.initial_url + self.course_id + '/grouped/allowance';
+            self.collection.fetch({
+                success: function() {
+                    self.render();
+                }
+            });
+        },
+        collectionChanged: function() {
+            this.hydrate();
+        },
+        render: function() {
+            var self = this;
+            var html;
+            if (this.template !== null) {
+                html = this.template({
+                    proctored_exam_allowances: this.collection.toJSON()[0],
+                    allowance_types: self.allowance_types,
+                    generateDomId: self.generateDomId
+                });
+                this.$el.html(html);
+            }
+        },
+        showAddModal: function(event) {
+            var self = this;
+            self.proctoredExamCollection.fetch({
+                success: function() {
+                    // eslint-disable-next-line no-new
+                    new edx.instructor_dashboard.proctoring.AddBulkAllowanceView({
+                        course_id: self.course_id,
+                        proctored_exams: self.proctoredExamCollection.toJSON(),
+                        proctored_exam_allowance_view: self,
+                        allowance_types: self.allowance_types
+                    });
+                }
+            });
+            event.stopPropagation();
+            event.preventDefault();
+        },
+        editAllowance: function(event) {
+            var $element = $(event.currentTarget);
+            var userName = $element.data('user-name');
+            var examID = $element.data('exam-id');
+            var examName = $element.data('exam-name');
+            var key = $element.data('key-name');
+            var keyName = $element.data('key-value');
+            var self = this;
+            self.proctoredExamCollection.fetch({
+                success: function() {
+                    // eslint-disable-next-line no-new
+                    new edx.instructor_dashboard.proctoring.EditAllowanceView({
+                        course_id: self.course_id,
+                        selected_exam_ID: examID,
+                        selected_exam_name: examName,
+                        proctored_exam_allowance_view: self,
+                        selected_user: userName,
+                        allowance_type: key,
+                        allowance_type_name: keyName
+                    });
+                }
+            });
+        },
+        toggleAllowanceAccordion: function(event) {
+            // based on code from openedx/features/course_experience/static/course_experience/js/CourseOutline.js
+            // but modified to better fit this feature's needs
+            var accordionRow, isExpanded, $toggleChevron, $contentPanel;
+            accordionRow = event.currentTarget;
+            if (accordionRow.classList.contains('accordion-trigger')) {
+                isExpanded = accordionRow.getAttribute('aria-expanded') === 'true';
+                if (!isExpanded) {
+                    $toggleChevron = $(accordionRow).find('.fa-chevron-down');
+                    $contentPanel = $('#' + accordionRow.getAttribute('data-key-id').trim());
+                    $contentPanel.show();
+                    $toggleChevron.addClass('fa-rotate-180');
+                    accordionRow.setAttribute('aria-expanded', 'true');
+                } else {
+                    $toggleChevron = $(accordionRow).find('.fa-chevron-down');
+                    $contentPanel = $('#' + accordionRow.getAttribute('data-key-id').trim());
+                    $contentPanel.hide();
+                    $toggleChevron.removeClass('fa-rotate-180');
+                    accordionRow.setAttribute('aria-expanded', 'false');
+                }
+            }
+        },
+        generateDomId: function(username) {
+            return 'ui-id-' + username.replace(/\W/g, '');
         }
-      }
-      return cookieValue;
-    },
-    removeAllowance(event) {
-      const $element = $(event.currentTarget);
-      const userID = $element.data('user-id');
-      const examID = $element.data('exam-id');
-      const key = $element.data('key-name');
-      const self = this;
-      self.collection.url = this.allowance_url;
-      self.collection.fetch(
-        {
-          headers: {
-            'X-CSRFToken': this.getCSRFToken(),
-          },
-          type: 'DELETE',
-          data: {
-            exam_id: examID,
-            user_id: userID,
-            key,
-          },
-          success() {
-            // fetch the allowances again.
-            self.hydrate();
-          },
-        },
-      );
-      event.stopPropagation();
-      event.preventDefault();
-    },
-    /*
-      This entry point is required for Instructor Dashboard
-      See setup_instructor_dashboard_sections() in
-      instructor_dashboard.coffee (in edx-platform)
-    */
-    // eslint-disable-next-line func-names
-    constructor: function (section) {
-      /* the Instructor Dashboard javascript expects this to be set up */
-      $(section).data('wrapper', this);
-
-      this.initialize({});
-    },
-    onClickTitle() {
-      // called when this is selected in the instructor dashboard
-
-    },
-    loadTemplateData() {
-      const self = this;
-      $.ajax({ url: self.template_url, dataType: 'html' })
-        .done((templateData) => {
-          self.template = _.template(templateData);
-          self.hydrate();
-        });
-    },
-    hydrate() {
-      /* This function will load the bound collection */
-
-      /* add and remove a class when we do the initial loading */
-      /* we might - at some point - add a visual element to the */
-      /* loading, like a spinner */
-      const self = this;
-      self.collection.url = `${self.initial_url + self.course_id}/grouped/allowance`;
-      self.collection.fetch({
-        success() {
-          self.render();
-        },
-      });
-    },
-    collectionChanged() {
-      this.hydrate();
-    },
-    render() {
-      const self = this;
-      let html;
-      if (this.template !== null) {
-        html = this.template({
-          proctored_exam_allowances: this.collection.toJSON()[0],
-          allowance_types: self.allowance_types,
-          generateDomId: self.generateDomId,
-        });
-        this.$el.html(html);
-      }
-    },
-    showAddModal(event) {
-      const self = this;
-      self.proctoredExamCollection.fetch({
-        success() {
-          // eslint-disable-next-line no-new
-          new edx.instructor_dashboard.proctoring.AddBulkAllowanceView({
-            course_id: self.course_id,
-            proctored_exams: self.proctoredExamCollection.toJSON(),
-            proctored_exam_allowance_view: self,
-            allowance_types: self.allowance_types,
-          });
-        },
-      });
-      event.stopPropagation();
-      event.preventDefault();
-    },
-    editAllowance(event) {
-      const $element = $(event.currentTarget);
-      const userName = $element.data('user-name');
-      const examID = $element.data('exam-id');
-      const examName = $element.data('exam-name');
-      const key = $element.data('key-name');
-      const keyName = $element.data('key-value');
-      const self = this;
-      self.proctoredExamCollection.fetch({
-        success() {
-          // eslint-disable-next-line no-new
-          new edx.instructor_dashboard.proctoring.EditAllowanceView({
-            course_id: self.course_id,
-            selected_exam_ID: examID,
-            selected_exam_name: examName,
-            proctored_exam_allowance_view: self,
-            selected_user: userName,
-            allowance_type: key,
-            allowance_type_name: keyName,
-          });
-        },
-      });
-    },
-    toggleAllowanceAccordion(event) {
-      // based on code from openedx/features/course_experience/static/course_experience/js/CourseOutline.js
-      // but modified to better fit this feature's needs
-      let isExpanded; let $toggleChevron; let
-        $contentPanel;
-      const accordionRow = event.currentTarget;
-      if (accordionRow.classList.contains('accordion-trigger')) {
-        isExpanded = accordionRow.getAttribute('aria-expanded') === 'true';
-        if (!isExpanded) {
-          $toggleChevron = $(accordionRow).find('.fa-chevron-down');
-          $contentPanel = $(`#${accordionRow.getAttribute('data-key-id').trim()}`);
-          $contentPanel.show();
-          $toggleChevron.addClass('fa-rotate-180');
-          accordionRow.setAttribute('aria-expanded', 'true');
-        } else {
-          $toggleChevron = $(accordionRow).find('.fa-chevron-down');
-          $contentPanel = $(`#${accordionRow.getAttribute('data-key-id').trim()}`);
-          $contentPanel.hide();
-          $toggleChevron.removeClass('fa-rotate-180');
-          accordionRow.setAttribute('aria-expanded', 'false');
-        }
-      }
-    },
-    generateDomId(username) {
-      return `ui-id-${username.replace(/\W/g, '')}`;
-    },
-  });
-  const proctoredExamAllowanceView = edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView;
-  this.edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView = proctoredExamAllowanceView;
+    });
+    this.edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView =
+        edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView;
 }).call(this, Backbone, $, _);

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_attempt_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_attempt_view.js
@@ -1,302 +1,307 @@
 edx = edx || {};
 
-((Backbone, $, _, gettext) => {
-  'use strict';
+(function(Backbone, $, _, gettext) {
+    'use strict';
 
-  edx.instructor_dashboard = edx.instructor_dashboard || {};
-  edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
-  const examStatusReadableFormat = {
-    eligible: gettext('Eligible'),
-    created: gettext('Created'),
-    download_software_clicked: gettext('Download Software Clicked'),
-    ready_to_start: gettext('Ready to start'),
-    started: gettext('Started'),
-    ready_to_submit: gettext('Ready to submit'),
-    declined: gettext('Declined'),
-    timed_out: gettext('Timed out'),
-    second_review_required: gettext('Second Review Required'),
-    submitted: gettext('Submitted'),
-    verified: gettext('Verified'),
-    rejected: gettext('Rejected'),
-    error: gettext('Error'),
-    onboarding_missing: gettext('Onboarding Missing'),
-    onboarding_pending: gettext('Onboarding Pending'),
-    onboarding_failed: gettext('Onboarding Failed'),
-    onboarding_expired: gettext('Onboarding Expired'),
-  };
-  const viewHelper = {
-    getDateFormat(date) {
-      if (date) {
-        return new Date(date).toString('MMM dd, yyyy h:mmtt');
-      }
-      return '---';
-    },
-    getExamAttemptStatus(status) {
-      if (status in examStatusReadableFormat) {
-        return examStatusReadableFormat[status];
-      }
-      return status;
-    },
-  };
-  edx.instructor_dashboard.proctoring.ProctoredExamAttemptView = Backbone.View.extend({
-    initialize() {
-      this.setElement($('.student-proctored-exam-container'));
-      this.course_id = this.$el.data('course-id');
-      this.template = null;
-      this.model = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptModel();
-
-      this.collection = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptGroupedCollection();
-      this.template_url = '/static/proctoring/templates/student-proctored-exam-attempts-grouped.underscore';
-
-      this.initial_url = this.collection.url;
-      this.attempt_url = this.model.url;
-      this.collection.url = this.initial_url + this.course_id;
-      this.inSearchMode = false;
-      this.searchText = '';
-
-      /* re-render if the model changes */
-      this.listenTo(this.collection, 'change', this.collectionChanged);
-
-      /* Load the static template for rendering. */
-      this.loadTemplateData();
-    },
-    events: {
-      'click .remove-attempt': 'onRemoveAttempt',
-      'click .resume-attempt': 'onResumeAttempt',
-      'click li > a.target-link': 'getPaginatedAttempts',
-      'click .search-attempts > span.search': 'searchAttempts',
-      'click .search-attempts > span.clear-search': 'clearSearch',
-      'click .action-more': 'toggleExamAttemptActionDropdownMenu',
-      'click .accordion-trigger': 'toggleAttemptAccordion',
-      'keypress .accordion-trigger': 'keyToggleAttemptAccordion',
-    },
-    toggleExamAttemptActionDropdownMenu(event) {
-      edx.dashboard.dropdown.toggleExamAttemptActionDropdownMenu(event);
-    },
-    searchAttempts(event) {
-      const searchText = $('#search_attempt_id').val();
-      if (searchText !== '') {
-        this.inSearchMode = true;
-        this.searchText = searchText;
-        this.collection.url = `${this.initial_url + this.course_id}/search/${searchText}`;
-        const $searchIcon = $(document.getElementById('attempt-search-indicator'));
-        $searchIcon.addClass('hidden');
-        const $spinner = $(document.getElementById('attempt-loading-indicator'));
-        $spinner.removeClass('hidden');
-        this.hydrate();
-        event.stopPropagation();
-        event.preventDefault();
-      }
-    },
-    clearSearch(event) {
-      this.inSearchMode = false;
-      this.searchText = '';
-      this.collection.url = this.initial_url + this.course_id;
-      this.hydrate();
-      event.stopPropagation();
-      event.preventDefault();
-    },
-    getPaginatedAttempts(event) {
-      const $target = $(event.currentTarget);
-      this.collection.url = $target.data('target-url');
-      this.hydrate();
-      event.stopPropagation();
-      event.preventDefault();
-    },
-    getCSRFToken() {
-      let cookieValue = null;
-      const name = 'csrftoken';
-      let cookie; let cookies; let
-        i;
-      if (document.cookie && document.cookie !== '') {
-        cookies = document.cookie.split(';');
-        for (i = 0; i < cookies.length; i += 1) {
-          cookie = jQuery.trim(cookies[i]);
-          // Does this cookie string begin with the name we want?
-          if (cookie.substring(0, name.length + 1) === (`${name}=`)) {
-            cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-            break;
-          }
+    var viewHelper, examStatusReadableFormat;
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+    examStatusReadableFormat = {
+        eligible: gettext('Eligible'),
+        created: gettext('Created'),
+        download_software_clicked: gettext('Download Software Clicked'),
+        ready_to_start: gettext('Ready to start'),
+        started: gettext('Started'),
+        ready_to_submit: gettext('Ready to submit'),
+        declined: gettext('Declined'),
+        timed_out: gettext('Timed out'),
+        second_review_required: gettext('Second Review Required'),
+        submitted: gettext('Submitted'),
+        verified: gettext('Verified'),
+        rejected: gettext('Rejected'),
+        error: gettext('Error'),
+        onboarding_missing: gettext('Onboarding Missing'),
+        onboarding_pending: gettext('Onboarding Pending'),
+        onboarding_failed: gettext('Onboarding Failed'),
+        onboarding_expired: gettext('Onboarding Expired')
+    };
+    viewHelper = {
+        getDateFormat: function(date) {
+            if (date) {
+                return new Date(date).toString('MMM dd, yyyy h:mmtt');
+            } else {
+                return '---';
+            }
+        },
+        getExamAttemptStatus: function(status) {
+            if (status in examStatusReadableFormat) {
+                return examStatusReadableFormat[status];
+            } else {
+                return status;
+            }
         }
-      }
-      return cookieValue;
-    },
-    loadTemplateData() {
-      const self = this;
-      $.ajax({ url: self.template_url, dataType: 'html' })
-        .done((templateData) => {
-          self.template = _.template(templateData);
-          self.hydrate();
-        });
-    },
-    hydrate() {
-      /* This function will load the bound collection */
+    };
+    edx.instructor_dashboard.proctoring.ProctoredExamAttemptView = Backbone.View.extend({
+        initialize: function() {
+            this.setElement($('.student-proctored-exam-container'));
+            this.course_id = this.$el.data('course-id');
+            this.template = null;
+            this.model = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptModel();
 
-      /* add and remove a class when we do the initial loading */
-      /* we might - at some point - add a visual element to the */
-      /* loading, like a spinner */
-      const self = this;
-      self.collection.fetch({
-        success() {
-          self.render();
-          const $spinner = $(document.getElementById('attempt-loading-indicator'));
-          $spinner.addClass('hidden');
-          const $searchIcon = $(document.getElementById('attempt-search-indicator'));
-          $searchIcon.removeClass('hidden');
+            this.collection = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptGroupedCollection();
+            this.template_url = '/static/proctoring/templates/student-proctored-exam-attempts-grouped.underscore';
+
+
+            this.initial_url = this.collection.url;
+            this.attempt_url = this.model.url;
+            this.collection.url = this.initial_url + this.course_id;
+            this.inSearchMode = false;
+            this.searchText = '';
+
+            /* re-render if the model changes */
+            this.listenTo(this.collection, 'change', this.collectionChanged);
+
+            /* Load the static template for rendering. */
+            this.loadTemplateData();
         },
-      });
-    },
-    collectionChanged() {
-      this.hydrate();
-    },
-    render() {
-      let dataJson; let startPage; let endPage; let data; let
-        html;
-      if (this.template !== null) {
-        [dataJson] = this.collection.toJSON();
+        events: {
+            'click .remove-attempt': 'onRemoveAttempt',
+            'click .resume-attempt': 'onResumeAttempt',
+            'click li > a.target-link': 'getPaginatedAttempts',
+            'click .search-attempts > span.search': 'searchAttempts',
+            'click .search-attempts > span.clear-search': 'clearSearch',
+            'click .action-more': 'toggleExamAttemptActionDropdownMenu',
+            'click .accordion-trigger': 'toggleAttemptAccordion',
+            'keypress .accordion-trigger': 'keyToggleAttemptAccordion'
+        },
+        toggleExamAttemptActionDropdownMenu: function(event) {
+            edx.dashboard.dropdown.toggleExamAttemptActionDropdownMenu(event);
+        },
+        searchAttempts: function(event) {
+            var $searchIcon, $spinner;
+            var searchText = $('#search_attempt_id').val();
+            if (searchText !== '') {
+                this.inSearchMode = true;
+                this.searchText = searchText;
+                this.collection.url = this.initial_url + this.course_id + '/search/' + searchText;
+                $searchIcon = $(document.getElementById('attempt-search-indicator'));
+                $searchIcon.addClass('hidden');
+                $spinner = $(document.getElementById('attempt-loading-indicator'));
+                $spinner.removeClass('hidden');
+                this.hydrate();
+                event.stopPropagation();
+                event.preventDefault();
+            }
+        },
+        clearSearch: function(event) {
+            this.inSearchMode = false;
+            this.searchText = '';
+            this.collection.url = this.initial_url + this.course_id;
+            this.hydrate();
+            event.stopPropagation();
+            event.preventDefault();
+        },
+        getPaginatedAttempts: function(event) {
+            var $target = $(event.currentTarget);
+            this.collection.url = $target.data('target-url');
+            this.hydrate();
+            event.stopPropagation();
+            event.preventDefault();
+        },
+        getCSRFToken: function() {
+            var cookieValue = null;
+            var name = 'csrftoken';
+            var cookie, cookies, i;
+            if (document.cookie && document.cookie !== '') {
+                cookies = document.cookie.split(';');
+                for (i = 0; i < cookies.length; i += 1) {
+                    cookie = jQuery.trim(cookies[i]);
+                    // Does this cookie string begin with the name we want?
+                    if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                        break;
+                    }
+                }
+            }
+            return cookieValue;
+        },
+        loadTemplateData: function() {
+            var self = this;
+            $.ajax({url: self.template_url, dataType: 'html'})
+                .done(function(templateData) {
+                    self.template = _.template(templateData);
+                    self.hydrate();
+                });
+        },
+        hydrate: function() {
+            /* This function will load the bound collection */
 
-        // calculate which pages ranges to display
-        // show no more than 5 pages at the same time
-        startPage = dataJson.pagination_info.current_page - 2;
+            /* add and remove a class when we do the initial loading */
+            /* we might - at some point - add a visual element to the */
+            /* loading, like a spinner */
+            var self = this;
+            self.collection.fetch({
+                success: function() {
+                    var $searchIcon, $spinner;
+                    self.render();
+                    $spinner = $(document.getElementById('attempt-loading-indicator'));
+                    $spinner.addClass('hidden');
+                    $searchIcon = $(document.getElementById('attempt-search-indicator'));
+                    $searchIcon.removeClass('hidden');
+                }
+            });
+        },
+        collectionChanged: function() {
+            this.hydrate();
+        },
+        render: function() {
+            var dataJson, startPage, endPage, data, html;
+            if (this.template !== null) {
+                dataJson = this.collection.toJSON()[0];
 
-        if (startPage < 1) {
-          startPage = 1;
+                // calculate which pages ranges to display
+                // show no more than 5 pages at the same time
+                startPage = dataJson.pagination_info.current_page - 2;
+
+                if (startPage < 1) {
+                    startPage = 1;
+                }
+
+                endPage = startPage + 4;
+
+                if (endPage > dataJson.pagination_info.total_pages) {
+                    endPage = dataJson.pagination_info.total_pages;
+                }
+
+                dataJson.proctored_exam_attempts.forEach(function(proctoredExamAttempt, i) {
+                    var isProctored = proctoredExamAttempt.proctored_exam.is_proctored;
+                    var isPractice = proctoredExamAttempt.proctored_exam.is_practice_exam;
+                    var proctoredText = isPractice ? gettext('Practice') : gettext('Proctored');
+                    // eslint-disable-next-line no-param-reassign
+                    proctoredExamAttempt.exam_attempt_type = !isProctored ? gettext('Timed') : proctoredText;
+
+                    // current CSS selectors do not allow the selection of nth-child for a class selector,
+                    // so we are determining a class used for CSS styling here
+                    // eslint-disable-next-line no-param-reassign
+                    proctoredExamAttempt.row_class = 'odd';
+                    if ((i + 1) % 2 === 0) {
+                        // eslint-disable-next-line no-param-reassign
+                        proctoredExamAttempt.row_class = 'even';
+                    }
+                });
+
+                data = {
+                    proctored_exam_attempts: dataJson.proctored_exam_attempts,
+                    pagination_info: dataJson.pagination_info,
+                    attempt_url: dataJson.attempt_url,
+                    inSearchMode: this.inSearchMode,
+                    searchText: this.searchText,
+                    start_page: startPage,
+                    end_page: endPage
+                };
+                _.extend(data, viewHelper);
+                html = this.template(data);
+                this.$el.html(html);
+            }
+        },
+        onRemoveAttempt: function(event) {
+            var $target, attemptId, userId, examId;
+            var self = this;
+            event.preventDefault();
+
+            // confirm the user's intent
+            // eslint-disable-next-line no-alert
+            if (!confirm(gettext('Are you sure you want to remove this student\'s exam attempt?'))) {
+                return;
+            }
+            $('body').css('cursor', 'wait');
+            $target = $(event.currentTarget);
+            attemptId = $target.data('attemptId');
+            userId = $target.data('userId');
+            examId = $target.data('examId');
+
+            self.model.url = this.attempt_url + attemptId;
+
+            // call reset endpoint that can be used to delete all attempts for a given
+            // user and exam
+            $.ajax({
+                url: '/api/edx_proctoring/v1/proctored_exam/exam_id/' + examId +
+                    '/user_id/' + userId + '/reset_attempts',
+                type: 'DELETE',
+                headers: {
+                    'X-CSRFToken': this.getCSRFToken()
+                },
+                success: function() {
+                    // fetch the attempts again.
+                    self.hydrate();
+                    $('body').css('cursor', 'auto');
+                }
+            });
+        },
+        onResumeAttempt: function(event) {
+            var $target, attemptId, userId;
+            var self = this;
+            event.preventDefault();
+
+            // confirm the user's intent
+            // eslint-disable-next-line no-alert
+            if (!confirm(gettext('Are you sure you want to resume this student\'s exam attempt?'))) {
+                return;
+            }
+            $('body').css('cursor', 'wait');
+            $target = $(event.currentTarget);
+            attemptId = $target.data('attemptId');
+            userId = $target.data('userId');
+
+            self.model.url = this.attempt_url + attemptId;
+            self.model.fetch({
+                headers: {
+                    'X-CSRFToken': this.getCSRFToken()
+                },
+                type: 'PUT',
+                data: {
+                    action: 'mark_ready_to_resume',
+                    user_id: userId
+                },
+                success: function() {
+                    // fetch the attempts again.
+                    self.hydrate();
+                    $('body').css('cursor', 'auto');
+                }
+            });
+        },
+        toggleAttemptAccordion: function(event) {
+            // based on code from openedx/features/course_experience/static/course_experience/js/CourseOutline.js
+            // but modified to better fit this feature's needs
+            var accordionRow, isExpanded, $toggleChevron, $contentPanel;
+            event.preventDefault();
+            accordionRow = event.currentTarget;
+            if (accordionRow.classList.contains('accordion-trigger')) {
+                isExpanded = accordionRow.getAttribute('aria-expanded') === 'true';
+                if (!isExpanded) {
+                    $toggleChevron = $(accordionRow).find('.fa-chevron-right');
+                    $contentPanel = $(document.getElementById(accordionRow.getAttribute('aria-controls')));
+                    $contentPanel.removeClass('is-hidden');
+                    $toggleChevron.addClass('fa-rotate-90');
+                    accordionRow.setAttribute('aria-expanded', 'true');
+                } else {
+                    $toggleChevron = $(accordionRow).find('.fa-chevron-right');
+                    $contentPanel = $(document.getElementById(accordionRow.getAttribute('aria-controls')));
+                    $contentPanel.addClass('is-hidden');
+                    $toggleChevron.removeClass('fa-rotate-90');
+                    accordionRow.setAttribute('aria-expanded', 'false');
+                }
+            }
+        },
+        keyToggleAttemptAccordion: function(event) {
+            var key = event.which || event.keyCode || 0;
+            event.preventDefault();
+
+            if (key === 13) {
+                $(event.target).click();
+            }
         }
-
-        endPage = startPage + 4;
-
-        if (endPage > dataJson.pagination_info.total_pages) {
-          endPage = dataJson.pagination_info.total_pages;
-        }
-
-        dataJson.proctored_exam_attempts.forEach((proctoredExamAttempt, i) => {
-          const isProctored = proctoredExamAttempt.proctored_exam.is_proctored;
-          const isPractice = proctoredExamAttempt.proctored_exam.is_practice_exam;
-          const proctoredText = isPractice ? gettext('Practice') : gettext('Proctored');
-          // eslint-disable-next-line no-param-reassign
-          proctoredExamAttempt.exam_attempt_type = !isProctored ? gettext('Timed') : proctoredText;
-
-          // current CSS selectors do not allow the selection of nth-child for a class selector,
-          // so we are determining a class used for CSS styling here
-          // eslint-disable-next-line no-param-reassign
-          proctoredExamAttempt.row_class = 'odd';
-          if ((i + 1) % 2 === 0) {
-            // eslint-disable-next-line no-param-reassign
-            proctoredExamAttempt.row_class = 'even';
-          }
-        });
-
-        data = {
-          proctored_exam_attempts: dataJson.proctored_exam_attempts,
-          pagination_info: dataJson.pagination_info,
-          attempt_url: dataJson.attempt_url,
-          inSearchMode: this.inSearchMode,
-          searchText: this.searchText,
-          start_page: startPage,
-          end_page: endPage,
-        };
-        _.extend(data, viewHelper);
-        html = this.template(data);
-        this.$el.html(html);
-      }
-    },
-    onRemoveAttempt(event) {
-      const self = this;
-      event.preventDefault();
-
-      // confirm the user's intent
-      // eslint-disable-next-line no-alert
-      if (!window.confirm(gettext('Are you sure you want to remove this student\'s exam attempt?'))) {
-        return;
-      }
-      $('body').css('cursor', 'wait');
-      const $target = $(event.currentTarget);
-      const attemptId = $target.data('attemptId');
-      const userId = $target.data('userId');
-      const examId = $target.data('examId');
-
-      self.model.url = this.attempt_url + attemptId;
-
-      // call reset endpoint that can be used to delete all attempts for a given
-      // user and exam
-      $.ajax({
-        url: `/api/edx_proctoring/v1/proctored_exam/exam_id/${examId
-        }/user_id/${userId}/reset_attempts`,
-        type: 'DELETE',
-        headers: {
-          'X-CSRFToken': this.getCSRFToken(),
-        },
-        success() {
-          // fetch the attempts again.
-          self.hydrate();
-          $('body').css('cursor', 'auto');
-        },
-      });
-    },
-    onResumeAttempt(event) {
-      const self = this;
-      event.preventDefault();
-
-      // confirm the user's intent
-      // eslint-disable-next-line no-alert
-      if (!window.confirm(gettext('Are you sure you want to resume this student\'s exam attempt?'))) {
-        return;
-      }
-      $('body').css('cursor', 'wait');
-      const $target = $(event.currentTarget);
-      const attemptId = $target.data('attemptId');
-      const userId = $target.data('userId');
-
-      self.model.url = this.attempt_url + attemptId;
-      self.model.fetch({
-        headers: {
-          'X-CSRFToken': this.getCSRFToken(),
-        },
-        type: 'PUT',
-        data: {
-          action: 'mark_ready_to_resume',
-          user_id: userId,
-        },
-        success() {
-          // fetch the attempts again.
-          self.hydrate();
-          $('body').css('cursor', 'auto');
-        },
-      });
-    },
-    toggleAttemptAccordion(event) {
-      // based on code from openedx/features/course_experience/static/course_experience/js/CourseOutline.js
-      // but modified to better fit this feature's needs
-      let isExpanded; let $toggleChevron; let
-        $contentPanel;
-      event.preventDefault();
-      const accordionRow = event.currentTarget;
-      if (accordionRow.classList.contains('accordion-trigger')) {
-        isExpanded = accordionRow.getAttribute('aria-expanded') === 'true';
-        if (!isExpanded) {
-          $toggleChevron = $(accordionRow).find('.fa-chevron-right');
-          $contentPanel = $(document.getElementById(accordionRow.getAttribute('aria-controls')));
-          $contentPanel.removeClass('is-hidden');
-          $toggleChevron.addClass('fa-rotate-90');
-          accordionRow.setAttribute('aria-expanded', 'true');
-        } else {
-          $toggleChevron = $(accordionRow).find('.fa-chevron-right');
-          $contentPanel = $(document.getElementById(accordionRow.getAttribute('aria-controls')));
-          $contentPanel.addClass('is-hidden');
-          $toggleChevron.removeClass('fa-rotate-90');
-          accordionRow.setAttribute('aria-expanded', 'false');
-        }
-      }
-    },
-    keyToggleAttemptAccordion(event) {
-      const key = event.which || event.keyCode || 0;
-      event.preventDefault();
-
-      if (key === 13) {
-        $(event.target).click();
-      }
-    },
-  });
-  const proctoredExamAttemptView = edx.instructor_dashboard.proctoring.ProctoredExamAttemptView;
-  this.edx.instructor_dashboard.proctoring.ProctoredExamAttemptView = proctoredExamAttemptView;
+    });
+    this.edx.instructor_dashboard.proctoring.ProctoredExamAttemptView =
+      edx.instructor_dashboard.proctoring.ProctoredExamAttemptView;
 }).call(this, Backbone, $, _, gettext);

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_edit_allowance_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_edit_allowance_view.js
@@ -1,164 +1,165 @@
 edx = edx || {};
 
-((Backbone, $, _, gettext) => {
-  'use strict';
+(function(Backbone, $, _, gettext) {
+    'use strict';
 
-  edx.instructor_dashboard = edx.instructor_dashboard || {};
-  edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
 
-  edx.instructor_dashboard.proctoring.EditAllowanceView = Backbone.ModalView.extend({
-    name: 'EditAllowanceView',
-    template: null,
-    template_url: '/static/proctoring/templates/edit-allowance.underscore',
-    initialize(options) {
-      this.selected_exam_ID = options.selected_exam_ID;
-      this.selected_exam_name = options.selected_exam_name;
-      this.proctored_exam_allowance_view = options.proctored_exam_allowance_view;
-      this.course_id = options.course_id;
-      this.selected_user = options.selected_user;
-      this.allowance_type = options.allowance_type;
-      this.allowance_type_name = options.allowance_type_name;
-      this.model = new edx.instructor_dashboard.proctoring.ProctoredExamBulkAllowanceModel();
-      _.bindAll(this, 'render');
-      this.loadTemplateData();
-      // Backbone.Validation.bind( this,  {valid:this.hideError, invalid:this.showError});
-    },
-    events: {
-      'submit form': 'editAllowance',
-    },
-    loadTemplateData() {
-      const self = this;
-      $.ajax({ url: self.template_url, dataType: 'html' })
-        .done((templateData) => {
-          self.template = _.template(templateData);
-          self.render();
-          self.showModal();
-          self.updateCss();
-        });
-    },
-    updateCss() {
-      const $el = $(this.el);
-      $el.find('.modal-header').css({
-        color: '#1580b0',
-        'font-size': '20px',
-        'font-weight': '600',
-        'line-height': 'normal',
-        padding: '10px 15px',
-        'border-bottom': '1px solid #ccc',
-      });
-      $el.find('form').css({
-        padding: '15px',
-      });
-      $el.find('form table.compact td').css({
-        'vertical-align': 'middle',
-        padding: '4px 8px',
-      });
-      $el.find('form label').css({
-        display: 'block',
-        'font-size': '14px',
-        margin: 0,
-        cursor: 'default',
-      });
-      $el.find('form input[type="text"]').css({
-        height: '26px',
-        padding: '1px 8px 2px',
-        'font-size': '14px',
-        width: '100%',
-      });
-      $el.find('form input[type="submit"]').css({
-        'margin-top': '10px',
-        float: 'right',
-      });
-      $el.find('.error-message').css({
-        color: '#ff0000',
-        'line-height': 'normal',
-        'font-size': '14px',
-      });
-      $el.find('.error-response').css({
-        color: '#ff0000',
-        'line-height': 'normal',
-        'font-size': '14px',
-        padding: '0px 10px 5px 7px',
-      });
-    },
-    getAllowanceValue() {
-      return $('#allowance_value').val();
-    },
-    hideError(view, attr) {
-      const $element = view.$form[attr];
+    edx.instructor_dashboard.proctoring.EditAllowanceView = Backbone.ModalView.extend({
+        name: 'EditAllowanceView',
+        template: null,
+        template_url: '/static/proctoring/templates/edit-allowance.underscore',
+        initialize: function(options) {
+            this.selected_exam_ID = options.selected_exam_ID;
+            this.selected_exam_name = options.selected_exam_name;
+            this.proctored_exam_allowance_view = options.proctored_exam_allowance_view;
+            this.course_id = options.course_id;
+            this.selected_user = options.selected_user;
+            this.allowance_type = options.allowance_type;
+            this.allowance_type_name = options.allowance_type_name;
+            this.model = new edx.instructor_dashboard.proctoring.ProctoredExamBulkAllowanceModel();
+            _.bindAll(this, 'render');
+            this.loadTemplateData();
+            // Backbone.Validation.bind( this,  {valid:this.hideError, invalid:this.showError});
+        },
+        events: {
+            'submit form': 'editAllowance'
+        },
+        loadTemplateData: function() {
+            var self = this;
+            $.ajax({url: self.template_url, dataType: 'html'})
+                .done(function(templateData) {
+                    self.template = _.template(templateData);
+                    self.render();
+                    self.showModal();
+                    self.updateCss();
+                });
+        },
+        updateCss: function() {
+            var $el = $(this.el);
+            $el.find('.modal-header').css({
+                color: '#1580b0',
+                'font-size': '20px',
+                'font-weight': '600',
+                'line-height': 'normal',
+                padding: '10px 15px',
+                'border-bottom': '1px solid #ccc'
+            });
+            $el.find('form').css({
+                padding: '15px'
+            });
+            $el.find('form table.compact td').css({
+                'vertical-align': 'middle',
+                padding: '4px 8px'
+            });
+            $el.find('form label').css({
+                display: 'block',
+                'font-size': '14px',
+                margin: 0,
+                cursor: 'default'
+            });
+            $el.find('form input[type="text"]').css({
+                height: '26px',
+                padding: '1px 8px 2px',
+                'font-size': '14px',
+                width: '100%'
+            });
+            $el.find('form input[type="submit"]').css({
+                'margin-top': '10px',
+                float: 'right'
+            });
+            $el.find('.error-message').css({
+                color: '#ff0000',
+                'line-height': 'normal',
+                'font-size': '14px'
+            });
+            $el.find('.error-response').css({
+                color: '#ff0000',
+                'line-height': 'normal',
+                'font-size': '14px',
+                padding: '0px 10px 5px 7px'
+            });
+        },
+        getAllowanceValue: function() {
+            return $('#allowance_value').val();
+        },
+        hideError: function(view, attr) {
+            var $element = view.$form[attr];
 
-      $element.removeClass('error');
-      $element.parent().find('.error-message').empty();
-    },
-    showError(view, attr, errorMessage) {
-      const $element = view.$form[attr];
-      let $errorMessage;
+            $element.removeClass('error');
+            $element.parent().find('.error-message').empty();
+        },
+        showError: function(view, attr, errorMessage) {
+            var $element = view.$form[attr];
+            var $errorMessage;
 
-      $element.addClass('error');
-      $errorMessage = $element.parent().find('.error-message');
-      if ($errorMessage.length === 0) {
-        $errorMessage = $("<div class='error-message'></div>");
-        $element.parent().append($errorMessage);
-      }
+            $element.addClass('error');
+            $errorMessage = $element.parent().find('.error-message');
+            if ($errorMessage.length === 0) {
+                $errorMessage = $("<div class='error-message'></div>");
+                $element.parent().append($errorMessage);
+            }
 
-      $errorMessage.empty().append(errorMessage);
-      this.updateCss();
-    },
-    editAllowance(event) {
-      let formHasErrors;
-      const self = this;
-      event.preventDefault();
-      const $errorResponse = $('.error-response');
-      $errorResponse.html();
-      const allowanceValue = this.getAllowanceValue();
-      formHasErrors = false;
-
-      if (allowanceValue === '') {
-        formHasErrors = true;
-        self.showError(self, 'allowance_value', gettext('Required field'));
-      } else {
-        self.hideError(self, 'allowance_value');
-      }
-
-      if (!formHasErrors) {
-        self.model.fetch({
-          headers: {
-            'X-CSRFToken': self.proctored_exam_allowance_view.getCSRFToken(),
-          },
-          type: 'PUT',
-          data: {
-            course_id: self.course_id,
-            exam_ids: this.selected_exam_ID,
-            user_ids: this.selected_user,
-            allowance_type: this.allowance_type,
-            value: allowanceValue,
-          },
-          success() {
-            // fetch the allowances again.
+            $errorMessage.empty().append(errorMessage);
+            this.updateCss();
+        },
+        editAllowance: function(event) {
+            var $errorResponse, formHasErrors, allowanceValue;
+            var self = this;
+            event.preventDefault();
+            $errorResponse = $('.error-response');
             $errorResponse.html();
-            self.proctored_exam_allowance_view.collection.url = `${self.proctored_exam_allowance_view.initial_url + self.course_id}/allowance`;
-            self.proctored_exam_allowance_view.hydrate();
-            self.hideModal();
-          },
-          error(unused, response) {
-            const data = $.parseJSON(response.responseText);
-            self.showError(self, data.field, data.detail);
-          },
-        });
-      }
-    },
-    render() {
-      $(this.el).html(this.template({
-        selected_user: this.selected_user,
-        selected_exam_name: this.selected_exam_name,
-        allowance_type: this.allowance_type,
-        allowance_type_name: this.allowance_type_name,
-      }));
+            allowanceValue = this.getAllowanceValue();
+            formHasErrors = false;
 
-      this.$form = {
-        allowance_value: this.$('#allowance_value'),
-      };
-      return this;
-    },
-  });
+            if (allowanceValue === '') {
+                formHasErrors = true;
+                self.showError(self, 'allowance_value', gettext('Required field'));
+            } else {
+                self.hideError(self, 'allowance_value');
+            }
+
+            if (!formHasErrors) {
+                self.model.fetch({
+                    headers: {
+                        'X-CSRFToken': self.proctored_exam_allowance_view.getCSRFToken()
+                    },
+                    type: 'PUT',
+                    data: {
+                        course_id: self.course_id,
+                        exam_ids: this.selected_exam_ID,
+                        user_ids: this.selected_user,
+                        allowance_type: this.allowance_type,
+                        value: allowanceValue
+                    },
+                    success: function() {
+                        // fetch the allowances again.
+                        $errorResponse.html();
+                        self.proctored_exam_allowance_view.collection.url =
+                            self.proctored_exam_allowance_view.initial_url + self.course_id + '/allowance';
+                        self.proctored_exam_allowance_view.hydrate();
+                        self.hideModal();
+                    },
+                    error: function(unused, response) {
+                        var data = $.parseJSON(response.responseText);
+                        self.showError(self, data.field, data.detail);
+                    }
+                });
+            }
+        },
+        render: function() {
+            $(this.el).html(this.template({
+                selected_user: this.selected_user,
+                selected_exam_name: this.selected_exam_name,
+                allowance_type: this.allowance_type,
+                allowance_type_name: this.allowance_type_name
+            }));
+
+            this.$form = {
+                allowance_value: this.$('#allowance_value')
+            };
+            return this;
+        }
+    });
 }).call(this, Backbone, $, _, gettext);

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_info.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_info.js
@@ -1,208 +1,211 @@
-((Backbone, $) => {
-  'use strict';
+(function(Backbone, $) {
+    'use strict';
 
-  edx.courseware = edx.courseware || {};
-  edx.courseware.proctored_exam = edx.courseware.proctored_exam || {};
+    var examStatusReadableFormat, notStartedText, startedText, submittedText;
 
-  const notStartedText = {
-    status: gettext('Not Started'),
-    message: gettext('You have not started your onboarding exam.'),
-  };
-  const startedText = {
-    status: gettext('Started'),
-    message: gettext('You have started your onboarding exam.'),
-  };
-  const submittedText = {
-    status: gettext('Submitted'),
-    message: gettext('You have submitted your onboarding exam.'),
-  };
+    edx.courseware = edx.courseware || {};
+    edx.courseware.proctored_exam = edx.courseware.proctored_exam || {};
 
-  const examStatusReadableFormat = {
-    created: notStartedText,
-    download_software_clicked: notStartedText,
-    ready_to_start: notStartedText,
-    started: startedText,
-    ready_to_submit: startedText,
-    second_review_required: submittedText,
-    submitted: submittedText,
-    verified: {
-      status: gettext('Verified'),
-      message: gettext('Your onboarding exam has been approved in this course.'),
-    },
-    rejected: {
-      status: gettext('Rejected'),
-      message: gettext('Your onboarding exam has been rejected. Please retry onboarding.'),
-    },
-    error: {
-      status: gettext('Error'),
-      message: gettext('An error has occurred during your onboarding exam. Please retry onboarding.'),
-    },
-    other_course_approved: {
-      status: gettext('Approved in Another Course'),
-      message: gettext('Your onboarding exam has been approved in another course.'),
-      detail: gettext(
-        'If your device has changed, we recommend that you complete this '
-                + 'course\'s onboarding exam in order to ensure that your setup '
-                + 'still meets the requirements for proctoring.',
-      ),
-    },
-    expiring_soon: {
-      status: gettext('Expiring Soon'),
-      message: gettext(
-        'Your onboarding profile has been approved in another course. '
-                + 'However, your onboarding status is expiring soon. Please '
-                + 'complete onboarding again to ensure that you will be '
-                + 'able to continue taking proctored exams.',
-      ),
-    },
-  };
+    notStartedText = {
+        status: gettext('Not Started'),
+        message: gettext('You have not started your onboarding exam.')
+    };
+    startedText = {
+        status: gettext('Started'),
+        message: gettext('You have started your onboarding exam.')
+    };
+    submittedText = {
+        status: gettext('Submitted'),
+        message: gettext('You have submitted your onboarding exam.')
+    };
 
-  edx.courseware.proctored_exam.ProctoredExamInfo = Backbone.View.extend({
-    initialize() {
-      this.course_id = this.$el.data('course-id');
-      this.username = this.$el.data('username');
-      this.model.url = `${this.model.url}?course_id=${encodeURIComponent(this.course_id)}`;
-      if (this.username) {
-        this.model.url = `${this.model.url}&username=${encodeURIComponent(this.username)}`;
-      }
-      this.template_url = '/static/proctoring/templates/proctored-exam-info.underscore';
-      this.status = '';
-
-      this.loadTemplateData();
-    },
-
-    updateCss() {
-      const $el = $(this.el);
-      let color = '#b20610';
-      if (['verified', 'other_course_approved'].includes(this.status)) {
-        color = '#008100';
-      } else if (['submitted', 'second_review_required', 'expiring_soon'].includes(this.status)) {
-        color = '#0d4e6c';
-      }
-
-      $el.find('.proctoring-info').css({
-        padding: '10px',
-        border: '1px solid #e7e7e7',
-        'border-top': `5px solid ${color}`,
-        'margin-bottom': '15px',
-      });
-
-      $el.find('.onboarding-status').css({
-        'font-weight': 'bold',
-        'margin-bottom': '15px',
-      });
-
-      $el.find('.onboarding-status-message').css({
-        'margin-bottom': '15px',
-      });
-
-      $el.find('.onboarding-status-detail').css({
-        'font-size': '0.8rem',
-        'margin-bottom': '15px',
-      });
-
-      $el.find('.action').css({
-        display: 'block',
-        'font-weight': '600',
-        'text-align': 'center',
-        'text-decoration': 'none',
-        padding: '15px 20px',
-        border: 'none',
-      });
-
-      $el.find('.action-onboarding').css({
-        color: '#ffffff',
-        background: '#98050e',
-        'margin-bottom': '15px',
-      });
-
-      $el.find('.action-onboarding-practice').css({
-        color: '#ffffff',
-        background: '#0075b4',
-        'margin-bottom': '15px',
-      });
-
-      $el.find('.action-disabled').css({
-        background: '#b4b6bd',
-      });
-
-      $el.find('.action-info-link').css({
-        border: '1px solid #0d4e6c',
-      });
-    },
-
-    getExamAttemptText(status) {
-      if (status in examStatusReadableFormat) {
-        return examStatusReadableFormat[status];
-      }
-      return { status: status || 'Not Started', message: '' };
-    },
-
-    isExpiringSoon(expirationDate) {
-      const today = new Date();
-      const expirationDateObject = new Date(expirationDate);
-      // Return true if the expiration date is within 28 days
-      return today.getTime() > expirationDateObject.getTime() - 2419200000;
-    },
-
-    shouldShowExamLink(status) {
-      // show the exam link if the user should retry onboarding, or if they haven't submitted the exam
-      const NO_SHOW_STATES = ['submitted', 'second_review_required', 'verified'];
-      return !NO_SHOW_STATES.includes(status);
-    },
-
-    render() {
-      let statusText = {};
-      let releaseDate;
-      const now = new Date();
-      let data = this.model.toJSON();
-      if (this.template) {
-        if (data.expiration_date && this.isExpiringSoon(data.expiration_date)) {
-          this.status = 'expiring_soon';
-        } else {
-          this.status = data.onboarding_status;
-        }
-        statusText = this.getExamAttemptText(this.status);
-        releaseDate = new Date(data.onboarding_release_date);
-        data = {
-          onboardingStatus: this.status,
-          onboardingStatusText: statusText.status,
-          onboardingMessage: statusText.message,
-          onboardingDetail: statusText.detail,
-          showOnboardingReminder: !['verified', 'other_course_approved'].includes(data.onboarding_status),
-          onboardingNotReleased: releaseDate > now,
-          onboardingPastDue: data.onboarding_past_due,
-          showOnboardingExamLink: this.shouldShowExamLink(data.onboarding_status),
-          onboardingLink: data.onboarding_link,
-          onboardingReleaseDate: releaseDate.toLocaleDateString(),
-          reviewRequirementsUrl: data.review_requirements_url,
-        };
-
-        $(this.el).html(this.template(data));
-      }
-    },
-
-    loadTemplateData() {
-      const self = this;
-      // only load data/render if course_id is defined
-      if (self.course_id) {
-        $.ajax({ url: self.template_url, dataType: 'html' })
-          .done((templateData) => {
-            self.template = _.template(templateData);
-            self.hydrate();
-          });
-      }
-    },
-
-    hydrate() {
-      const self = this;
-      self.model.fetch({
-        success() {
-          self.render();
-          self.updateCss();
+    examStatusReadableFormat = {
+        created: notStartedText,
+        download_software_clicked: notStartedText,
+        ready_to_start: notStartedText,
+        started: startedText,
+        ready_to_submit: startedText,
+        second_review_required: submittedText,
+        submitted: submittedText,
+        verified: {
+            status: gettext('Verified'),
+            message: gettext('Your onboarding exam has been approved in this course.')
         },
-      });
-    },
-  });
-  this.edx.courseware.proctored_exam.ProctoredExamInfo = edx.courseware.proctored_exam.ProctoredExamInfo;
+        rejected: {
+            status: gettext('Rejected'),
+            message: gettext('Your onboarding exam has been rejected. Please retry onboarding.')
+        },
+        error: {
+            status: gettext('Error'),
+            message: gettext('An error has occurred during your onboarding exam. Please retry onboarding.')
+        },
+        other_course_approved: {
+            status: gettext('Approved in Another Course'),
+            message: gettext('Your onboarding exam has been approved in another course.'),
+            detail: gettext(
+                'If your device has changed, we recommend that you complete this ' +
+                'course\'s onboarding exam in order to ensure that your setup ' +
+                'still meets the requirements for proctoring.'
+            )
+        },
+        expiring_soon: {
+            status: gettext('Expiring Soon'),
+            message: gettext(
+                'Your onboarding profile has been approved in another course. ' +
+                'However, your onboarding status is expiring soon. Please ' +
+                'complete onboarding again to ensure that you will be ' +
+                'able to continue taking proctored exams.'
+            )
+        }
+    };
+
+    edx.courseware.proctored_exam.ProctoredExamInfo = Backbone.View.extend({
+        initialize: function() {
+            this.course_id = this.$el.data('course-id');
+            this.username = this.$el.data('username');
+            this.model.url = this.model.url + '?course_id=' + encodeURIComponent(this.course_id);
+            if (this.username) {
+                this.model.url = this.model.url + '&username=' + encodeURIComponent(this.username);
+            }
+            this.template_url = '/static/proctoring/templates/proctored-exam-info.underscore';
+            this.status = '';
+
+            this.loadTemplateData();
+        },
+
+        updateCss: function() {
+            var $el = $(this.el);
+            var color = '#b20610';
+            if (['verified', 'other_course_approved'].includes(this.status)) {
+                color = '#008100';
+            } else if (['submitted', 'second_review_required', 'expiring_soon'].includes(this.status)) {
+                color = '#0d4e6c';
+            }
+
+            $el.find('.proctoring-info').css({
+                padding: '10px',
+                border: '1px solid #e7e7e7',
+                'border-top': '5px solid ' + color,
+                'margin-bottom': '15px'
+            });
+
+            $el.find('.onboarding-status').css({
+                'font-weight': 'bold',
+                'margin-bottom': '15px'
+            });
+
+            $el.find('.onboarding-status-message').css({
+                'margin-bottom': '15px'
+            });
+
+            $el.find('.onboarding-status-detail').css({
+                'font-size': '0.8rem',
+                'margin-bottom': '15px'
+            });
+
+            $el.find('.action').css({
+                display: 'block',
+                'font-weight': '600',
+                'text-align': 'center',
+                'text-decoration': 'none',
+                padding: '15px 20px',
+                border: 'none'
+            });
+
+            $el.find('.action-onboarding').css({
+                color: '#ffffff',
+                background: '#98050e',
+                'margin-bottom': '15px'
+            });
+
+            $el.find('.action-onboarding-practice').css({
+                color: '#ffffff',
+                background: '#0075b4',
+                'margin-bottom': '15px'
+            });
+
+            $el.find('.action-disabled').css({
+                background: '#b4b6bd'
+            });
+
+            $el.find('.action-info-link').css({
+                border: '1px solid #0d4e6c'
+            });
+        },
+
+        getExamAttemptText: function(status) {
+            if (status in examStatusReadableFormat) {
+                return examStatusReadableFormat[status];
+            } else {
+                return {status: status || 'Not Started', message: ''};
+            }
+        },
+
+        isExpiringSoon: function(expirationDate) {
+            var today = new Date();
+            var expirationDateObject = new Date(expirationDate);
+            // Return true if the expiration date is within 28 days
+            return today.getTime() > expirationDateObject.getTime() - 2419200000;
+        },
+
+        shouldShowExamLink: function(status) {
+            // show the exam link if the user should retry onboarding, or if they haven't submitted the exam
+            var NO_SHOW_STATES = ['submitted', 'second_review_required', 'verified'];
+            return !NO_SHOW_STATES.includes(status);
+        },
+
+        render: function() {
+            var statusText = {};
+            var releaseDate;
+            var now = new Date();
+            var data = this.model.toJSON();
+            if (this.template) {
+                if (data.expiration_date && this.isExpiringSoon(data.expiration_date)) {
+                    this.status = 'expiring_soon';
+                } else {
+                    this.status = data.onboarding_status;
+                }
+                statusText = this.getExamAttemptText(this.status);
+                releaseDate = new Date(data.onboarding_release_date);
+                data = {
+                    onboardingStatus: this.status,
+                    onboardingStatusText: statusText.status,
+                    onboardingMessage: statusText.message,
+                    onboardingDetail: statusText.detail,
+                    showOnboardingReminder: !['verified', 'other_course_approved'].includes(data.onboarding_status),
+                    onboardingNotReleased: releaseDate > now,
+                    onboardingPastDue: data.onboarding_past_due,
+                    showOnboardingExamLink: this.shouldShowExamLink(data.onboarding_status),
+                    onboardingLink: data.onboarding_link,
+                    onboardingReleaseDate: releaseDate.toLocaleDateString(),
+                    reviewRequirementsUrl: data.review_requirements_url
+                };
+
+                $(this.el).html(this.template(data));
+            }
+        },
+
+        loadTemplateData: function() {
+            var self = this;
+            // only load data/render if course_id is defined
+            if (self.course_id) {
+                $.ajax({url: self.template_url, dataType: 'html'})
+                    .done(function(templateData) {
+                        self.template = _.template(templateData);
+                        self.hydrate();
+                    });
+            }
+        },
+
+        hydrate: function() {
+            var self = this;
+            self.model.fetch({
+                success: function() {
+                    self.render();
+                    self.updateCss();
+                }
+            });
+        }
+    });
+    this.edx.courseware.proctored_exam.ProctoredExamInfo = edx.courseware.proctored_exam.ProctoredExamInfo;
 }).call(this, Backbone, $, _, gettext);

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_instructor_launch.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_instructor_launch.js
@@ -1,41 +1,41 @@
 edx = edx || {};
 
-((Backbone, $, _) => {
-  'use strict';
+(function(Backbone, $, _) {
+    'use strict';
 
-  edx.instructor_dashboard = edx.instructor_dashboard || {};
-  edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
-  edx.instructor_dashboard.proctoring.ProctoredExamDashboardView = Backbone.View.extend({
-    initialize() {
-      const self = this;
-      this.setElement($('.student-review-dashboard-container'));
-      this.template_url = '/static/proctoring/templates/dashboard.underscore';
-      this.iframeHTML = null;
-      this.doRender = true;
-      this.context = {
-        dashboardURL: `/api/edx_proctoring/v1/instructor/${this.$el.data('course-id')}`,
-      };
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+    edx.instructor_dashboard.proctoring.ProctoredExamDashboardView = Backbone.View.extend({
+        initialize: function() {
+            var self = this;
+            this.setElement($('.student-review-dashboard-container'));
+            this.template_url = '/static/proctoring/templates/dashboard.underscore';
+            this.iframeHTML = null;
+            this.doRender = true;
+            this.context = {
+                dashboardURL: '/api/edx_proctoring/v1/instructor/' + this.$el.data('course-id')
+            };
 
-      $('#proctoring-accordion').on('accordionactivate', (event, ui) => {
-        self.render(ui);
-      });
-      /* Load the static template for rendering. */
-      this.loadTemplateData();
-    },
-    loadTemplateData() {
-      const self = this;
-      $.ajax({ url: self.template_url, dataType: 'html' })
-        .done((templateHtml) => {
-          self.iframeHTML = _.template(templateHtml)(self.context);
-        });
-    },
-    render(ui) {
-      if (ui.newPanel.eq(this.$el) && this.doRender && this.iframeHTML) {
-        this.$el.html(this.iframeHTML);
-        this.doRender = false;
-      }
-    },
-  });
-  const proctoredExamDashboardView = edx.instructor_dashboard.proctoring.ProctoredExamDashboardView;
-  this.edx.instructor_dashboard.proctoring.ProctoredExamDashboardView = proctoredExamDashboardView;
+            $('#proctoring-accordion').on('accordionactivate', function(event, ui) {
+                self.render(ui);
+            });
+            /* Load the static template for rendering. */
+            this.loadTemplateData();
+        },
+        loadTemplateData: function() {
+            var self = this;
+            $.ajax({url: self.template_url, dataType: 'html'})
+                .done(function(templateHtml) {
+                    self.iframeHTML = _.template(templateHtml)(self.context);
+                });
+        },
+        render: function(ui) {
+            if (ui.newPanel.eq(this.$el) && this.doRender && this.iframeHTML) {
+                this.$el.html(this.iframeHTML);
+                this.doRender = false;
+            }
+        }
+    });
+    this.edx.instructor_dashboard.proctoring.ProctoredExamDashboardView =
+        edx.instructor_dashboard.proctoring.ProctoredExamDashboardView;
 }).call(this, Backbone, $, _);

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_onboarding_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_onboarding_view.js
@@ -1,285 +1,288 @@
 edx = edx || {};
 
-((Backbone, $, _, gettext) => {
-  'use strict';
+(function(Backbone, $, _, gettext) {
+    'use strict';
 
-  edx.instructor_dashboard = edx.instructor_dashboard || {};
-  edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
-  const onboardingStatuses = [
-    'not_started',
-    'setup_started',
-    'onboarding_started',
-    'other_course_approved',
-    'submitted',
-    'verified',
-    'rejected',
-    'error',
-  ];
-  const onboardingProfileAPIStatuses = [
-    'not_started',
-    'other_course_approved',
-    'submitted',
-    'verified',
-    'rejected',
-    'expired',
-  ];
-  const statusAndModeReadableFormat = {
-    // Onboarding statuses
-    not_started: gettext('Not Started'),
-    setup_started: gettext('Setup Started'),
-    onboarding_started: gettext('Onboarding Started'),
-    other_course_approved: gettext('Approved in Another Course'),
-    started: gettext('Started'),
-    submitted: gettext('Submitted'),
-    verified: gettext('Verified'),
-    rejected: gettext('Rejected'),
-    error: gettext('Error'),
-    expired: gettext('Expired'),
-    // TODO: remove as part of MST-745
-    onboarding_reset_past_due: gettext('Onboarding Reset Failed Due to Past Due Exam'),
-    // Enrollment modes (Note: 'verified' is both a status and enrollment mode)
-    audit: gettext('Audit'),
-    honor: gettext('Honor'),
-    professional: gettext('Professional'),
-    'no-id-professional': gettext('No ID Professional'),
-    credit: gettext('Credit'),
-    masters: gettext('Master\'s'),
-    'executive-education': gettext('Executive Education'),
-  };
-  const viewHelper = {
-    getDateFormat(date) {
-      if (date) {
-        return new Date(date).toString('MMM dd, yyyy h:mmtt');
-      }
-      return '---';
-    },
-    getReadableString(str) {
-      if (str in statusAndModeReadableFormat) {
-        return statusAndModeReadableFormat[str];
-      }
-      return str;
-    },
-  };
-  edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView = Backbone.View.extend({
-    initialize() {
-      this.setElement($('.student-onboarding-status-container'));
-      this.collection = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingCollection();
-      this.templateUrl = '/static/proctoring/templates/student-onboarding-status.underscore';
-      this.courseId = this.$el.data('course-id');
-      this.template = null;
-
-      this.initialUrl = this.collection.url;
-      this.collection.url = this.initialUrl + this.courseId;
-      this.inSearchMode = false;
-      this.searchText = '';
-      this.filters = [];
-      this.currentPage = 1;
-
-      /* re-render if the model changes */
-      this.listenTo(this.collection, 'change', this.collectionChanged);
-
-      /* Load the static template for rendering. */
-      this.loadTemplateData();
-    },
-    events: {
-      'click .search-onboarding > span.search': 'searchItems',
-      'click .search-onboarding > span.clear-search': 'clearSearch',
-      'submit .filter-form': 'filterItems',
-      'click .clear-filters': 'clearFilters',
-      'click li > a.target-link': 'getPaginatedItems',
-    },
-    searchItems(event) {
-      const searchText = $('#search_onboarding_id').val();
-      if (searchText !== '') {
-        this.inSearchMode = true;
-        this.searchText = searchText;
-        this.currentPage = 1;
-        this.collection.url = this.constructUrl();
-        const $searchIcon = $(document.getElementById('onboarding-search-indicator'));
-        $searchIcon.addClass('hidden');
-        const $spinner = $(document.getElementById('onboarding-loading-indicator'));
-        $spinner.removeClass('hidden');
-        this.hydrate();
-        event.stopPropagation();
-        event.preventDefault();
-      }
-    },
-    clearSearch(event) {
-      this.inSearchMode = false;
-      this.searchText = '';
-      this.currentPage = 1;
-      this.collection.url = this.constructUrl();
-      this.hydrate();
-      event.stopPropagation();
-      event.preventDefault();
-    },
-    filterItems(event) {
-      const $checkboxes = $('.status-checkboxes li input').get();
-      const filters = [];
-      $checkboxes.forEach((checkbox) => {
-        if (checkbox.checked) {
-          filters.push(checkbox.value);
-        }
-      });
-      this.filters = filters;
-      // return to the first page and rerender the view
-      this.currentPage = 1;
-      this.collection.url = this.constructUrl();
-      this.hydrate();
-      event.stopPropagation();
-      event.preventDefault();
-    },
-    clearFilters(event) {
-      this.filters = [];
-      this.currentPage = 1;
-      this.collection.url = this.constructUrl();
-      this.hydrate();
-      event.stopPropagation();
-      event.preventDefault();
-    },
-    constructUrl(page) {
-      let url;
-      page = typeof page !== 'undefined' ? page : null; // eslint-disable-line no-param-reassign
-      // if the page has changed, update the current page
-      if (page) {
-        this.currentPage = page;
-      }
-      url = `${this.initialUrl + this.courseId}?page=${this.currentPage}`;
-      if (this.searchText) {
-        url = `${url}&text_search=${this.searchText}`;
-      }
-      if (this.filters.length > 0) {
-        url += '&statuses=';
-        // creates a string of onboarding statuses separated by ','
-        this.filters.forEach((filter, i) => {
-          if (i > 0) {
-            url += ',';
-          }
-          url += filter;
-        });
-      }
-      return url;
-    },
-    getPaginatedItems(event) {
-      const $target = $(event.currentTarget);
-      const page = Number($target.data('page-number'));
-      this.collection.url = this.constructUrl(page);
-      this.hydrate();
-      event.stopPropagation();
-      event.preventDefault();
-    },
-    loadTemplateData() {
-      const self = this;
-      $.ajax({ url: self.templateUrl, dataType: 'html' })
-        .done((templateData) => {
-          self.template = _.template(templateData);
-          self.hydrate();
-        });
-    },
-    hydrate() {
-      /* This function will load the bound collection */
-
-      /* add and remove a class when we do the initial loading */
-      /* we might - at some point - add a visual element to the */
-      /* loading, like a spinner */
-      const self = this;
-      self.collection.fetch({
-        success() {
-          self.render();
-          const $spinner = $(document.getElementById('onboarding-loading-indicator'));
-          $spinner.addClass('hidden');
-          const $searchIcon = $(document.getElementById('onboarding-search-indicator'));
-          $searchIcon.removeClass('hidden');
+    var viewHelper, onboardingStatuses, onboardingProfileAPIStatuses, statusAndModeReadableFormat;
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+    onboardingStatuses = [
+        'not_started',
+        'setup_started',
+        'onboarding_started',
+        'other_course_approved',
+        'submitted',
+        'verified',
+        'rejected',
+        'error'
+    ];
+    onboardingProfileAPIStatuses = [
+        'not_started',
+        'other_course_approved',
+        'submitted',
+        'verified',
+        'rejected',
+        'expired'
+    ];
+    statusAndModeReadableFormat = {
+        // Onboarding statuses
+        not_started: gettext('Not Started'),
+        setup_started: gettext('Setup Started'),
+        onboarding_started: gettext('Onboarding Started'),
+        other_course_approved: gettext('Approved in Another Course'),
+        started: gettext('Started'),
+        submitted: gettext('Submitted'),
+        verified: gettext('Verified'),
+        rejected: gettext('Rejected'),
+        error: gettext('Error'),
+        expired: gettext('Expired'),
+        // TODO: remove as part of MST-745
+        onboarding_reset_past_due: gettext('Onboarding Reset Failed Due to Past Due Exam'),
+        // Enrollment modes (Note: 'verified' is both a status and enrollment mode)
+        audit: gettext('Audit'),
+        honor: gettext('Honor'),
+        professional: gettext('Professional'),
+        'no-id-professional': gettext('No ID Professional'),
+        credit: gettext('Credit'),
+        masters: gettext('Master\'s'),
+        'executive-education': gettext('Executive Education')
+    };
+    viewHelper = {
+        getDateFormat: function(date) {
+            if (date) {
+                return new Date(date).toString('MMM dd, yyyy h:mmtt');
+            } else {
+                return '---';
+            }
         },
-        error(unused, response) {
-          let data; let $errorResponse; let $onboardingPanel;
-
-          // in the case that there is no onboarding data, we
-          // still want the view to render
-          self.render();
-
-          try {
-            data = $.parseJSON(response.responseText);
-          } catch (error) {
-            data = {
-              detail: 'An unexpected error occured. Please try again later.',
-            };
-          }
-
-          if (data.detail) {
-            $errorResponse = $('#error-response');
-            $errorResponse.html(data.detail);
-            $onboardingPanel = $('.onboarding-status-content');
-            $onboardingPanel.hide();
-          }
-
-          const $spinner = $(document.getElementById('onboarding-loading-indicator'));
-          $spinner.addClass('hidden');
-          const $searchIcon = $(document.getElementById('onboarding-search-indicator'));
-          $searchIcon.removeClass('hidden');
-        },
-      });
-    },
-    collectionChanged() {
-      this.hydrate();
-    },
-    render() {
-      let data; let dataJson; let html; let startPage; let endPage; let
-        statuses;
-
-      if (this.template !== null) {
-        data = {
-          previousPage: null,
-          nextPage: null,
-          currentPage: 1,
-          onboardingItems: [],
-          onboardingStatuses,
-          inSearchMode: this.inSearchMode,
-          searchText: this.searchText,
-          filters: this.filters,
-          constructUrl: this.constructUrl,
-          startPage: 1,
-          endPage: 1,
-        };
-
-        [dataJson] = this.collection.toJSON();
-        if (dataJson) {
-          // calculate which pages ranges to display
-          // show no more than 5 pages at the same time
-          if (this.currentPage > 3) {
-            startPage = this.currentPage - 2;
-          } else {
-            startPage = 1;
-          }
-
-          endPage = startPage + 4;
-
-          if (endPage > dataJson.num_pages) {
-            endPage = dataJson.num_pages;
-          }
-
-          statuses = dataJson.use_onboarding_profile_api ? onboardingProfileAPIStatuses : onboardingStatuses;
-          data = {
-            previousPage: dataJson.previous,
-            nextPage: dataJson.next,
-            currentPage: this.currentPage,
-            onboardingItems: dataJson.results,
-            onboardingStatuses: statuses,
-            inSearchMode: this.inSearchMode,
-            searchText: this.searchText,
-            filters: this.filters,
-            constructUrl: this.constructUrl,
-            startPage,
-            endPage,
-          };
+        getReadableString: function(str) {
+            if (str in statusAndModeReadableFormat) {
+                return statusAndModeReadableFormat[str];
+            }
+            return str;
         }
+    };
+    edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView = Backbone.View.extend({
+        initialize: function() {
+            this.setElement($('.student-onboarding-status-container'));
+            this.collection = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingCollection();
+            this.templateUrl = '/static/proctoring/templates/student-onboarding-status.underscore';
+            this.courseId = this.$el.data('course-id');
+            this.template = null;
 
-        _.extend(data, viewHelper);
-        html = this.template(data);
-        this.$el.html(html);
-      }
-    },
-  });
-  const proctoredExamOnboardingView = edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView;
-  this.edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView = proctoredExamOnboardingView;
+            this.initialUrl = this.collection.url;
+            this.collection.url = this.initialUrl + this.courseId;
+            this.inSearchMode = false;
+            this.searchText = '';
+            this.filters = [];
+            this.currentPage = 1;
+
+            /* re-render if the model changes */
+            this.listenTo(this.collection, 'change', this.collectionChanged);
+
+            /* Load the static template for rendering. */
+            this.loadTemplateData();
+        },
+        events: {
+            'click .search-onboarding > span.search': 'searchItems',
+            'click .search-onboarding > span.clear-search': 'clearSearch',
+            'submit .filter-form': 'filterItems',
+            'click .clear-filters': 'clearFilters',
+            'click li > a.target-link': 'getPaginatedItems'
+        },
+        searchItems: function(event) {
+            var $searchIcon, $spinner;
+            var searchText = $('#search_onboarding_id').val();
+            if (searchText !== '') {
+                this.inSearchMode = true;
+                this.searchText = searchText;
+                this.currentPage = 1;
+                this.collection.url = this.constructUrl();
+                $searchIcon = $(document.getElementById('onboarding-search-indicator'));
+                $searchIcon.addClass('hidden');
+                $spinner = $(document.getElementById('onboarding-loading-indicator'));
+                $spinner.removeClass('hidden');
+                this.hydrate();
+                event.stopPropagation();
+                event.preventDefault();
+            }
+        },
+        clearSearch: function(event) {
+            this.inSearchMode = false;
+            this.searchText = '';
+            this.currentPage = 1;
+            this.collection.url = this.constructUrl();
+            this.hydrate();
+            event.stopPropagation();
+            event.preventDefault();
+        },
+        filterItems: function(event) {
+            var $checkboxes = $('.status-checkboxes li input').get();
+            var filters = [];
+            $checkboxes.forEach(function(checkbox) {
+                if (checkbox.checked) {
+                    filters.push(checkbox.value);
+                }
+            });
+            this.filters = filters;
+            // return to the first page and rerender the view
+            this.currentPage = 1;
+            this.collection.url = this.constructUrl();
+            this.hydrate();
+            event.stopPropagation();
+            event.preventDefault();
+        },
+        clearFilters: function(event) {
+            this.filters = [];
+            this.currentPage = 1;
+            this.collection.url = this.constructUrl();
+            this.hydrate();
+            event.stopPropagation();
+            event.preventDefault();
+        },
+        constructUrl: function(page) {
+            var url;
+            page = typeof page !== 'undefined' ? page : null; // eslint-disable-line no-param-reassign
+            // if the page has changed, update the current page
+            if (page) {
+                this.currentPage = page;
+            }
+            url = this.initialUrl + this.courseId + '?page=' + this.currentPage;
+            if (this.searchText) {
+                url = url + '&text_search=' + this.searchText;
+            }
+            if (this.filters.length > 0) {
+                url += '&statuses=';
+                // creates a string of onboarding statuses separated by ','
+                this.filters.forEach(function(filter, i) {
+                    if (i > 0) {
+                        url += ',';
+                    }
+                    url += filter;
+                });
+            }
+            return url;
+        },
+        getPaginatedItems: function(event) {
+            var $target = $(event.currentTarget);
+            var page = Number($target.data('page-number'));
+            this.collection.url = this.constructUrl(page);
+            this.hydrate();
+            event.stopPropagation();
+            event.preventDefault();
+        },
+        loadTemplateData: function() {
+            var self = this;
+            $.ajax({url: self.templateUrl, dataType: 'html'})
+                .done(function(templateData) {
+                    self.template = _.template(templateData);
+                    self.hydrate();
+                });
+        },
+        hydrate: function() {
+            /* This function will load the bound collection */
+
+            /* add and remove a class when we do the initial loading */
+            /* we might - at some point - add a visual element to the */
+            /* loading, like a spinner */
+            var self = this;
+            self.collection.fetch({
+                success: function() {
+                    var $searchIcon, $spinner;
+                    self.render();
+                    $spinner = $(document.getElementById('onboarding-loading-indicator'));
+                    $spinner.addClass('hidden');
+                    $searchIcon = $(document.getElementById('onboarding-search-indicator'));
+                    $searchIcon.removeClass('hidden');
+                },
+                error: function(unused, response) {
+                    var data, $searchIcon, $spinner, $errorResponse, $onboardingPanel;
+
+                    // in the case that there is no onboarding data, we
+                    // still want the view to render
+                    self.render();
+
+                    try {
+                        data = $.parseJSON(response.responseText);
+                    } catch (error) {
+                        data = {
+                            detail: 'An unexpected error occured. Please try again later.'
+                        };
+                    }
+
+                    if (data.detail) {
+                        $errorResponse = $('#error-response');
+                        $errorResponse.html(data.detail);
+                        $onboardingPanel = $('.onboarding-status-content');
+                        $onboardingPanel.hide();
+                    }
+
+                    $spinner = $(document.getElementById('onboarding-loading-indicator'));
+                    $spinner.addClass('hidden');
+                    $searchIcon = $(document.getElementById('onboarding-search-indicator'));
+                    $searchIcon.removeClass('hidden');
+                }
+            });
+        },
+        collectionChanged: function() {
+            this.hydrate();
+        },
+        render: function() {
+            var data, dataJson, html, startPage, endPage, statuses;
+
+            if (this.template !== null) {
+                data = {
+                    previousPage: null,
+                    nextPage: null,
+                    currentPage: 1,
+                    onboardingItems: [],
+                    onboardingStatuses: onboardingStatuses,
+                    inSearchMode: this.inSearchMode,
+                    searchText: this.searchText,
+                    filters: this.filters,
+                    constructUrl: this.constructUrl,
+                    startPage: 1,
+                    endPage: 1
+                };
+
+                dataJson = this.collection.toJSON()[0];
+                if (dataJson) {
+                    // calculate which pages ranges to display
+                    // show no more than 5 pages at the same time
+                    if (this.currentPage > 3) {
+                        startPage = this.currentPage - 2;
+                    } else {
+                        startPage = 1;
+                    }
+
+                    endPage = startPage + 4;
+
+                    if (endPage > dataJson.num_pages) {
+                        endPage = dataJson.num_pages;
+                    }
+
+                    statuses = dataJson.use_onboarding_profile_api ? onboardingProfileAPIStatuses : onboardingStatuses;
+                    data = {
+                        previousPage: dataJson.previous,
+                        nextPage: dataJson.next,
+                        currentPage: this.currentPage,
+                        onboardingItems: dataJson.results,
+                        onboardingStatuses: statuses,
+                        inSearchMode: this.inSearchMode,
+                        searchText: this.searchText,
+                        filters: this.filters,
+                        constructUrl: this.constructUrl,
+                        startPage: startPage,
+                        endPage: endPage
+                    };
+                }
+
+                _.extend(data, viewHelper);
+                html = this.template(data);
+                this.$el.html(html);
+            }
+        }
+    });
+    this.edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView =
+      edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView;
 }).call(this, Backbone, $, _, gettext);

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
@@ -1,265 +1,267 @@
 edx = edx || {};
 
-((Backbone, $, _, gettext) => {
-  'use strict';
+(function(Backbone, $, _, gettext) {
+    'use strict';
 
-  edx.courseware = edx.courseware || {};
-  edx.courseware.proctored_exam = edx.courseware.proctored_exam || {};
+    edx.courseware = edx.courseware || {};
+    edx.courseware.proctored_exam = edx.courseware.proctored_exam || {};
 
-  edx.courseware.proctored_exam.ProctoredExamView = Backbone.View.extend({
-    initialize(options) {
-      _.bindAll(this, 'detectScroll');
-      this.$el = options.el;
-      this.timerBarTopPosition = this.$el.position().top;
-      this.initialCourseNavBarMarginTop = this.timerBarTopPosition - 3;
-      this.model = options.model;
-      this.templateId = options.proctored_template;
-      this.template = null;
-      this.timerId = null;
-      this.timerTick = 0;
-      this.secondsLeft = 0;
-      /* give an extra 5 seconds where the timer holds at 00:00 before page refreshes */
-      this.grace_period_secs = 5;
-      this.poll_interval = 60;
-      this.first_time_rendering = true;
+    edx.courseware.proctored_exam.ProctoredExamView = Backbone.View.extend({
+        initialize: function(options) {
+            var templateHtml, controlsTemplateHtml;
+            _.bindAll(this, 'detectScroll');
+            this.$el = options.el;
+            this.timerBarTopPosition = this.$el.position().top;
+            this.initialCourseNavBarMarginTop = this.timerBarTopPosition - 3;
+            this.model = options.model;
+            this.templateId = options.proctored_template;
+            this.template = null;
+            this.timerId = null;
+            this.timerTick = 0;
+            this.secondsLeft = 0;
+            /* give an extra 5 seconds where the timer holds at 00:00 before page refreshes */
+            this.grace_period_secs = 5;
+            this.poll_interval = 60;
+            this.first_time_rendering = true;
 
-      // we need to keep a copy here because the model will
-      // get destroyed before onbeforeunload is called
-      this.taking_as_proctored = false;
+            // we need to keep a copy here because the model will
+            // get destroyed before onbeforeunload is called
+            this.taking_as_proctored = false;
 
-      const templateHtml = $(this.templateId).text();
-      if (templateHtml !== null) {
-        /* don't assume this backbone view is running on a page with the underscore templates */
-        this.template = _.template(templateHtml);
-      }
-
-      const controlsTemplateHtml = $(this.examControlsTemplateId).text();
-      if (controlsTemplateHtml !== null) {
-        /* don't assume this backbone view is running on a page with the underscore templates */
-        this.controls_template = _.template(controlsTemplateHtml);
-      }
-
-      /* re-render if the model changes */
-      this.listenTo(this.model, 'change', this.modelChanged);
-
-      $(window).unbind('beforeunload', this.unloadMessage);
-
-      /* make the async call to the backend REST API */
-      /* after it loads, the listenTo event will file and */
-      /* will call into the rendering */
-      this.model.fetch();
-    },
-    events: {
-      'click #toggle_timer': 'toggleTimerVisibility',
-      'click .js-toggle-show-more': 'toggleShowText',
-    },
-    detectScroll(event) {
-      let $courseNavBar = $('.wrapper-course-material');
-      if (!$courseNavBar.length) {
-        $courseNavBar = $('.course-tabs');
-      }
-      const examStatusBarHeight = this.$el.height();
-      if ($(event.currentTarget).scrollTop() > this.timerBarTopPosition) {
-        $('.proctored_exam_status').addClass('is-fixed');
-        $courseNavBar.css('margin-top', `${examStatusBarHeight}px`);
-      } else {
-        $('.proctored_exam_status').removeClass('is-fixed');
-        $courseNavBar.css('margin-top', '0');
-      }
-    },
-    modelChanged() {
-      // if we are a proctored exam, then we need to alert user that he/she
-      // should not be navigating around the courseware
-      const takingAsProctored = this.model.get('taking_as_proctored');
-      const timeLeft = this.model.get('time_remaining_seconds') > 0;
-      const status = this.model.get('attempt_status');
-      const inCourseware = document.location.href.indexOf(
-        `/courses/${this.model.get('course_id')}/courseware/`,
-      ) > -1;
-      this.secondsLeft = this.model.get('time_remaining_seconds');
-
-      if (takingAsProctored && timeLeft && inCourseware && status !== 'started') {
-        $(window).bind('beforeunload', this.unloadMessage);
-      } else {
-        // remove callback on unload event
-        $(window).unbind('beforeunload', this.unloadMessage);
-      }
-      const desktopApplicationJsUrl = this.model.get('desktop_application_js_url');
-      if (desktopApplicationJsUrl && !edx.courseware.proctored_exam.configuredWorkerURL) {
-        edx.courseware.proctored_exam.configuredWorkerURL = desktopApplicationJsUrl;
-      }
-
-      this.render();
-    },
-    render() {
-      let html; let
-        self;
-      if (this.template !== null) {
-        if (
-          this.model.get('in_timed_exam')
-                    && this.model.get('time_remaining_seconds') > 0
-                    && this.model.get('attempt_status') !== 'error'
-        ) {
-          // add callback on scroll event
-          $(window).bind('scroll', this.detectScroll);
-
-          html = this.template(this.model.toJSON());
-          this.$el.html(html);
-          this.$el.show();
-          // only render the accesibility string the first time we render after
-          // page load (then we will update on time left warnings)
-          if (this.first_time_rendering) {
-            this.accessibility_time_string = this.model.get('accessibility_time_string');
-            this.$el.find('.timer-announce').html(this.accessibility_time_string);
-            if (!(window && window.matchMedia && window.matchMedia('(min-width: 992px)').matches)) {
-              this.toggleShowText();
+            templateHtml = $(this.templateId).text();
+            if (templateHtml !== null) {
+                /* don't assume this backbone view is running on a page with the underscore templates */
+                this.template = _.template(templateHtml);
             }
-            this.first_time_rendering = false;
-          }
-          this.updateRemainingTime();
-          this.timerId = setInterval(this.updateRemainingTime.bind(this), 1000, this);
 
-          // Bind a click handler to the exam controls
-          self = this;
-          $('.exam-button-turn-in-exam').click(() => {
-            $(window).unbind('beforeunload', self.unloadMessage);
-
-            $.ajax({
-              url: `/api/edx_proctoring/v1/proctored_exam/attempt/${self.model.get('attempt_id')}`,
-              type: 'PUT',
-              data: {
-                action: 'stop',
-              },
-              success() {
-                // change the location of the page to the active exam page
-                // which will reflect the new state of the attempt
-                window.location.href = self.model.get('exam_url_path');
-              },
-            });
-          });
-        } else {
-          // remove callback on scroll event
-          $(window).unbind('scroll', this.detectScroll);
-        }
-      }
-      return this;
-    },
-    reloadPage() {
-      window.location.reload();
-    },
-    unloadMessage() {
-      return gettext('Are you sure you want to leave this page? \n'
-                + 'To pass your proctored exam you must also pass the online proctoring session review.');
-    },
-    updateRemainingTime() {
-      let url; let queryString;
-      const self = this;
-      const pingInterval = self.model.get('ping_interval');
-      self.timerTick += 1;
-      self.secondsLeft -= 1;
-
-      // AED 2020-02-21:
-      // If the learner is in a state where they've finished the exam
-      // and the attempt can be submitted (i.e. they are "ready_to_submit"),
-      // don't ping the proctoring app (which action could move
-      // the attempt into an error state).
-      if (
-        self.timerTick % pingInterval === pingInterval / 2
-                && edx.courseware.proctored_exam.configuredWorkerURL
-                && this.model.get('attempt_status') !== 'ready_to_submit'
-      ) {
-        edx.courseware.proctored_exam.pingApplication(pingInterval)
-          .catch((error) => {
-            self.endExamForFailureState(error);
-          });
-      }
-      if (self.timerTick % self.poll_interval === 0) {
-        url = `${self.model.url}/${self.model.get('attempt_id')}`;
-        queryString = `?sourceid=in_exam&proctored=${self.model.get('taking_as_proctored')}`;
-        $.ajax(url + queryString)
-          .success((data) => {
-            if (data.status === 'error') {
-              // The proctoring session is in error state
-              // refresh the page to bring up the new Proctoring state from the backend.
-              clearInterval(self.timerId); // stop the timer once the time finishes.
-              $(window).unbind('beforeunload', self.unloadMessage);
-              self.reloadPage();
-            } else {
-              self.secondsLeft = data.time_remaining_seconds;
-              self.accessibility_time_string = data.accessibility_time_string;
+            controlsTemplateHtml = $(this.examControlsTemplateId).text();
+            if (controlsTemplateHtml !== null) {
+                /* don't assume this backbone view is running on a page with the underscore templates */
+                this.controls_template = _.template(controlsTemplateHtml);
             }
-          })
-          .error((error) => {
-            // if unauthorized refresh the page to kick user out of exam
-            if (error.status === 403) {
-              clearInterval(self.timerId);
-              $(window).unbind('beforeunload', self.unloadMessage);
-              self.reloadPage();
-            }
-          });
-      }
-      self.$el.find('div.exam-timer').attr('class');
-      const newState = self.model.getRemainingTimeState(self.secondsLeft);
 
-      if (newState !== null && !self.$el.find('div.exam-timer').hasClass(newState)) {
-        self.$el.find('div.exam-timer').removeClass('warning critical');
-        self.$el.find('div.exam-timer').addClass(`low-time ${newState}`);
-        // refresh accessibility string
-        self.$el.find('.timer-announce').html(self.accessibility_time_string);
-      }
+            /* re-render if the model changes */
+            this.listenTo(this.model, 'change', this.modelChanged);
 
-      self.$el.find('h3#time_remaining_id b').html(self.model.getFormattedRemainingTime(self.secondsLeft));
-      if (self.secondsLeft <= -self.grace_period_secs) {
-        clearInterval(self.timerId); // stop the timer once the time finishes.
-        $(window).unbind('beforeunload', this.unloadMessage);
-        // refresh the page when the timer expired
-        edx.courseware.proctored_exam.endExam(self.model.get('exam_started_poll_url')).then(self.reloadPage);
-      }
-    },
-    endExamForFailureState(error) {
-      const self = this;
-      return $.ajax({
-        data: {
-          action: 'error',
-          detail: String(error),
+            $(window).unbind('beforeunload', this.unloadMessage);
+
+            /* make the async call to the backend REST API */
+            /* after it loads, the listenTo event will file and */
+            /* will call into the rendering */
+            this.model.fetch();
         },
-        url: `${this.model.url}/${this.model.get('attempt_id')}`,
-        type: 'PUT',
-      }).done((result) => {
-        if (result.exam_attempt_id) {
-          self.reloadPage();
+        events: {
+            'click #toggle_timer': 'toggleTimerVisibility',
+            'click .js-toggle-show-more': 'toggleShowText'
+        },
+        detectScroll: function(event) {
+            var examStatusBarHeight;
+            var $courseNavBar = $('.wrapper-course-material');
+            if (!$courseNavBar.length) {
+                $courseNavBar = $('.course-tabs');
+            }
+            examStatusBarHeight = this.$el.height();
+            if ($(event.currentTarget).scrollTop() > this.timerBarTopPosition) {
+                $('.proctored_exam_status').addClass('is-fixed');
+                $courseNavBar.css('margin-top', examStatusBarHeight + 'px');
+            } else {
+                $('.proctored_exam_status').removeClass('is-fixed');
+                $courseNavBar.css('margin-top', '0');
+            }
+        },
+        modelChanged: function() {
+            var desktopApplicationJsUrl;
+            // if we are a proctored exam, then we need to alert user that he/she
+            // should not be navigating around the courseware
+            var takingAsProctored = this.model.get('taking_as_proctored');
+            var timeLeft = this.model.get('time_remaining_seconds') > 0;
+            var status = this.model.get('attempt_status');
+            var inCourseware = document.location.href.indexOf(
+                '/courses/' + this.model.get('course_id') + '/courseware/'
+            ) > -1;
+            this.secondsLeft = this.model.get('time_remaining_seconds');
+
+            if (takingAsProctored && timeLeft && inCourseware && status !== 'started') {
+                $(window).bind('beforeunload', this.unloadMessage);
+            } else {
+                // remove callback on unload event
+                $(window).unbind('beforeunload', this.unloadMessage);
+            }
+            desktopApplicationJsUrl = this.model.get('desktop_application_js_url');
+            if (desktopApplicationJsUrl && !edx.courseware.proctored_exam.configuredWorkerURL) {
+                edx.courseware.proctored_exam.configuredWorkerURL = desktopApplicationJsUrl;
+            }
+
+            this.render();
+        },
+        render: function() {
+            var html, self;
+            if (this.template !== null) {
+                if (
+                    this.model.get('in_timed_exam') &&
+                    this.model.get('time_remaining_seconds') > 0 &&
+                    this.model.get('attempt_status') !== 'error'
+                ) {
+                    // add callback on scroll event
+                    $(window).bind('scroll', this.detectScroll);
+
+                    html = this.template(this.model.toJSON());
+                    this.$el.html(html);
+                    this.$el.show();
+                    // only render the accesibility string the first time we render after
+                    // page load (then we will update on time left warnings)
+                    if (this.first_time_rendering) {
+                        this.accessibility_time_string = this.model.get('accessibility_time_string');
+                        this.$el.find('.timer-announce').html(this.accessibility_time_string);
+                        if (!(window && window.matchMedia && window.matchMedia('(min-width: 992px)').matches)) {
+                            this.toggleShowText();
+                        }
+                        this.first_time_rendering = false;
+                    }
+                    this.updateRemainingTime();
+                    this.timerId = setInterval(this.updateRemainingTime.bind(this), 1000, this);
+
+                    // Bind a click handler to the exam controls
+                    self = this;
+                    $('.exam-button-turn-in-exam').click(function() {
+                        $(window).unbind('beforeunload', self.unloadMessage);
+
+                        $.ajax({
+                            url: '/api/edx_proctoring/v1/proctored_exam/attempt/' + self.model.get('attempt_id'),
+                            type: 'PUT',
+                            data: {
+                                action: 'stop'
+                            },
+                            success: function() {
+                                // change the location of the page to the active exam page
+                                // which will reflect the new state of the attempt
+                                location.href = self.model.get('exam_url_path');
+                            }
+                        });
+                    });
+                } else {
+                    // remove callback on scroll event
+                    $(window).unbind('scroll', this.detectScroll);
+                }
+            }
+            return this;
+        },
+        reloadPage: function() {
+            location.reload();
+        },
+        unloadMessage: function() {
+            return gettext('Are you sure you want to leave this page? \n' +
+                'To pass your proctored exam you must also pass the online proctoring session review.');
+        },
+        updateRemainingTime: function() {
+            var url, queryString, newState;
+            var self = this;
+            var pingInterval = self.model.get('ping_interval');
+            self.timerTick += 1;
+            self.secondsLeft -= 1;
+
+            // AED 2020-02-21:
+            // If the learner is in a state where they've finished the exam
+            // and the attempt can be submitted (i.e. they are "ready_to_submit"),
+            // don't ping the proctoring app (which action could move
+            // the attempt into an error state).
+            if (
+                self.timerTick % pingInterval === pingInterval / 2 &&
+                edx.courseware.proctored_exam.configuredWorkerURL &&
+                this.model.get('attempt_status') !== 'ready_to_submit'
+            ) {
+                edx.courseware.proctored_exam.pingApplication(pingInterval)
+                    .catch(function(error) {
+                        self.endExamForFailureState(error);
+                    });
+            }
+            if (self.timerTick % self.poll_interval === 0) {
+                url = self.model.url + '/' + self.model.get('attempt_id');
+                queryString = '?sourceid=in_exam&proctored=' + self.model.get('taking_as_proctored');
+                $.ajax(url + queryString)
+                    .success(function(data) {
+                        if (data.status === 'error') {
+                            // The proctoring session is in error state
+                            // refresh the page to bring up the new Proctoring state from the backend.
+                            clearInterval(self.timerId); // stop the timer once the time finishes.
+                            $(window).unbind('beforeunload', self.unloadMessage);
+                            self.reloadPage();
+                        } else {
+                            self.secondsLeft = data.time_remaining_seconds;
+                            self.accessibility_time_string = data.accessibility_time_string;
+                        }
+                    })
+                    .error(function(error) {
+                        // if unauthorized refresh the page to kick user out of exam
+                        if (error.status === 403) {
+                            clearInterval(self.timerId);
+                            $(window).unbind('beforeunload', self.unloadMessage);
+                            self.reloadPage();
+                        }
+                    });
+            }
+            self.$el.find('div.exam-timer').attr('class');
+            newState = self.model.getRemainingTimeState(self.secondsLeft);
+
+            if (newState !== null && !self.$el.find('div.exam-timer').hasClass(newState)) {
+                self.$el.find('div.exam-timer').removeClass('warning critical');
+                self.$el.find('div.exam-timer').addClass('low-time ' + newState);
+                // refresh accessibility string
+                self.$el.find('.timer-announce').html(self.accessibility_time_string);
+            }
+
+            self.$el.find('h3#time_remaining_id b').html(self.model.getFormattedRemainingTime(self.secondsLeft));
+            if (self.secondsLeft <= -self.grace_period_secs) {
+                clearInterval(self.timerId); // stop the timer once the time finishes.
+                $(window).unbind('beforeunload', this.unloadMessage);
+                // refresh the page when the timer expired
+                edx.courseware.proctored_exam.endExam(self.model.get('exam_started_poll_url')).then(self.reloadPage);
+            }
+        },
+        endExamForFailureState: function(error) {
+            var self = this;
+            return $.ajax({
+                data: {
+                    action: 'error',
+                    detail: String(error)
+                },
+                url: this.model.url + '/' + this.model.get('attempt_id'),
+                type: 'PUT'
+            }).done(function(result) {
+                if (result.exam_attempt_id) {
+                    self.reloadPage();
+                }
+            });
+        },
+        toggleTimerVisibility: function(event) {
+            var $button = $(event.currentTarget);
+            var icon = $button.find('i');
+            var timer = this.$el.find('h3#time_remaining_id b');
+            if (timer.hasClass('timer-hidden')) {
+                timer.removeClass('timer-hidden');
+                $button.attr('aria-pressed', 'false');
+                icon.removeClass('fa-eye').addClass('fa-eye-slash');
+            } else {
+                timer.addClass('timer-hidden');
+                $button.attr('aria-pressed', 'true');
+                icon.removeClass('fa-eye-slash').addClass('fa-eye');
+            }
+            event.stopPropagation();
+            event.preventDefault();
+        },
+        toggleShowText: function() {
+            var $examText = this.$el.find('.js-exam-text');
+            var $toggle = this.$el.find('.js-toggle-show-more');
+            var $additionalText = this.$el.find('.js-exam-additional-text');
+            var currentlyShowingLongText = $examText.data('showLong');
+            $additionalText
+                // uses both a v1 and a bootstrap utility class because
+                // this banner appears across both types of pages
+                .toggleClass('hidden d-none', currentlyShowingLongText)
+                .attr('aria-hidden', currentlyShowingLongText);
+            $toggle.html(currentlyShowingLongText ? $toggle.data('showMoreText') : $toggle.data('showLessText'));
+            $examText.data('showLong', !currentlyShowingLongText);
         }
-      });
-    },
-    toggleTimerVisibility(event) {
-      const $button = $(event.currentTarget);
-      const icon = $button.find('i');
-      const timer = this.$el.find('h3#time_remaining_id b');
-      if (timer.hasClass('timer-hidden')) {
-        timer.removeClass('timer-hidden');
-        $button.attr('aria-pressed', 'false');
-        icon.removeClass('fa-eye').addClass('fa-eye-slash');
-      } else {
-        timer.addClass('timer-hidden');
-        $button.attr('aria-pressed', 'true');
-        icon.removeClass('fa-eye-slash').addClass('fa-eye');
-      }
-      event.stopPropagation();
-      event.preventDefault();
-    },
-    toggleShowText() {
-      const $examText = this.$el.find('.js-exam-text');
-      const $toggle = this.$el.find('.js-toggle-show-more');
-      const $additionalText = this.$el.find('.js-exam-additional-text');
-      const currentlyShowingLongText = $examText.data('showLong');
-      $additionalText
-      // uses both a v1 and a bootstrap utility class because
-      // this banner appears across both types of pages
-        .toggleClass('hidden d-none', currentlyShowingLongText)
-        .attr('aria-hidden', currentlyShowingLongText);
-      $toggle.html(currentlyShowingLongText ? $toggle.data('showMoreText') : $toggle.data('showLessText'));
-      $examText.data('showLong', !currentlyShowingLongText);
-    },
-  });
-  this.edx.courseware.proctored_exam.ProctoredExamView = edx.courseware.proctored_exam.ProctoredExamView;
+    });
+    this.edx.courseware.proctored_exam.ProctoredExamView = edx.courseware.proctored_exam.ProctoredExamView;
 }).call(this, Backbone, $, _, gettext);

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_add_bulk_allowance_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_add_bulk_allowance_spec.js
@@ -1,349 +1,336 @@
-describe('ProctoredExamAAllowanceView', () => {
-  'use strict';
+describe('ProctoredExamAAllowanceView', function() {
+    'use strict';
 
-  let html = '';
-  let allowancesHtml = '';
-  const errorAddingAllowance = {
-    detail: 'Cannot find user',
-  };
-  const expectedProctoredAllowanceJson = [
-    {
-      created: '2015-08-10T09:15:45Z',
-      id: 1,
-      modified: '2015-08-10T09:15:45Z',
-      key: 'additional_time_granted',
-      value: '1',
-      proctored_exam: {
-        content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
-        course_id: 'edX/DemoX/Demo_Course',
-        exam_name: 'Test Exam',
-        external_id: null,
-        id: 6,
-        is_active: true,
-        is_practice_exam: false,
-        is_proctored: true,
-        time_limit_mins: 1,
-      },
-      user: {
-        username: 'testuser1',
-        email: 'testuser1@test.com',
-      },
-    },
-  ];
-
-  const expectedTimedAllowanceJson = [
-    {
-      created: '2015-08-10T09:15:45Z',
-      id: 1,
-      modified: '2015-08-10T09:15:45Z',
-      key: 'additional_time_granted',
-      value: '1',
-      proctored_exam: {
-        content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
-        course_id: 'edX/DemoX/Demo_Course',
-        exam_name: 'Test Exam',
-        external_id: null,
-        id: 6,
-        is_active: true,
-        is_practice_exam: false,
-        is_proctored: false,
-        time_limit_mins: 1,
-      },
-      user: {
-        username: 'testuser1',
-        email: 'testuser1@test.com',
-      },
-    },
-  ];
-
-  const proctoredExamJson = [
-    {
-      exam_name: 'Midterm Exam',
-      is_proctored: true,
-      is_practice: false,
-      id: 5,
-    },
-    {
-      exam_name: 'Final Exam',
-      is_proctored: false,
-      is_practice: false,
-      id: 6,
-    },
-    {
-      exam_name: 'Test Exam',
-      is_proctored: true,
-      is_practice: true,
-      id: 7,
-    },
-  ];
-
-  const allowanceTypes = [
-    ['additional_time_granted', gettext('Additional Time (minutes)')],
-    ['review_policy_exception', gettext('Review Policy Exception')],
-    ['time_multiplier', gettext('Time Multiplier')],
-  ];
-
-  beforeEach(() => {
-    // We have converted the edx_proctoring/static/proctoring/templates/add-new-allowance.underscore template
-    // from http://www.howtocreate.co.uk/tutorials/jsexamples/syntax/prepareInline.html
-
-    // eslint-disable-next-line max-len
-    html = '<div class=\'modal-header\'><%- gettext("Add a New Allowance") %></div>\n<form>\n    <h3 class=\'error-response\'><h3>\n    <table class=\'compact\'>\n        <tr>\n            <td>\n                <label><%- gettext("Add Usernames or Emails seperated by commas") %></label>\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <input type="text" id="user_info" />\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <label><%- gettext("Select Exam Type") %></label>\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <select id="exam_type">\n                    <option value="proctored_exam">\n                        <%- gettext("Proctored Exam") %>\n                    </option>\n                    <option value="timed_exam">\n                        <%- gettext("Timed Exam") %>\n                    </option>\n                </select>\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <label><%- gettext("Select Exams") %></label>\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <select multiple id=\'proctored_exam\' class="exam_dropdown">\n                    <option hidden selected value=default> <%- gettext("Choose Exams Below") %> </option>\n                    <% _.each(proctored_exams, function(proctored_exam){ %>\n                    <option value="<%= proctored_exam.id  %>">\n                    <%- interpolate(gettext(\' %(exam_display_name)s \'), { exam_display_name: proctored_exam.exam_name }, true) %>\n                    </option>\n                    <% }); %>\n                </select>\n                <select multiple id=\'timed_exam\' class="exam_dropdown" style="display:none;">\n                    <option hidden selected value=default> <%- gettext("Choose Exams Below") %> </option>\n                    <% _.each(timed_exams, function(timed_exam){ %>\n                    <option value="<%= timed_exam.id  %>">\n                    <%- interpolate(gettext(\' %(exam_display_name)s \'), { exam_display_name: timed_exam.exam_name }, true) %>\n                    </option>\n                    <% }); %>\n                </select>\n            </td>\n        </tr>\n        <tr>\n            <td colspan="3">\n                <div id="selected_exams" ></div>\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <label><%- gettext("Allowance Type") %></label>\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <select id="allowance_type">\n                    <% _.each(allowance_types, function(allowance_type){ %>\n                    <option value="<%= allowance_type[0] %>">\n                        <%= allowance_type[1] %>\n                    </option>\n                    <% }); %>\n                </select>\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <label id=\'allowance_value_label\'><%- gettext("Add Time(Minutes)") %></label>\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <input type="text" id="allowance_value" />\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <input id=\'addNewAllowance\' type=\'submit\' value=\'Create Allowance\' />\n            </td>\n        </tr>\n    </table>\n</form>\n';
-
-    allowancesHtml = '<span class="tip">'
-            + '<%- gettext("Allowances") %>'
-            + '<span> <a id="add-allowance" href="#"  class="add blue-button">+'
-            + '<%- gettext("Add Allowance") %>'
-            + '</a> </span> </span>'
-            + '<% var is_allowances = proctored_exam_allowances.length !== 0 %>'
-            + '<% if (is_allowances) { %>'
-            + '<div class="wrapper-content wrapper"> <section class="content"> <table class="allowance-table">'
-            + '<thead><tr class="allowance-headings">'
-            + '<th class="exam-name">Exam Name</th>'
-            + '<th class="username">Username</th>'
-            + '<th class="email">Email</th>'
-            + '<th class="allowance-name">Allowance Type</th>'
-            + '<th class="allowance-value">Allowance Value</th>'
-            + '<th class="c_action">Actions </th>'
-            + '</tr></thead>'
-            + '<tbody>'
-            + '<% _.each(proctored_exam_allowances, function(proctored_exam_allowance){ %>'
-            + '<tr class="allowance-items">'
-            + '<td>'
-            + '<%- interpolate(gettext(" %(exam_display_name)s "),'
-            + '{ exam_display_name: proctored_exam_allowance.proctored_exam.exam_name }, true) %>'
-            + '</td>'
-            + '<% if (proctored_exam_allowance.user){ %>'
-            + '<td>'
-            + '<%- interpolate(gettext(" %(username)s "),'
-            + '{ username: proctored_exam_allowance.user.username }, true) %>'
-            + '</td>'
-            + '<td>'
-            + '<%- interpolate(gettext(" %(email)s "),'
-            + '{ email: proctored_exam_allowance.user.email }, true) %>'
-            + '</td>'
-            + '<% }else{ %>'
-            + '<td>N/A</td><td>N/A</td>'
-            + '<% } %>'
-            + '<td>'
-            + '<%- interpolate(gettext(" %(allowance_name)s "),'
-            + '{ allowance_name: proctored_exam_allowance.key_display_name }, true) %>'
-            + '</td>'
-            + '<td>'
-            + '<%= proctored_exam_allowance.value %>'
-            + '</td>'
-            + '<td>'
-            + '<a data-exam-id="<%= proctored_exam_allowance.proctored_exam.id %>" '
-            + 'data-key-name="<%= proctored_exam_allowance.key %>" '
-            + 'data-user-id="<%= proctored_exam_allowance.user.id %>"class="remove_allowance" href="#">[x]</a>'
-            + '</td></tr>'
-            + '<% }); %>'
-            + '</tbody></table></section></div>'
-            + '<% } %>';
-    this.server = sinon.fakeServer.create();
-    this.server.autoRespond = true;
-
-    setFixtures('<div class="special-allowance-container" data-course-id="test_course_id"');
-    // load the underscore template response before calling the proctored exam allowance view.
-    this.server.respondWith(
-      'GET',
-      '/static/proctoring/templates/add-new-bulk-allowance.underscore',
-      [
-        200,
-        { 'Content-Type': 'text/html' },
-        html,
-      ],
-    );
-    this.server.respondWith(
-      'GET',
-      '/static/proctoring/templates/course_allowances.underscore',
-      [
-        200,
-        { 'Content-Type': 'text/html' },
-        allowancesHtml,
-      ],
-    );
-  });
-
-  afterEach(() => {
-    this.server.restore();
-  });
-  it('should render the proctored exam add allowance view properly', () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/test_course_id/allowance',
-      [
-        200,
+    var html = '';
+    var allowancesHtml = '';
+    var errorAddingAllowance = {
+        detail: 'Cannot find user'
+    };
+    var expectedProctoredAllowanceJson = [
         {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedProctoredAllowanceJson),
-      ],
-    );
+            created: '2015-08-10T09:15:45Z',
+            id: 1,
+            modified: '2015-08-10T09:15:45Z',
+            key: 'additional_time_granted',
+            value: '1',
+            proctored_exam: {
+                content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
+                course_id: 'edX/DemoX/Demo_Course',
+                exam_name: 'Test Exam',
+                external_id: null,
+                id: 6,
+                is_active: true,
+                is_practice_exam: false,
+                is_proctored: true,
+                time_limit_mins: 1
+            },
+            user: {
+                username: 'testuser1',
+                email: 'testuser1@test.com'
+            }
+        }
+    ];
 
-    this.proctored_exam_allowance = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
-    const addAllowanceView = new edx.instructor_dashboard.proctoring.AddBulkAllowanceView({
-      course_id: 'test_course_id',
-      proctored_exams: proctoredExamJson,
-      proctored_exam_allowance_view: this.proctored_exam_allowance,
-      allowance_types: allowanceTypes,
-    });
-    this.server.respond();
-    this.server.respond();
-    this.server.respond();
-
-    expect(addAllowanceView.$el.find('#proctored_exam').html()).toContain('Midterm Exam');
-    expect(addAllowanceView.$el.find('#proctored_exam').html()).toContain('Test Exam');
-    $('#proctored_exam').val('5');
-  });
-
-  it('should render the timed exam add allowance view properly', () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/test_course_id/allowance',
-      [
-        200,
+    var expectedTimedAllowanceJson = [
         {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedTimedAllowanceJson),
-      ],
-    );
+            created: '2015-08-10T09:15:45Z',
+            id: 1,
+            modified: '2015-08-10T09:15:45Z',
+            key: 'additional_time_granted',
+            value: '1',
+            proctored_exam: {
+                content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
+                course_id: 'edX/DemoX/Demo_Course',
+                exam_name: 'Test Exam',
+                external_id: null,
+                id: 6,
+                is_active: true,
+                is_practice_exam: false,
+                is_proctored: false,
+                time_limit_mins: 1
+            },
+            user: {
+                username: 'testuser1',
+                email: 'testuser1@test.com'
+            }
+        }
+    ];
 
-    this.proctored_exam_allowance = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
-    const addAllowanceView = new edx.instructor_dashboard.proctoring.AddBulkAllowanceView({
-      course_id: 'test_course_id',
-      proctored_exams: proctoredExamJson,
-      proctored_exam_allowance_view: this.proctored_exam_allowance,
-      allowance_types: allowanceTypes,
-    });
-    this.server.respond();
-    this.server.respond();
-    this.server.respond();
-
-    expect(addAllowanceView.$el.find('#timed_exam').html()).toContain('Final Exam');
-    $('#timed_exam').val('6');
-  });
-
-  it('should add the proctored exam allowance', () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/test_course_id/allowance',
-      [
-        200,
+    var proctoredExamJson = [
         {
-          'Content-Type': 'application/json',
+            exam_name: 'Midterm Exam',
+            is_proctored: true,
+            is_practice: false,
+            id: 5
         },
-        JSON.stringify([]),
-      ],
-    );
+        {
+            exam_name: 'Final Exam',
+            is_proctored: false,
+            is_practice: false,
+            id: 6
+        },
+        {
+            exam_name: 'Test Exam',
+            is_proctored: true,
+            is_practice: true,
+            id: 7
+        }
+    ];
 
-    this.proctored_exam_allowance = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
-    // eslint-disable-next-line no-new
-    new edx.instructor_dashboard.proctoring.AddBulkAllowanceView({
-      course_id: 'test_course_id',
-      proctored_exams: proctoredExamJson,
-      proctored_exam_allowance_view: this.proctored_exam_allowance,
-      allowance_types: allowanceTypes,
+    var allowanceTypes = [
+        ['additional_time_granted', gettext('Additional Time (minutes)')],
+        ['review_policy_exception', gettext('Review Policy Exception')],
+        ['time_multiplier', gettext('Time Multiplier')]
+    ];
+
+    beforeEach(function() {
+        // We have converted the edx_proctoring/static/proctoring/templates/add-new-allowance.underscore template
+        // from http://www.howtocreate.co.uk/tutorials/jsexamples/syntax/prepareInline.html
+
+        // eslint-disable-next-line max-len
+        html = '<div class=\'modal-header\'><%- gettext("Add a New Allowance") %></div>\n<form>\n    <h3 class=\'error-response\'><h3>\n    <table class=\'compact\'>\n        <tr>\n            <td>\n                <label><%- gettext("Add Usernames or Emails seperated by commas") %></label>\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <input type="text" id="user_info" />\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <label><%- gettext("Select Exam Type") %></label>\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <select id="exam_type">\n                    <option value="proctored_exam">\n                        <%- gettext("Proctored Exam") %>\n                    </option>\n                    <option value="timed_exam">\n                        <%- gettext("Timed Exam") %>\n                    </option>\n                </select>\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <label><%- gettext("Select Exams") %></label>\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <select multiple id=\'proctored_exam\' class="exam_dropdown">\n                    <option hidden selected value=default> <%- gettext("Choose Exams Below") %> </option>\n                    <% _.each(proctored_exams, function(proctored_exam){ %>\n                    <option value="<%= proctored_exam.id  %>">\n                    <%- interpolate(gettext(\' %(exam_display_name)s \'), { exam_display_name: proctored_exam.exam_name }, true) %>\n                    </option>\n                    <% }); %>\n                </select>\n                <select multiple id=\'timed_exam\' class="exam_dropdown" style="display:none;">\n                    <option hidden selected value=default> <%- gettext("Choose Exams Below") %> </option>\n                    <% _.each(timed_exams, function(timed_exam){ %>\n                    <option value="<%= timed_exam.id  %>">\n                    <%- interpolate(gettext(\' %(exam_display_name)s \'), { exam_display_name: timed_exam.exam_name }, true) %>\n                    </option>\n                    <% }); %>\n                </select>\n            </td>\n        </tr>\n        <tr>\n            <td colspan="3">\n                <div id="selected_exams" ></div>\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <label><%- gettext("Allowance Type") %></label>\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <select id="allowance_type">\n                    <% _.each(allowance_types, function(allowance_type){ %>\n                    <option value="<%= allowance_type[0] %>">\n                        <%= allowance_type[1] %>\n                    </option>\n                    <% }); %>\n                </select>\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <label id=\'allowance_value_label\'><%- gettext("Add Time(Minutes)") %></label>\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <input type="text" id="allowance_value" />\n            </td>\n        </tr>\n        <tr>\n            <td>\n                <input id=\'addNewAllowance\' type=\'submit\' value=\'Create Allowance\' />\n            </td>\n        </tr>\n    </table>\n</form>\n';
+
+        allowancesHtml = '<span class="tip">' +
+            '<%- gettext("Allowances") %>' +
+            '<span> <a id="add-allowance" href="#"  class="add blue-button">+' +
+            '<%- gettext("Add Allowance") %>' +
+            '</a> </span> </span>' +
+            '<% var is_allowances = proctored_exam_allowances.length !== 0 %>' +
+            '<% if (is_allowances) { %>' +
+            '<div class="wrapper-content wrapper"> <section class="content"> <table class="allowance-table">' +
+            '<thead><tr class="allowance-headings">' +
+            '<th class="exam-name">Exam Name</th>' +
+            '<th class="username">Username</th>' +
+            '<th class="email">Email</th>' +
+            '<th class="allowance-name">Allowance Type</th>' +
+            '<th class="allowance-value">Allowance Value</th>' +
+            '<th class="c_action">Actions </th>' +
+            '</tr></thead>' +
+            '<tbody>' +
+            '<% _.each(proctored_exam_allowances, function(proctored_exam_allowance){ %>' +
+            '<tr class="allowance-items">' +
+            '<td>' +
+            '<%- interpolate(gettext(" %(exam_display_name)s "),' +
+            '{ exam_display_name: proctored_exam_allowance.proctored_exam.exam_name }, true) %>' +
+            '</td>' +
+            '<% if (proctored_exam_allowance.user){ %>' +
+            '<td>' +
+            '<%- interpolate(gettext(" %(username)s "),' +
+            '{ username: proctored_exam_allowance.user.username }, true) %>' +
+            '</td>' +
+            '<td>' +
+            '<%- interpolate(gettext(" %(email)s "),' +
+            '{ email: proctored_exam_allowance.user.email }, true) %>' +
+            '</td>' +
+            '<% }else{ %>' +
+            '<td>N/A</td><td>N/A</td>' +
+            '<% } %>' +
+            '<td>' +
+            '<%- interpolate(gettext(" %(allowance_name)s "),' +
+            '{ allowance_name: proctored_exam_allowance.key_display_name }, true) %>' +
+            '</td>' +
+            '<td>' +
+            '<%= proctored_exam_allowance.value %>' +
+            '</td>' +
+            '<td>' +
+            '<a data-exam-id="<%= proctored_exam_allowance.proctored_exam.id %>" ' +
+            'data-key-name="<%= proctored_exam_allowance.key %>" ' +
+            'data-user-id="<%= proctored_exam_allowance.user.id %>"class="remove_allowance" href="#">[x]</a>' +
+            '</td></tr>' +
+            '<% }); %>' +
+            '</tbody></table></section></div>' +
+            '<% } %>';
+        this.server = sinon.fakeServer.create();
+        this.server.autoRespond = true;
+
+        setFixtures('<div class="special-allowance-container" data-course-id="test_course_id"');
+        // load the underscore template response before calling the proctored exam allowance view.
+        this.server.respondWith('GET', '/static/proctoring/templates/add-new-bulk-allowance.underscore',
+            [
+                200,
+                {'Content-Type': 'text/html'},
+                html
+            ]
+        );
+        this.server.respondWith('GET', '/static/proctoring/templates/course_allowances.underscore',
+            [
+                200,
+                {'Content-Type': 'text/html'},
+                allowancesHtml
+            ]
+        );
     });
 
-    this.server.respond();
-    this.server.respond();
-    this.server.respond();
+    afterEach(function() {
+        this.server.restore();
+    });
+    it('should render the proctored exam add allowance view properly', function() {
+        var addAllowanceView;
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/test_course_id/allowance',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedProctoredAllowanceJson)
+            ]
+        );
 
-    expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
-      .not.toContain('testuser1');
-    expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
-      .not.toContain('testuser1@test.com');
-    expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
-      .not.toContain('Additional Time (minutes)');
-    expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
-      .not.toContain('Test Exam');
+        this.proctored_exam_allowance = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
+        addAllowanceView = new edx.instructor_dashboard.proctoring.AddBulkAllowanceView({
+            course_id: 'test_course_id',
+            proctored_exams: proctoredExamJson,
+            proctored_exam_allowance_view: this.proctored_exam_allowance,
+            allowance_types: allowanceTypes
+        });
+        this.server.respond();
+        this.server.respond();
+        this.server.respond();
 
-    // add the proctored exam allowance
-    this.server.respondWith(
-      'PUT',
-      '/api/edx_proctoring/v1/proctored_exam/bulk_allowance',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify([]),
-      ],
-    );
-  });
-  it('should send error when adding proctored exam allowance', () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/test_course_id/allowance',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify([]),
-      ],
-    );
-
-    this.proctored_exam_allowance = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
-    const addAllowanceView = new edx.instructor_dashboard.proctoring.AddBulkAllowanceView({
-      course_id: 'test_course_id',
-      proctored_exams: proctoredExamJson,
-      proctored_exam_allowance_view: this.proctored_exam_allowance,
-      allowance_types: allowanceTypes,
+        expect(addAllowanceView.$el.find('#proctored_exam').html()).toContain('Midterm Exam');
+        expect(addAllowanceView.$el.find('#proctored_exam').html()).toContain('Test Exam');
+        $('#proctored_exam').val('5');
     });
 
-    this.server.respond();
-    this.server.respond();
-    this.server.respond();
 
-    expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
-      .not.toContain('testuser1');
-    expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
-      .not.toContain('testuser1@test.com');
-    expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
-      .not.toContain('Additional Time (minutes)');
-    expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
-      .not.toContain('Test Exam');
+    it('should render the timed exam add allowance view properly', function() {
+        var addAllowanceView;
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/test_course_id/allowance',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedTimedAllowanceJson)
+            ]
+        );
 
-    // add the proctored exam allowance
-    this.server.respondWith(
-      'PUT',
-      '/api/edx_proctoring/v1/proctored_exam/bulk_allowance',
-      [
-        400,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(errorAddingAllowance),
-      ],
-    );
+        this.proctored_exam_allowance = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
+        addAllowanceView = new edx.instructor_dashboard.proctoring.AddBulkAllowanceView({
+            course_id: 'test_course_id',
+            proctored_exams: proctoredExamJson,
+            proctored_exam_allowance_view: this.proctored_exam_allowance,
+            allowance_types: allowanceTypes
+        });
+        this.server.respond();
+        this.server.respond();
+        this.server.respond();
 
-    // again fetch the results after the proctored exam allowance addition
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/test_course_id/allowance',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedProctoredAllowanceJson),
-      ],
-    );
+        expect(addAllowanceView.$el.find('#timed_exam').html()).toContain('Final Exam');
+        $('#timed_exam').val('6');
+    });
 
-    // select the form values
-    // empty value returns error
-    $('#proctored_exam').val('Test Exam');
-    $('#allowance_type').val('Additional Time (minutes)');
-    $('#allowance_value').val('');
-    $('#user_info').val('testuser1');
 
-    // trigger the add allowance event.
-    spyOnEvent('form', 'submit');
-    $('form').trigger('submit');
+    it('should add the proctored exam allowance', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/test_course_id/allowance',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify([])
+            ]
+        );
 
-    expect(addAllowanceView.$el.find('.error-message').html()).toContain('Required field');
-  });
+        this.proctored_exam_allowance = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
+        // eslint-disable-next-line no-new
+        new edx.instructor_dashboard.proctoring.AddBulkAllowanceView({
+            course_id: 'test_course_id',
+            proctored_exams: proctoredExamJson,
+            proctored_exam_allowance_view: this.proctored_exam_allowance,
+            allowance_types: allowanceTypes
+        });
+
+        this.server.respond();
+        this.server.respond();
+        this.server.respond();
+
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('testuser1');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('testuser1@test.com');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('Additional Time (minutes)');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('Test Exam');
+
+        // add the proctored exam allowance
+        this.server.respondWith('PUT', '/api/edx_proctoring/v1/proctored_exam/bulk_allowance',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify([])
+            ]
+        );
+    });
+    it('should send error when adding proctored exam allowance', function() {
+        var addAllowanceView;
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/test_course_id/allowance',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify([])
+            ]
+        );
+
+        this.proctored_exam_allowance = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
+        addAllowanceView = new edx.instructor_dashboard.proctoring.AddBulkAllowanceView({
+            course_id: 'test_course_id',
+            proctored_exams: proctoredExamJson,
+            proctored_exam_allowance_view: this.proctored_exam_allowance,
+            allowance_types: allowanceTypes
+        });
+
+        this.server.respond();
+        this.server.respond();
+        this.server.respond();
+
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('testuser1');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('testuser1@test.com');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('Additional Time (minutes)');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('Test Exam');
+
+        // add the proctored exam allowance
+        this.server.respondWith('PUT', '/api/edx_proctoring/v1/proctored_exam/bulk_allowance',
+            [
+                400,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(errorAddingAllowance)
+            ]
+        );
+
+        // again fetch the results after the proctored exam allowance addition
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/test_course_id/allowance',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedProctoredAllowanceJson)
+            ]
+        );
+
+        // select the form values
+        // empty value returns error
+        $('#proctored_exam').val('Test Exam');
+        $('#allowance_type').val('Additional Time (minutes)');
+        $('#allowance_value').val('');
+        $('#user_info').val('testuser1');
+
+        // trigger the add allowance event.
+        spyOnEvent('form', 'submit');
+        $('form').trigger('submit');
+
+        expect(addAllowanceView.$el.find('.error-message').html()).toContain('Required field');
+    });
 });

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_attempt_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_attempt_spec.js
@@ -1,944 +1,927 @@
-describe('ProctoredExamAttemptView', () => {
-  'use strict';
+describe('ProctoredExamAttemptView', function() {
+    'use strict';
 
-  let html = '';
-  const deletedProctoredExamAttemptJson = [{
-    attempt_url: '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/edX/DemoX/Demo_Course',
-    proctored_exam_attempts: [],
-    pagination_info: {
-      current_page: 1,
-      has_next: false,
-      has_previous: false,
-      total_pages: 1,
-    },
-
-  }];
-  function getExpectedProctoredExamAttemptWithAttemptStatusJson(status, isPracticeExam) {
-    // eslint-disable-next-line no-param-reassign
-    isPracticeExam = typeof isPracticeExam !== 'undefined' ? isPracticeExam : false;
-    return (
-      [{
+    var html = '';
+    var deletedProctoredExamAttemptJson = [{
         attempt_url: '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/edX/DemoX/Demo_Course',
+        proctored_exam_attempts: [],
         pagination_info: {
-          current_page: 1,
-          has_next: false,
-          has_previous: false,
-          total_pages: 1,
-        },
-        proctored_exam_attempts: [{
-          allowed_time_limit_mins: 1,
-          attempt_code: '20C32387-372E-48BD-BCAC-A2BE9DC91E09',
-          completed_at: null,
-          created: '2015-08-10T09:15:45Z',
-          external_id: '40eceb15-bcc3-4791-b43f-4e843afb7ae8',
-          id: 43,
-          is_sample_attempt: false,
-          modified: '2015-08-10T09:15:45Z',
-          started_at: '2015-08-10T09:15:45Z',
-          status,
-          is_resumable: false,
-          taking_as_proctored: true,
-          proctored_exam: {
-            content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
-            course_id: 'edX/DemoX/Demo_Course',
-            exam_name: 'Normal Exam',
-            external_id: null,
-            id: 17,
-            is_active: true,
-            is_practice_exam: isPracticeExam,
-            is_proctored: true,
-            time_limit_mins: 1,
-          },
-          user: {
-            id: 1,
-            username: 'testuser1',
-            email: 'testuser1@test.com',
-          },
-          all_attempts: [{
-            allowed_time_limit_mins: 1,
-            attempt_code: '20C32387-372E-48BD-BCAC-A2BE9DC91E09',
-            completed_at: null,
-            created: '2015-08-10T09:15:45Z',
-            external_id: '40eceb15-bcc3-4791-b43f-4e843afb7ae8',
-            id: 43,
-            is_sample_attempt: false,
-            modified: '2015-08-10T09:15:45Z',
-            started_at: '2015-08-10T09:15:45Z',
-            status,
-            taking_as_proctored: true,
-            proctored_exam: {
-              content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
-              course_id: 'edX/DemoX/Demo_Course',
-              exam_name: 'Normal Exam',
-              external_id: null,
-              id: 17,
-              is_active: true,
-              is_practice_exam: isPracticeExam,
-              is_proctored: true,
-              time_limit_mins: 1,
-            },
-            user: {
-              id: 1,
-              username: 'testuser1',
-              email: 'testuser1@test.com',
-            },
-          }],
-        }],
-      }]
-    );
-  }
+            current_page: 1,
+            has_next: false,
+            has_previous: false,
+            total_pages: 1
+        }
 
-  function getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson(
-    status,
-    isPracticeExam,
-    isResumable,
-    readyToResume,
-    resumed,
-  ) {
-    // eslint-disable-next-line no-param-reassign
-    isPracticeExam = typeof isPracticeExam !== 'undefined' ? isPracticeExam : false;
-    // eslint-disable-next-line no-param-reassign
-    isResumable = typeof isResumable !== 'undefined' ? isResumable : false;
-    return (
-      [{
-        attempt_url: '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/edX/DemoX/Demo_Course',
-        pagination_info: {
-          current_page: 1,
-          has_next: false,
-          has_previous: false,
-          total_pages: 1,
-        },
-        proctored_exam_attempts: [{
-          allowed_time_limit_mins: 1,
-          attempt_code: '20C32387-372E-48BD-BCAC-A2BE9DC91E09',
-          completed_at: null,
-          created: '2015-08-10T09:15:45Z',
-          external_id: '40eceb15-bcc3-4791-b43f-4e843afb7ae8',
-          id: 43,
-          is_sample_attempt: false,
-          modified: '2015-08-10T09:15:45Z',
-          started_at: '2015-08-10T09:15:45Z',
-          status,
-          is_resumable: isResumable,
-          ready_to_resume: readyToResume,
-          resumed,
-          taking_as_proctored: true,
-          proctored_exam: {
-            content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
-            course_id: 'edX/DemoX/Demo_Course',
-            exam_name: 'Normal Exam',
-            external_id: null,
-            id: 17,
-            is_active: true,
-            is_practice_exam: isPracticeExam,
-            is_proctored: true,
-            time_limit_mins: 1,
-          },
-          user: {
-            username: 'testuser1',
-            email: 'testuser1@test.com',
-            id: 1,
-          },
-          all_attempts: [
-            {
-              allowed_time_limit_mins: 1,
-              attempt_code: '20C32387-372E-48BD-BCAC-A2BE9DC91E09',
-              completed_at: null,
-              created: '2015-08-10T09:15:45Z',
-              external_id: '40eceb15-bcc3-4791-b43f-4e843afb7ae8',
-              id: 43,
-              is_sample_attempt: false,
-              modified: '2015-08-10T09:15:45Z',
-              started_at: '2015-08-10T09:15:45Z',
-              status,
-              is_resumable: isResumable,
-              ready_to_resume: readyToResume,
-              resumed,
-              taking_as_proctored: true,
-              proctored_exam: {
-                content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
-                course_id: 'edX/DemoX/Demo_Course',
-                exam_name: 'Normal Exam',
-                external_id: null,
-                id: 17,
-                is_active: true,
-                is_practice_exam: isPracticeExam,
-                is_proctored: true,
-                time_limit_mins: 1,
-              },
-              user: {
-                username: 'testuser1',
-                email: 'testuser1@test.com',
-                id: 1,
-              },
-            },
-            {
-              allowed_time_limit_mins: 1,
-              attempt_code: '20C32387-372E-48BD-BCAC-A2BE9DC91E10',
-              completed_at: null,
-              created: '2015-08-10T09:15:45Z',
-              external_id: '40eceb15-bcc3-4791-b43f-4e843afb7ae9',
-              id: 44,
-              is_sample_attempt: false,
-              modified: '2015-08-10T09:15:45Z',
-              started_at: '2015-08-10T09:15:45Z',
-              status: 'resumed',
-              is_resumable: false,
-              ready_to_resume: true,
-              resumed: true,
-              taking_as_proctored: true,
-              proctored_exam: {
-                content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
-                course_id: 'edX/DemoX/Demo_Course',
-                exam_name: 'Normal Exam',
-                external_id: null,
-                id: 17,
-                is_active: true,
-                is_practice_exam: isPracticeExam,
-                is_proctored: true,
-                time_limit_mins: 1,
-              },
-              user: {
-                username: 'testuser1',
-                email: 'testuser1@test.com',
-                id: 1,
-              },
-            },
-          ],
-        }],
-      }]
-    );
-  }
+    }];
+    function getExpectedProctoredExamAttemptWithAttemptStatusJson(status, isPracticeExam) {
+        // eslint-disable-next-line no-param-reassign
+        isPracticeExam = typeof isPracticeExam !== 'undefined' ? isPracticeExam : false;
+        return (
+            [{
+                attempt_url: '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/edX/DemoX/Demo_Course',
+                pagination_info: {
+                    current_page: 1,
+                    has_next: false,
+                    has_previous: false,
+                    total_pages: 1
+                },
+                proctored_exam_attempts: [{
+                    allowed_time_limit_mins: 1,
+                    attempt_code: '20C32387-372E-48BD-BCAC-A2BE9DC91E09',
+                    completed_at: null,
+                    created: '2015-08-10T09:15:45Z',
+                    external_id: '40eceb15-bcc3-4791-b43f-4e843afb7ae8',
+                    id: 43,
+                    is_sample_attempt: false,
+                    modified: '2015-08-10T09:15:45Z',
+                    started_at: '2015-08-10T09:15:45Z',
+                    status: status,
+                    is_resumable: false,
+                    taking_as_proctored: true,
+                    proctored_exam: {
+                        content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
+                        course_id: 'edX/DemoX/Demo_Course',
+                        exam_name: 'Normal Exam',
+                        external_id: null,
+                        id: 17,
+                        is_active: true,
+                        is_practice_exam: isPracticeExam,
+                        is_proctored: true,
+                        time_limit_mins: 1
+                    },
+                    user: {
+                        id: 1,
+                        username: 'testuser1',
+                        email: 'testuser1@test.com'
+                    },
+                    all_attempts: [{
+                        allowed_time_limit_mins: 1,
+                        attempt_code: '20C32387-372E-48BD-BCAC-A2BE9DC91E09',
+                        completed_at: null,
+                        created: '2015-08-10T09:15:45Z',
+                        external_id: '40eceb15-bcc3-4791-b43f-4e843afb7ae8',
+                        id: 43,
+                        is_sample_attempt: false,
+                        modified: '2015-08-10T09:15:45Z',
+                        started_at: '2015-08-10T09:15:45Z',
+                        status: status,
+                        taking_as_proctored: true,
+                        proctored_exam: {
+                            content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
+                            course_id: 'edX/DemoX/Demo_Course',
+                            exam_name: 'Normal Exam',
+                            external_id: null,
+                            id: 17,
+                            is_active: true,
+                            is_practice_exam: isPracticeExam,
+                            is_proctored: true,
+                            time_limit_mins: 1
+                        },
+                        user: {
+                            id: 1,
+                            username: 'testuser1',
+                            email: 'testuser1@test.com'
+                        }
+                    }]
+                }]
+            }]
+        );
+    }
 
-  beforeEach(() => {
-    html = '<div class="wrapper-content wrapper">'
-        + '<% var is_proctored_attempts = proctored_exam_attempts.length !== 0 %>'
-        + '<div class="content exam-attempts-content">'
-        + '<div class="top-header">'
-        + '<div class="search-attempts">'
-        + '<input type="text" id="search_attempt_id" placeholder="e.g johndoe or john.doe@gmail.com"'
-        + '<% if (inSearchMode) { %> value="<%= searchText %>" <%} %> /> '
-        + '<span class="search">'
-        + '<span class="icon fa fa-search" id="attempt-search-indicator" aria-hidden="true"></span>'
-        + '<div aria-live="polite" aria-relevant="all">'
-        + '<div id="attempt-loading-indicator" class="hidden">'
-        + '<span class="icon fa fa-spinner fa-pulse" aria-hidden="true"></span>'
-        + '<span class="sr"><%- gettext("Loading") %></span>'
-        + '</div>'
-        + '</div>'
-        + '</span>'
-        + '<span class="clear-search"><span class="icon fa fa-remove" aria-hidden="true"></span></span>'
-        + '</div>'
-        + '<ul class="pagination">'
-        + '<% if (!pagination_info.has_previous){ %>'
-        + '<li class="disabled"> <a aria-label="Previous"> <span aria-hidden="true">&laquo;</span> </a> </li>'
-        + '<% } else { %>'
-        + '<li>'
-        + '<a class="target-link " data-target-url="'
-        + '<%- interpolate("%(attempt_url)s?page=%(count)s ",'
-        + '{attempt_url: attempt_url, count: pagination_info.current_page - 1}, true) %>'
-        + '"'
-        + 'href="#" aria-label="Previous">'
-        + '<span aria-hidden="true">&laquo;</span> </a> </li> <% }%>'
-        + '<% for(var n = 1; n <= pagination_info.total_pages; n++) { %>'
-        + '<li> <a class="target-link <% if (pagination_info.current_page == n){ %> active <% } %>" data-target-url=" '
-        + '<%- interpolate("%(attempt_url)s?page=%(count)s ", {attempt_url: attempt_url, count: n}, true) %>'
-        + '"href="#"><%= n %> </a></li> <% } %>'
-        + '<% if (!pagination_info.has_next){ %>'
-        + '<li class="disabled"> <a aria-label="Next"> <span aria-hidden="true">&raquo;</span> </a></li>'
-        + '<% } else { %> <li> <a class="target-link" href="#" aria-label="Next" data-target-url="'
-        + '<%- interpolate("%(attempt_url)s?page=%(count)s ",'
-        + '{attempt_url: attempt_url, count: pagination_info.current_page + 1}, true) %>'
-        + '" > <span aria-hidden="true">&raquo;</span></a> </li> <% }%> </ul><div class="clearfix"></div></div>'
-        + '<table class="exam-attempts-table"> <thead><tr class="exam-attempt-headings">'
-        + '<th class="more"></th>'
-        + '<th class="username">Username</th>'
-        + '<th class="exam-name">Exam Name</th>'
-        + '<th class="attempt-allowed-time">Allowed Time (Minutes)</th>'
-        + '<th class="attempt-started-at">Started At</th>'
-        + '<th class="attempt-completed-at">Completed At</th>'
-        + '<th class="attempt-status">Status</th>'
-        + '<th class="attempt-ready-to-resume"><%- gettext("Ready to Resume") %> </th>'
-        + '<th class="c_action">Actions</th>'
-        + '</tr></thead>'
-        + '<% if (is_proctored_attempts) { %>\n'
-        + '<% _.each(proctored_exam_attempts, function(proctored_exam_attempt, dashboard_index){ %>'
-        + '<tbody class="<%= proctored_exam_attempt.row_class %><% if (proctored_exam_attempt.all_attempts.length > 1)'
-        + ' { %> accordion-trigger <% } %>"'
-        + 'aria-expanded="false"'
-        + 'id="<%= proctored_exam_attempt.id %>"'
-        + 'aria-controls="<%= proctored_exam_attempt.id %>_contents"'
-        + '<% if (proctored_exam_attempt.all_attempts.length > 1) { %>'
-        + 'tabindex=0 <% } %>'
-        + '>'
-        + '<tr class="allowance-items">'
-        + '<td>'
-        + '<% if (proctored_exam_attempt.all_attempts.length > 1) { %>'
-        + '<span class="fa fa-chevron-right" aria-hidden="true"></span>'
-        + '<% } %> </td>'
-        + '<td>'
-        + '<%- interpolate(gettext(\' %(username)s \'), { username: proctored_exam_attempt.user.username }, true) %>'
-        + '</td>'
-        + '<td>'
-        + '<%- interpolate(gettext(\' %(exam_display_name)s \'), '
-        + '{ exam_display_name: proctored_exam_attempt.proctored_exam.exam_name }, true) %>'
-        + '</td>'
-        + '<td> <%= proctored_exam_attempt.allowed_time_limit_mins %></td>'
-        + '<td> <%= proctored_exam_attempt.exam_attempt_type %></td>'
-        + '<% if (proctored_exam_attempt.all_attempts.length <= 1){ %>'
-        + '<td> <%= getDateFormat(proctored_exam_attempt.started_at) %></td>'
-        + '<td> <%= getDateFormat(proctored_exam_attempt.completed_at) %></td>'
-        + '<td>'
-        + '<% if (proctored_exam_attempt.status){ %>'
-        + '<%= getExamAttemptStatus(proctored_exam_attempt.status) %>'
-        + '<% } else { %> N/A <% } %>'
-        + '</td>'
-        + '<% if ('
-        + 'proctored_exam_attempt.ready_to_resume && !proctored_exam_attempt.resumed'
-        + ') { %>'
-        + '<td>'
-        + '<span class="fa fa-check-circle" aria-hidden="true"></span>'
-        + '</td>'
-        + '<% } else { %>'
-        + '<td></td>'
-        + '<% } %>'
-        + '<% } else { %>'
-        + '<td></td>'
-        + '<td></td>'
-        + '<td></td>'
-        + '<td></td>'
-        + '<% } %>'
-        + '<td>'
-        + '<% if (proctored_exam_attempt.status){ %>'
-        + '<% if ('
-        + 'proctored_exam_attempt.is_resumable &&'
-        + '!proctored_exam_attempt.proctored_exam.is_practice_exam'
-        + ') { %>'
-        + '<div class="wrapper-action-more">'
-        + '<button class="action action-more" type="button" '
-        + 'id="actions-dropdown-link-<%= dashboard_index %>" aria-haspopup="true" aria-expanded="false" '
-        + 'aria-controls="actions-dropdown-<%= dashboard_index %>" data-dashboard-index="<%= dashboard_index %>">'
-        + '<span class="fa fa-cog" aria-hidden="true"></span>'
-        + '</button>'
-        + '<div class="actions-dropdown" id="actions-dropdown-<%= dashboard_index %>" tabindex="-1">'
-        + '<ul class="actions-dropdown-list" id="actions-dropdown-list-<%= dashboard_index %>" '
-        + 'aria-label="<%- gettext("Available Actions") %>" role="menu">'
-        + '<li class="actions-item" role="menuitem">'
-        + '<a href="#" class="action resume-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" '
-        + 'data-user-id="<%= proctored_exam_attempt.user.id %>" >'
-        + '<%- gettext("Resume") %>'
-        + '</a>'
-        + '</li>'
-        + '<li class="actions-item" role="menuitem">'
-        + '<a href="#" class="action remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" '
-        + 'data-user-id="<%= proctored_exam_attempt.user.id %>" '
-        + 'data-exam-id="<%= proctored_exam_attempt.proctored_exam.id %>" >'
-        + '<%- gettext("Reset") %>'
-        + '</a>'
-        + '</li>'
-        + '</ul>'
-        + '</div>'
-        + '</div>'
-        + '<% } else { %>'
-        + '<a href="#" class="action remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" '
-        + 'data-user-id="<%= proctored_exam_attempt.user.id %>" '
-        + 'data-exam-id="<%= proctored_exam_attempt.proctored_exam.id %>" >'
-        + '<%- gettext("Reset") %>'
-        + '</a>'
-        + '<% } %>'
-        + '<% } else { %>'
-        + 'N/A'
-        + '<% } %>'
-        + '</td>'
-        + '</tr>'
-        + '</tbody>'
-        + '<% if (proctored_exam_attempt.all_attempts.length > 1) { %>'
-        + '<tbody class="accordion-panel is-hidden" id="<%= proctored_exam_attempt.id %>_contents">'
-        + '<% _.each(proctored_exam_attempt.all_attempts, function(proctored_exam_attempt) { %>'
-        + '<tr class="allowance-items">'
-        + '<td></td> <td></td> <td></td> <td></td> <td></td>'
-        + '<td> <%= getDateFormat(proctored_exam_attempt.started_at) %></td>'
-        + '<td> <%= getDateFormat(proctored_exam_attempt.completed_at) %></td>'
-        + '<td>'
-        + '<% if (proctored_exam_attempt.status) { %>'
-        + '<%= getExamAttemptStatus(proctored_exam_attempt.status) %>'
-        + '<% } else { %> N/A <% } %> </td>'
-        + '<% if ('
-        + 'proctored_exam_attempt.ready_to_resume && !proctored_exam_attempt.resumed'
-        + ') { %>'
-        + '<td>'
-        + '<span class="fa fa-check-circle" aria-hidden="true"></span>'
-        + '</td>'
-        + '<% } else { %>'
-        + '<td></td>'
-        + '<% } %>'
-        + '<td></td> '
-        + '</tr> <% }); %>'
-        + '</tbody> <% }%> <% }); %> <% } %>'
-        + '</table>'
-        + '<% if (!is_proctored_attempts) { %>'
-        + '<p> No exam results found. </p>'
-        + '<% } %>'
-        + '</div>'
-        + '</div>';
-    this.server = sinon.fakeServer.create();
-    this.server.autoRespond = true;
-    setFixtures('<div class="student-proctored-exam-container" data-course-id="test_course_id"></div>');
+    function getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson(
+        status, isPracticeExam, isResumable, readyToResume, resumed
+    ) {
+        // eslint-disable-next-line no-param-reassign
+        isPracticeExam = typeof isPracticeExam !== 'undefined' ? isPracticeExam : false;
+        // eslint-disable-next-line no-param-reassign
+        isResumable = typeof isResumable !== 'undefined' ? isResumable : false;
+        return (
+            [{
+                attempt_url: '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/edX/DemoX/Demo_Course',
+                pagination_info: {
+                    current_page: 1,
+                    has_next: false,
+                    has_previous: false,
+                    total_pages: 1
+                },
+                proctored_exam_attempts: [{
+                    allowed_time_limit_mins: 1,
+                    attempt_code: '20C32387-372E-48BD-BCAC-A2BE9DC91E09',
+                    completed_at: null,
+                    created: '2015-08-10T09:15:45Z',
+                    external_id: '40eceb15-bcc3-4791-b43f-4e843afb7ae8',
+                    id: 43,
+                    is_sample_attempt: false,
+                    modified: '2015-08-10T09:15:45Z',
+                    started_at: '2015-08-10T09:15:45Z',
+                    status: status,
+                    is_resumable: isResumable,
+                    ready_to_resume: readyToResume,
+                    resumed: resumed,
+                    taking_as_proctored: true,
+                    proctored_exam: {
+                        content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
+                        course_id: 'edX/DemoX/Demo_Course',
+                        exam_name: 'Normal Exam',
+                        external_id: null,
+                        id: 17,
+                        is_active: true,
+                        is_practice_exam: isPracticeExam,
+                        is_proctored: true,
+                        time_limit_mins: 1
+                    },
+                    user: {
+                        username: 'testuser1',
+                        email: 'testuser1@test.com',
+                        id: 1
+                    },
+                    all_attempts: [
+                        {
+                            allowed_time_limit_mins: 1,
+                            attempt_code: '20C32387-372E-48BD-BCAC-A2BE9DC91E09',
+                            completed_at: null,
+                            created: '2015-08-10T09:15:45Z',
+                            external_id: '40eceb15-bcc3-4791-b43f-4e843afb7ae8',
+                            id: 43,
+                            is_sample_attempt: false,
+                            modified: '2015-08-10T09:15:45Z',
+                            started_at: '2015-08-10T09:15:45Z',
+                            status: status,
+                            is_resumable: isResumable,
+                            ready_to_resume: readyToResume,
+                            resumed: resumed,
+                            taking_as_proctored: true,
+                            proctored_exam: {
+                                content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
+                                course_id: 'edX/DemoX/Demo_Course',
+                                exam_name: 'Normal Exam',
+                                external_id: null,
+                                id: 17,
+                                is_active: true,
+                                is_practice_exam: isPracticeExam,
+                                is_proctored: true,
+                                time_limit_mins: 1
+                            },
+                            user: {
+                                username: 'testuser1',
+                                email: 'testuser1@test.com',
+                                id: 1
+                            }
+                        },
+                        {
+                            allowed_time_limit_mins: 1,
+                            attempt_code: '20C32387-372E-48BD-BCAC-A2BE9DC91E10',
+                            completed_at: null,
+                            created: '2015-08-10T09:15:45Z',
+                            external_id: '40eceb15-bcc3-4791-b43f-4e843afb7ae9',
+                            id: 44,
+                            is_sample_attempt: false,
+                            modified: '2015-08-10T09:15:45Z',
+                            started_at: '2015-08-10T09:15:45Z',
+                            status: 'resumed',
+                            is_resumable: false,
+                            ready_to_resume: true,
+                            resumed: true,
+                            taking_as_proctored: true,
+                            proctored_exam: {
+                                content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
+                                course_id: 'edX/DemoX/Demo_Course',
+                                exam_name: 'Normal Exam',
+                                external_id: null,
+                                id: 17,
+                                is_active: true,
+                                is_practice_exam: isPracticeExam,
+                                is_proctored: true,
+                                time_limit_mins: 1
+                            },
+                            user: {
+                                username: 'testuser1',
+                                email: 'testuser1@test.com',
+                                id: 1
+                            }
+                        }
+                    ]
+                }]
+            }]
+        );
+    }
 
-    // load the underscore template response before calling the proctored exam attempt view.
-    this.server.respondWith(
-      'GET',
-      '/static/proctoring/templates/student-proctored-exam-attempts-grouped.underscore',
-      [
-        200,
-        { 'Content-Type': 'text/html' },
-        html,
-      ],
-    );
-  });
+    beforeEach(function() {
+        html = '<div class="wrapper-content wrapper">' +
+        '<% var is_proctored_attempts = proctored_exam_attempts.length !== 0 %>' +
+        '<div class="content exam-attempts-content">' +
+        '<div class="top-header">' +
+        '<div class="search-attempts">' +
+        '<input type="text" id="search_attempt_id" placeholder="e.g johndoe or john.doe@gmail.com"' +
+        '<% if (inSearchMode) { %> value="<%= searchText %>" <%} %> /> ' +
+        '<span class="search">' +
+        '<span class="icon fa fa-search" id="attempt-search-indicator" aria-hidden="true"></span>' +
+        '<div aria-live="polite" aria-relevant="all">' +
+        '<div id="attempt-loading-indicator" class="hidden">' +
+        '<span class="icon fa fa-spinner fa-pulse" aria-hidden="true"></span>' +
+        '<span class="sr"><%- gettext("Loading") %></span>' +
+        '</div>' +
+        '</div>' +
+        '</span>' +
+        '<span class="clear-search"><span class="icon fa fa-remove" aria-hidden="true"></span></span>' +
+        '</div>' +
+        '<ul class="pagination">' +
+        '<% if (!pagination_info.has_previous){ %>' +
+        '<li class="disabled"> <a aria-label="Previous"> <span aria-hidden="true">&laquo;</span> </a> </li>' +
+        '<% } else { %>' +
+        '<li>' +
+        '<a class="target-link " data-target-url="' +
+        '<%- interpolate("%(attempt_url)s?page=%(count)s ",' +
+        '{attempt_url: attempt_url, count: pagination_info.current_page - 1}, true) %>' +
+        '"' +
+        'href="#" aria-label="Previous">' +
+        '<span aria-hidden="true">&laquo;</span> </a> </li> <% }%>' +
+        '<% for(var n = 1; n <= pagination_info.total_pages; n++) { %>' +
+        '<li> <a class="target-link <% if (pagination_info.current_page == n){ %> active <% } %>" data-target-url=" ' +
+        '<%- interpolate("%(attempt_url)s?page=%(count)s ", {attempt_url: attempt_url, count: n}, true) %>' +
+        '"href="#"><%= n %> </a></li> <% } %>' +
+        '<% if (!pagination_info.has_next){ %>' +
+        '<li class="disabled"> <a aria-label="Next"> <span aria-hidden="true">&raquo;</span> </a></li>' +
+        '<% } else { %> <li> <a class="target-link" href="#" aria-label="Next" data-target-url="' +
+        '<%- interpolate("%(attempt_url)s?page=%(count)s ",' +
+        '{attempt_url: attempt_url, count: pagination_info.current_page + 1}, true) %>' +
+        '" > <span aria-hidden="true">&raquo;</span></a> </li> <% }%> </ul><div class="clearfix"></div></div>' +
+        '<table class="exam-attempts-table"> <thead><tr class="exam-attempt-headings">' +
+        '<th class="more"></th>' +
+        '<th class="username">Username</th>' +
+        '<th class="exam-name">Exam Name</th>' +
+        '<th class="attempt-allowed-time">Allowed Time (Minutes)</th>' +
+        '<th class="attempt-started-at">Started At</th>' +
+        '<th class="attempt-completed-at">Completed At</th>' +
+        '<th class="attempt-status">Status</th>' +
+        '<th class="attempt-ready-to-resume"><%- gettext("Ready to Resume") %> </th>' +
+        '<th class="c_action">Actions</th>' +
+        '</tr></thead>' +
+        '<% if (is_proctored_attempts) { %>\n' +
+        '<% _.each(proctored_exam_attempts, function(proctored_exam_attempt, dashboard_index){ %>' +
+        '<tbody class="<%= proctored_exam_attempt.row_class %><% if (proctored_exam_attempt.all_attempts.length > 1)' +
+        ' { %> accordion-trigger <% } %>"' +
+        'aria-expanded="false"' +
+        'id="<%= proctored_exam_attempt.id %>"' +
+        'aria-controls="<%= proctored_exam_attempt.id %>_contents"' +
+        '<% if (proctored_exam_attempt.all_attempts.length > 1) { %>' +
+        'tabindex=0 <% } %>' +
+        '>' +
+        '<tr class="allowance-items">' +
+        '<td>' +
+        '<% if (proctored_exam_attempt.all_attempts.length > 1) { %>' +
+        '<span class="fa fa-chevron-right" aria-hidden="true"></span>' +
+        '<% } %> </td>' +
+        '<td>' +
+        '<%- interpolate(gettext(\' %(username)s \'), { username: proctored_exam_attempt.user.username }, true) %>' +
+        '</td>' +
+        '<td>' +
+        '<%- interpolate(gettext(\' %(exam_display_name)s \'), ' +
+        '{ exam_display_name: proctored_exam_attempt.proctored_exam.exam_name }, true) %>' +
+        '</td>' +
+        '<td> <%= proctored_exam_attempt.allowed_time_limit_mins %></td>' +
+        '<td> <%= proctored_exam_attempt.exam_attempt_type %></td>' +
+        '<% if (proctored_exam_attempt.all_attempts.length <= 1){ %>' +
+        '<td> <%= getDateFormat(proctored_exam_attempt.started_at) %></td>' +
+        '<td> <%= getDateFormat(proctored_exam_attempt.completed_at) %></td>' +
+        '<td>' +
+        '<% if (proctored_exam_attempt.status){ %>' +
+        '<%= getExamAttemptStatus(proctored_exam_attempt.status) %>' +
+        '<% } else { %> N/A <% } %>' +
+        '</td>' +
+        '<% if (' +
+        'proctored_exam_attempt.ready_to_resume && !proctored_exam_attempt.resumed' +
+        ') { %>' +
+        '<td>' +
+        '<span class="fa fa-check-circle" aria-hidden="true"></span>' +
+        '</td>' +
+        '<% } else { %>' +
+        '<td></td>' +
+        '<% } %>' +
+        '<% } else { %>' +
+        '<td></td>' +
+        '<td></td>' +
+        '<td></td>' +
+        '<td></td>' +
+        '<% } %>' +
+        '<td>' +
+        '<% if (proctored_exam_attempt.status){ %>' +
+        '<% if (' +
+        'proctored_exam_attempt.is_resumable &&' +
+        '!proctored_exam_attempt.proctored_exam.is_practice_exam' +
+        ') { %>' +
+        '<div class="wrapper-action-more">' +
+        '<button class="action action-more" type="button" ' +
+        'id="actions-dropdown-link-<%= dashboard_index %>" aria-haspopup="true" aria-expanded="false" ' +
+        'aria-controls="actions-dropdown-<%= dashboard_index %>" data-dashboard-index="<%= dashboard_index %>">' +
+        '<span class="fa fa-cog" aria-hidden="true"></span>' +
+        '</button>' +
+        '<div class="actions-dropdown" id="actions-dropdown-<%= dashboard_index %>" tabindex="-1">' +
+        '<ul class="actions-dropdown-list" id="actions-dropdown-list-<%= dashboard_index %>" ' +
+        'aria-label="<%- gettext("Available Actions") %>" role="menu">' +
+        '<li class="actions-item" role="menuitem">' +
+        '<a href="#" class="action resume-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" ' +
+        'data-user-id="<%= proctored_exam_attempt.user.id %>" >' +
+        '<%- gettext("Resume") %>' +
+        '</a>' +
+        '</li>' +
+        '<li class="actions-item" role="menuitem">' +
+        '<a href="#" class="action remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" ' +
+        'data-user-id="<%= proctored_exam_attempt.user.id %>" ' +
+        'data-exam-id="<%= proctored_exam_attempt.proctored_exam.id %>" >' +
+        '<%- gettext("Reset") %>' +
+        '</a>' +
+        '</li>' +
+        '</ul>' +
+        '</div>' +
+        '</div>' +
+        '<% } else { %>' +
+        '<a href="#" class="action remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" ' +
+        'data-user-id="<%= proctored_exam_attempt.user.id %>" ' +
+        'data-exam-id="<%= proctored_exam_attempt.proctored_exam.id %>" >' +
+        '<%- gettext("Reset") %>' +
+        '</a>' +
+        '<% } %>' +
+        '<% } else { %>' +
+        'N/A' +
+        '<% } %>' +
+        '</td>' +
+        '</tr>' +
+        '</tbody>' +
+        '<% if (proctored_exam_attempt.all_attempts.length > 1) { %>' +
+        '<tbody class="accordion-panel is-hidden" id="<%= proctored_exam_attempt.id %>_contents">' +
+        '<% _.each(proctored_exam_attempt.all_attempts, function(proctored_exam_attempt) { %>' +
+        '<tr class="allowance-items">' +
+        '<td></td> <td></td> <td></td> <td></td> <td></td>' +
+        '<td> <%= getDateFormat(proctored_exam_attempt.started_at) %></td>' +
+        '<td> <%= getDateFormat(proctored_exam_attempt.completed_at) %></td>' +
+        '<td>' +
+        '<% if (proctored_exam_attempt.status) { %>' +
+        '<%= getExamAttemptStatus(proctored_exam_attempt.status) %>' +
+        '<% } else { %> N/A <% } %> </td>' +
+        '<% if (' +
+        'proctored_exam_attempt.ready_to_resume && !proctored_exam_attempt.resumed' +
+        ') { %>' +
+        '<td>' +
+        '<span class="fa fa-check-circle" aria-hidden="true"></span>' +
+        '</td>' +
+        '<% } else { %>' +
+        '<td></td>' +
+        '<% } %>' +
+        '<td></td> ' +
+        '</tr> <% }); %>' +
+        '</tbody> <% }%> <% }); %> <% } %>' +
+        '</table>' +
+        '<% if (!is_proctored_attempts) { %>' +
+        '<p> No exam results found. </p>' +
+        '<% } %>' +
+        '</div>' +
+        '</div>';
+        this.server = sinon.fakeServer.create();
+        this.server.autoRespond = true;
+        setFixtures('<div class="student-proctored-exam-container" data-course-id="test_course_id"></div>');
 
-  afterEach(async () => {
-    this.server.restore();
-  });
-  it('should render the proctored exam attempt view properly', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('started')),
-      ],
-    );
-    this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
+        // load the underscore template response before calling the proctored exam attempt view.
+        this.server.respondWith(
+            'GET',
+            '/static/proctoring/templates/student-proctored-exam-attempts-grouped.underscore',
+            [
+                200,
+                {'Content-Type': 'text/html'},
+                html
+            ]
+        );
+    });
 
-    this.server.respond();
-    this.server.respond();
+    afterEach(function() {
+        this.server.restore();
+    });
+    it('should render the proctored exam attempt view properly', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('started'))
+            ]
+        );
+        this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
 
-    expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items')).toContainHtml('<td> testuser1 </td>');
-    expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
-  });
+        this.server.respond();
+        this.server.respond();
 
-  it('should search for the proctored exam attempt', async () => {
-    const searchText = 'testuser1';
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('started')),
-      ],
-    );
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items')).toContainHtml('<td> testuser1 </td>');
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
+    });
 
-    this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
+    it('should search for the proctored exam attempt', function() {
+        var searchText = 'testuser1';
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('started'))
+            ]
+        );
 
-    // Process all requests so far
-    this.server.respond();
-    this.server.respond();
+        this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
 
-    expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items')).toContainHtml('<td> testuser1 </td>');
-    expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
-    expect(this.proctored_exam_attempt_view.$el.find('#attempt-search-indicator').hasClass('hidden'))
-      .toEqual(false);
-    expect(this.proctored_exam_attempt_view.$el.find('#attempt-loading-indicator').hasClass('hidden'))
-      .toEqual(true);
+        // Process all requests so far
+        this.server.respond();
+        this.server.respond();
 
-    $('#search_attempt_id').val(searchText);
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items')).toContainHtml('<td> testuser1 </td>');
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
+        expect(this.proctored_exam_attempt_view.$el.find('#attempt-search-indicator').hasClass('hidden'))
+            .toEqual(false);
+        expect(this.proctored_exam_attempt_view.$el.find('#attempt-loading-indicator').hasClass('hidden'))
+            .toEqual(true);
 
-    // search for the proctored exam attempt
-    this.server.respondWith(
-      'GET',
-      `/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id/search/${searchText}`,
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('started')),
-      ],
-    );
+        $('#search_attempt_id').val(searchText);
 
-    // trigger the search attempt event.
-    spyOnEvent('.search-attempts > span.search', 'click');
-    $('.search-attempts > span.search').trigger('click');
+        // search for the proctored exam attempt
+        this.server.respondWith(
+            'GET',
+            '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id/search/' + searchText,
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('started'))
+            ]
+        );
 
-    // check that spinner is visible
-    expect(this.proctored_exam_attempt_view.$el.find('#attempt-search-indicator').hasClass('hidden'))
-      .toEqual(true);
-    expect(this.proctored_exam_attempt_view.$el.find('#attempt-loading-indicator').hasClass('hidden'))
-      .toEqual(false);
+        // trigger the search attempt event.
+        spyOnEvent('.search-attempts > span.search', 'click');
+        $('.search-attempts > span.search').trigger('click');
 
-    // process the search attempt requests.
-    this.server.respond();
+        // check that spinner is visible
+        expect(this.proctored_exam_attempt_view.$el.find('#attempt-search-indicator').hasClass('hidden'))
+            .toEqual(true);
+        expect(this.proctored_exam_attempt_view.$el.find('#attempt-loading-indicator').hasClass('hidden'))
+            .toEqual(false);
 
-    // search matches the existing attempts
-    expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('testuser1');
-    expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
-    // check that spinner is hidden again
-    expect(this.proctored_exam_attempt_view.$el.find('#attempt-search-indicator').hasClass('hidden'))
-      .toEqual(false);
-    expect(this.proctored_exam_attempt_view.$el.find('#attempt-loading-indicator').hasClass('hidden'))
-      .toEqual(true);
-  });
+        // process the search attempt requests.
+        this.server.respond();
 
-  it('should clear the search for the proctored exam attempt', async () => {
-    const searchText = 'invalid_search_text';
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('started')),
-      ],
-    );
-    this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
+        // search matches the existing attempts
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('testuser1');
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
+        // check that spinner is hidden again
+        expect(this.proctored_exam_attempt_view.$el.find('#attempt-search-indicator').hasClass('hidden'))
+            .toEqual(false);
+        expect(this.proctored_exam_attempt_view.$el.find('#attempt-loading-indicator').hasClass('hidden'))
+            .toEqual(true);
+    });
 
-    // Process all requests so far
-    this.server.respond();
-    this.server.respond();
+    it('should clear the search for the proctored exam attempt', function() {
+        var searchText = 'invalid_search_text';
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('started'))
+            ]
+        );
+        this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
 
-    expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items')).toContainHtml('<td> testuser1 </td>');
-    expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
+        // Process all requests so far
+        this.server.respond();
+        this.server.respond();
 
-    $('#search_attempt_id').val(searchText);
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items')).toContainHtml('<td> testuser1 </td>');
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
 
-    // search the proctored exam attempt
-    this.server.respondWith(
-      'GET',
-      `/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id/search/${searchText}`,
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(deletedProctoredExamAttemptJson),
-      ],
-    );
+        $('#search_attempt_id').val(searchText);
 
-    // trigger the search attempt event.
-    spyOnEvent('.search-attempts > span.search', 'click');
-    $('.search-attempts > span.search').trigger('click');
+        // search the proctored exam attempt
+        this.server.respondWith(
+            'GET',
+            '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id/search/' + searchText,
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(deletedProctoredExamAttemptJson)
+            ]
+        );
 
-    // process the search attempt request.
-    this.server.respond();
+        // trigger the search attempt event.
+        spyOnEvent('.search-attempts > span.search', 'click');
+        $('.search-attempts > span.search').trigger('click');
 
-    // search doesn't matches the existing attempts
-    expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).not.toContain('testuser1');
-    expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).not.toContain('Normal Exam');
+        // process the search attempt request.
+        this.server.respond();
 
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('started')),
-      ],
-    );
+        // search doesn't matches the existing attempts
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).not.toContain('testuser1');
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).not.toContain('Normal Exam');
 
-    // trigger the clear search event.
-    spyOnEvent('.search-attempts > span.clear-search', 'click');
-    $('.search-attempts > span.clear-search').trigger('click');
 
-    // process the reset attempt request.
-    this.server.respond();
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('started'))
+            ]
+        );
 
-    // after resetting the attempts, selector matches the existing attempts
-    expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('testuser1');
-    expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
-  });
+        // trigger the clear search event.
+        spyOnEvent('.search-attempts > span.clear-search', 'click');
+        $('.search-attempts > span.clear-search').trigger('click');
 
-  it('should display check when exam attempt is ready to resume', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('error', false, true, true, false)),
-      ],
-    );
-    this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
+        // process the reset attempt request.
+        this.server.respond();
 
-    // Process all requests so far
-    this.server.respond();
-    this.server.respond();
+        // after resetting the attempts, selector matches the existing attempts
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('testuser1');
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
+    });
 
-    const rows = this.proctored_exam_attempt_view.$el.find('tbody').children();
-    expect(rows.length).toEqual(3);
+    it('should display check when exam attempt is ready to resume', function() {
+        var rows;
 
-    // check that ready to resume check does not appear in outer level
-    expect(rows[0].outerHTML).not.toContain('fa-check-circle');
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson(
+                    'error', false, true, true, false)
+                )
+            ]
+        );
+        this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
 
-    // check that status is present in other two rows
-    expect(rows[1].outerHTML).toContain('fa-check-circle');
-    expect(rows[2].outerHTML).not.toContain('fa-check-circle');
-  });
+        // Process all requests so far
+        this.server.respond();
+        this.server.respond();
 
-  it('should not display check when exam attempt has status ready to resume but has been resumed', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('error', false, false, false, true)),
-      ],
-    );
-    this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
+        rows = this.proctored_exam_attempt_view.$el.find('tbody').children();
+        expect(rows.length).toEqual(3);
 
-    // Process all requests so far
-    this.server.respond();
-    this.server.respond();
+        // check that ready to resume check does not appear in outer level
+        expect(rows[0].outerHTML).not.toContain('fa-check-circle');
 
-    const rows = this.proctored_exam_attempt_view.$el.find('tbody').children();
-    expect(rows.length).toEqual(3);
+        // check that status is present in other two rows
+        expect(rows[1].outerHTML).toContain('fa-check-circle');
+        expect(rows[2].outerHTML).not.toContain('fa-check-circle');
+    });
 
-    // check that ready to resume check does not appear in outer level
-    expect(rows[0].outerHTML).not.toContain('fa-check-circle');
+    it('should not display check when exam attempt has status ready to resume but has been resumed', function() {
+        var rows;
 
-    // check that status is present in other two rows
-    expect(rows[1].outerHTML).not.toContain('fa-check-circle');
-    expect(rows[2].outerHTML).not.toContain('fa-check-circle');
-  });
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson(
+                    'error', false, false, false, true)
+                )
+            ]
+        );
+        this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
 
-  it('should mark exam attempt "ready_to_resume" on resume', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('error', false, true)),
-      ],
-    );
-    this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
+        // Process all requests so far
+        this.server.respond();
+        this.server.respond();
 
-    // Process all requests so far
-    this.server.respond();
-    this.server.respond();
+        rows = this.proctored_exam_attempt_view.$el.find('tbody').children();
+        expect(rows.length).toEqual(3);
 
-    expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('testuser1');
-    expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('Normal Exam');
-    expect(this.proctored_exam_attempt_view.$el.find('tbody.accordion-panel').html()).toContain('Error');
+        // check that ready to resume check does not appear in outer level
+        expect(rows[0].outerHTML).not.toContain('fa-check-circle');
 
-    expect(this.proctored_exam_attempt_view.$el.find('button.action').html()).not.toHaveLength(0);
-    expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').hasClass('is-visible')).toEqual(false);
+        // check that status is present in other two rows
+        expect(rows[1].outerHTML).not.toContain('fa-check-circle');
+        expect(rows[2].outerHTML).not.toContain('fa-check-circle');
+    });
 
-    this.server.respondWith(
-      'PUT',
-      '/api/edx_proctoring/v1/proctored_exam/attempt/43',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify([]),
-      ],
-    );
+    it('should mark exam attempt "ready_to_resume" on resume', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('error', false, true))
+            ]
+        );
+        this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
 
-    // again fetch the results after the proctored exam attempt is marked ready_to_resume
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('error', false, false, true, false)),
-      ],
-    );
+        // Process all requests so far
+        this.server.respond();
+        this.server.respond();
 
-    spyOn(window, 'confirm').and.callFake(() => true);
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('testuser1');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('Normal Exam');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody.accordion-panel').html()).toContain('Error');
 
-    // click the gear button to open the action dropdown
-    spyOnEvent('.action-more', 'click');
-    $('.action-more').trigger('click');
+        expect(this.proctored_exam_attempt_view.$el.find('button.action').html()).not.toHaveLength(0);
+        expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').hasClass('is-visible')).toEqual(false);
 
-    expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').hasClass('is-visible')).toEqual(true);
-    expect(this.proctored_exam_attempt_view.$el.find(
-      '.actions-dropdown .actions-dropdown-list .actions-item .action',
-    )[0].text).toContain('Resume');
-    expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown .actions-dropdown-list '
+        this.server.respondWith('PUT', '/api/edx_proctoring/v1/proctored_exam/attempt/43',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify([])
+            ]
+        );
+
+        // again fetch the results after the proctored exam attempt is marked ready_to_resume
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson(
+                    'error', false, false, true, false
+                ))
+            ]
+        );
+
+        spyOn(window, 'confirm').and.callFake(function() {
+            return true;
+        });
+
+        // click the gear button to open the action dropdown
+        spyOnEvent('.action-more', 'click');
+        $('.action-more').trigger('click');
+
+        expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').hasClass('is-visible')).toEqual(true);
+        expect(this.proctored_exam_attempt_view.$el.find(
+            '.actions-dropdown .actions-dropdown-list .actions-item .action'
+        )[0].text).toContain('Resume');
+        expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown .actions-dropdown-list '
         + '.actions-item .action')[1].text).toContain('Reset');
-    expect(this.proctored_exam_attempt_view.$el.find('.accordion-panel').hasClass('is-hidden')).toEqual(true);
+        expect(this.proctored_exam_attempt_view.$el.find('.accordion-panel').hasClass('is-hidden')).toEqual(true);
 
-    // trigger the resume attempt event.
-    spyOnEvent('.resume-attempt', 'click');
-    $('.resume-attempt').trigger('click');
+        // trigger the resume attempt event.
+        spyOnEvent('.resume-attempt', 'click');
+        $('.resume-attempt').trigger('click');
 
-    expect(window.confirm.calls.argsFor(0)[0]).toEqual(
-      'Are you sure you want to resume this student\'s exam attempt?',
-    );
+        expect(window.confirm.calls.argsFor(0)[0]).toEqual(
+            'Are you sure you want to resume this student\'s exam attempt?'
+        );
 
-    // process the resume attempt requests.
-    this.server.respond();
-    this.server.respond();
+        // process the resume attempt requests.
+        this.server.respond();
+        this.server.respond();
 
-    expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('testuser1');
-    expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('Normal Exam');
-    expect(this.proctored_exam_attempt_view.$el.find('tbody.accordion-panel').html()).toContain('fa-check-circle');
-    expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').hasClass('is-visible')).toEqual(false);
-  });
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('testuser1');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('Normal Exam');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody.accordion-panel').html()).toContain('fa-check-circle');
+        expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').hasClass('is-visible')).toEqual(false);
+    });
 
-  it('should not display actions dropdown for practice exam attempts', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('error', true, true)),
-      ],
-    );
-    this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
+    it('should not display actions dropdown for practice exam attempts', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('error', true, true))
+            ]
+        );
+        this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
 
-    // Process all requests so far
-    this.server.respond();
-    this.server.respond();
+        // Process all requests so far
+        this.server.respond();
+        this.server.respond();
 
-    expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('testuser1');
-    expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('Normal Exam');
-    expect(this.proctored_exam_attempt_view.$el.find('tbody.accordion-panel').html()).toContain('Error');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('testuser1');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('Normal Exam');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody.accordion-panel').html()).toContain('Error');
 
-    expect(this.proctored_exam_attempt_view.$el.find('button.action').html()).toHaveLength(0);
-    expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').html()).toHaveLength(0);
-  });
+        expect(this.proctored_exam_attempt_view.$el.find('button.action').html()).toHaveLength(0);
+        expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').html()).toHaveLength(0);
+    });
 
-  it('should not display actions dropdown for exam attempts not resumable', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('error', true, false)),
-      ],
-    );
-    this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
+    it('should not display actions dropdown for exam attempts not resumable', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('error', true, false))
+            ]
+        );
+        this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
 
-    // Process all requests so far
-    this.server.respond();
-    this.server.respond();
+        // Process all requests so far
+        this.server.respond();
+        this.server.respond();
 
-    expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('testuser1');
-    expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('Normal Exam');
-    expect(this.proctored_exam_attempt_view.$el.find('tbody.accordion-panel').html()).toContain('Error');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('testuser1');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('Normal Exam');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody.accordion-panel').html()).toContain('Error');
 
-    expect(this.proctored_exam_attempt_view.$el.find('button.action').html()).toHaveLength(0);
-    expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').html()).toHaveLength(0);
-  });
+        expect(this.proctored_exam_attempt_view.$el.find('button.action').html()).toHaveLength(0);
+        expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').html()).toHaveLength(0);
+    });
 
-  it('should display grouped attempts', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('error', false, true)),
-      ],
-    );
-    this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
+    it('should display grouped attempts', function() {
+        var rows;
 
-    // Process all requests so far
-    this.server.respond();
-    this.server.respond();
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('error', false, true))
+            ]
+        );
+        this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
 
-    const rows = this.proctored_exam_attempt_view.$el.find('tbody').children();
+        // Process all requests so far
+        this.server.respond();
+        this.server.respond();
 
-    expect(rows.length).toEqual(3);
+        rows = this.proctored_exam_attempt_view.$el.find('tbody').children();
 
-    // check that status does not appear in first row of group
-    expect(rows[0].outerHTML).not.toContain('Error');
-    expect(rows[0].outerHTML).not.toContain('Resumed');
-    expect(rows[0].outerHTML).toContain('action-more');
+        expect(rows.length).toEqual(3);
 
-    // check that status is present in other two rows
-    expect(rows[1].outerHTML).toContain('Error');
-    expect(rows[1].outerHTML).not.toContain('action-more');
-    expect(rows[2].outerHTML).toContain('resumed');
-    expect(rows[2].outerHTML).not.toContain('action-more');
-  });
+        // check that status does not appear in first row of group
+        expect(rows[0].outerHTML).not.toContain('Error');
+        expect(rows[0].outerHTML).not.toContain('Resumed');
+        expect(rows[0].outerHTML).toContain('action-more');
 
-  it('deletes attempts', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('error', false, true)),
-      ],
-    );
-    this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
+        // check that status is present in other two rows
+        expect(rows[1].outerHTML).toContain('Error');
+        expect(rows[1].outerHTML).not.toContain('action-more');
+        expect(rows[2].outerHTML).toContain('resumed');
+        expect(rows[2].outerHTML).not.toContain('action-more');
+    });
 
-    // Process all requests so far
-    this.server.respond();
-    this.server.respond();
+    it('deletes attempts', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('error', false, true))
+            ]
+        );
+        this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
 
-    // delete the proctored exam attempts
-    this.server.respondWith(
-      'DELETE',
-      '/api/edx_proctoring/v1/proctored_exam/exam_id/17/user_id/1/reset_attempts',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify([]),
-      ],
-    );
+        // Process all requests so far
+        this.server.respond();
+        this.server.respond();
 
-    // again fetch the results after the proctored exam attempt deletion
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(deletedProctoredExamAttemptJson),
-      ],
-    );
+        // delete the proctored exam attempts
+        this.server.respondWith(
+            'DELETE',
+            '/api/edx_proctoring/v1/proctored_exam/exam_id/17/user_id/1/reset_attempts',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify([])
+            ]
+        );
 
-    spyOn(window, 'confirm').and.callFake(() => true);
+        // again fetch the results after the proctored exam attempt deletion
+        this.server.respondWith(
+            'GET',
+            '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(deletedProctoredExamAttemptJson)
+            ]
+        );
 
-    // click the gear button to open the action dropdown
-    spyOnEvent('.action-more', 'click');
-    $('.action-more').trigger('click');
+        spyOn(window, 'confirm').and.callFake(function() {
+            return true;
+        });
 
-    expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').hasClass('is-visible')).toEqual(true);
-    expect(this.proctored_exam_attempt_view.$el.find(
-      '.actions-dropdown .actions-dropdown-list .actions-item .action',
-    )[0].text).toContain('Resume');
-    expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown .actions-dropdown-list '
+        // click the gear button to open the action dropdown
+        spyOnEvent('.action-more', 'click');
+        $('.action-more').trigger('click');
+
+        expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').hasClass('is-visible')).toEqual(true);
+        expect(this.proctored_exam_attempt_view.$el.find(
+            '.actions-dropdown .actions-dropdown-list .actions-item .action'
+        )[0].text).toContain('Resume');
+        expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown .actions-dropdown-list '
         + '.actions-item .action')[1].text).toContain('Reset');
 
-    // trigger the remove attempt event.
-    spyOnEvent('.remove-attempt', 'click');
-    $('.remove-attempt').trigger('click');
+        // trigger the remove attempt event.
+        spyOnEvent('.remove-attempt', 'click');
+        $('.remove-attempt').trigger('click');
 
-    // process the deleted attempt requests.
-    this.server.respond();
-    this.server.respond();
+        // process the deleted attempt requests.
+        this.server.respond();
+        this.server.respond();
 
-    expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).not.toContain('testuser1');
-    expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).not.toContain('Normal Exam');
-  });
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).not.toContain('testuser1');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).not.toContain('Normal Exam');
+    });
 
-  it('shows and hides accordion when toggled', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('submitted', false)),
-      ],
-    );
-    this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
+    it('shows and hides accordion when toggled', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('submitted', false))
+            ]
+        );
+        this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
 
-    // Process all requests so far
-    this.server.respond();
-    this.server.respond();
+        // Process all requests so far
+        this.server.respond();
+        this.server.respond();
 
-    // check that accordion is hidden
-    expect(this.proctored_exam_attempt_view.$el.find('.accordion-panel').hasClass('is-hidden')).toEqual(true);
+        // check that accordion is hidden
+        expect(this.proctored_exam_attempt_view.$el.find('.accordion-panel').hasClass('is-hidden')).toEqual(true);
 
-    // click to expand section
-    spyOnEvent('.accordion-trigger', 'click');
-    $('.accordion-trigger').trigger('click');
+        // click to expand section
+        spyOnEvent('.accordion-trigger', 'click');
+        $('.accordion-trigger').trigger('click');
 
-    // check that accordion is no longer hidden
-    expect(this.proctored_exam_attempt_view.$el.find('.accordion-panel').hasClass('is-hidden')).toEqual(false);
-  });
+        // check that accordion is no longer hidden
+        expect(this.proctored_exam_attempt_view.$el.find('.accordion-panel').hasClass('is-hidden')).toEqual(false);
+    });
 
-  it('searches and shows spinner for grouped attempts', async () => {
-    const searchText = 'testuser1';
+    it('searches and shows spinner for grouped attempts', function() {
+        var searchText = 'testuser1';
 
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('submitted', false)),
-      ],
-    );
-    this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('submitted', false))
+            ]
+        );
+        this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
 
-    // Process all requests so far
-    this.server.respond();
-    this.server.respond();
+        // Process all requests so far
+        this.server.respond();
+        this.server.respond();
 
-    expect(this.proctored_exam_attempt_view.$el.find('#attempt-search-indicator').hasClass('hidden'))
-      .toEqual(false);
-    expect(this.proctored_exam_attempt_view.$el.find('#attempt-loading-indicator').hasClass('hidden'))
-      .toEqual(true);
+        expect(this.proctored_exam_attempt_view.$el.find('#attempt-search-indicator').hasClass('hidden'))
+            .toEqual(false);
+        expect(this.proctored_exam_attempt_view.$el.find('#attempt-loading-indicator').hasClass('hidden'))
+            .toEqual(true);
 
-    $('#search_attempt_id').val(searchText);
+        $('#search_attempt_id').val(searchText);
 
-    // search for the proctored exam attempt
-    this.server.respondWith(
-      'GET',
-      `/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id/search/${searchText}`,
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('started')),
-      ],
-    );
+        // search for the proctored exam attempt
+        this.server.respondWith(
+            'GET',
+            '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id/search/' + searchText,
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('started'))
+            ]
+        );
 
-    // trigger the search attempt event.
-    spyOnEvent('.search-attempts > span.search', 'click');
-    $('.search-attempts > span.search').trigger('click');
+        // trigger the search attempt event.
+        spyOnEvent('.search-attempts > span.search', 'click');
+        $('.search-attempts > span.search').trigger('click');
 
-    // check that spinner is visible
-    expect(this.proctored_exam_attempt_view.$el.find('#attempt-search-indicator').hasClass('hidden'))
-      .toEqual(true);
-    expect(this.proctored_exam_attempt_view.$el.find('#attempt-loading-indicator').hasClass('hidden'))
-      .toEqual(false);
+        // check that spinner is visible
+        expect(this.proctored_exam_attempt_view.$el.find('#attempt-search-indicator').hasClass('hidden'))
+            .toEqual(true);
+        expect(this.proctored_exam_attempt_view.$el.find('#attempt-loading-indicator').hasClass('hidden'))
+            .toEqual(false);
 
-    // process the search attempt requests.
-    this.server.respond();
+        // process the search attempt requests.
+        this.server.respond();
 
-    // check that spinner is hidden again
-    expect(this.proctored_exam_attempt_view.$el.find('#attempt-search-indicator').hasClass('hidden'))
-      .toEqual(false);
-    expect(this.proctored_exam_attempt_view.$el.find('#attempt-loading-indicator').hasClass('hidden'))
-      .toEqual(true);
-  });
+        // check that spinner is hidden again
+        expect(this.proctored_exam_attempt_view.$el.find('#attempt-search-indicator').hasClass('hidden'))
+            .toEqual(false);
+        expect(this.proctored_exam_attempt_view.$el.find('#attempt-loading-indicator').hasClass('hidden'))
+            .toEqual(true);
+    });
 });

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_bulk_allowance_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_bulk_allowance_spec.js
@@ -1,97 +1,90 @@
-describe('ProctoredExamAllowanceView', () => {
-  'use strict';
+describe('ProctoredExamAllowanceView', function() {
+    'use strict';
 
-  let html = '';
-  const expectedProctoredAllowanceJson = [{
-    testuser1: [{
-      created: '2015-08-10T09:15:45Z',
-      id: 1,
-      modified: '2015-08-10T09:15:45Z',
-      key: 'Additional time (minutes)',
-      value: '1',
-      proctored_exam: {
-        content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
-        course_id: 'edX/DemoX/Demo_Course',
-        exam_name: 'Test Exam',
-        external_id: null,
-        id: 17,
-        is_active: true,
-        is_practice_exam: false,
-        is_proctored: true,
-        time_limit_mins: 1,
-      },
-      user: {
-        username: 'testuser1',
-        email: 'testuser1@test.com',
-      },
-    }],
-  },
-  ];
+    var html = '';
+    var expectedProctoredAllowanceJson = [{
+        testuser1: [{
+            created: '2015-08-10T09:15:45Z',
+            id: 1,
+            modified: '2015-08-10T09:15:45Z',
+            key: 'Additional time (minutes)',
+            value: '1',
+            proctored_exam: {
+                content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
+                course_id: 'edX/DemoX/Demo_Course',
+                exam_name: 'Test Exam',
+                external_id: null,
+                id: 17,
+                is_active: true,
+                is_practice_exam: false,
+                is_proctored: true,
+                time_limit_mins: 1
+            },
+            user: {
+                username: 'testuser1',
+                email: 'testuser1@test.com'
+            }
+        }]}
+    ];
 
-  beforeEach(() => {
-    // eslint-disable-next-line max-len
-    html = '<span class="tip"> <%- gettext("Allowances") %>\n    <span>\n        <a id="add-allowance" href="#"  class="add blue-button">+ <%- gettext("Add Allowance") %></a>\n    </span>\n</span>\n<% var is_allowances = proctored_exam_allowances.length !== 0 %>\n<% if (is_allowances) { %>\n\n<div class="wrapper-content wrapper">\n   <section class="content exam-allowances-content">\n            <% _.each(proctored_exam_allowances, function(student){ %>\n                <div class="accordion-trigger" aria-expanded="false" style="font-size:20px;" data-key-id="<%=generateDomId(student[0].user.username)%>">\n                    <span class="fa fa-chevron-down" aria-hidden="true"></span>\n                    <%=student[0].user.username %>\n                </div>\n                <table class="allowance-table" id="<%=generateDomId(student[0].user.username)%>" style="display:none;">\n                    <tbody>\n                        <tr class="allowance-headings">\n                            <th class="exam-name"><%- gettext("Exam Name") %></th>\n                            <th class="email"><%- gettext("Email") %></th>\n                            <th class="allowance-name"><%- gettext("Allowance Type") %> </th>\n                            <th class="allowance-value"><%- gettext("Allowance Value") %></th>\n                            <th class="c_action"><%- gettext("Actions") %> </th>\n                        </tr>\n                    <% _.each(student, function(proctored_exam_allowance){ %>\n                            <% var key = proctored_exam_allowance.key; %>\n                            <% for (i = 0; i < allowance_types.length; i += 1) { %>\n                                <% if (key === allowance_types[i][0]) { %>\n                                    <% proctored_exam_allowance.key_display_name = allowance_types[i][1]; %>\n                                    <% break; %>\n                                <% }} %>\n                            <% if (!proctored_exam_allowance.key_display_name) { %>\n                                <% proctored_exam_allowance.key_display_name = key;} %>\n                        <tr class="allowance-items">\n                            <td>\n                            <%- proctored_exam_allowance.proctored_exam.exam_name %>\n                            </td>\n                            <td>\n                            <% if (proctored_exam_allowance.user){ %>\n                            <%= proctored_exam_allowance.user.email %>\n                            </td>\n                            <% }else{ %>\n                                <td>N/A</td>\n                                <td>N/A</td>\n                            <% } %>\n                            <td>\n                            <%= proctored_exam_allowance.key_display_name %>\n                            </td>\n                        <td>\n                            <%- proctored_exam_allowance.value %></td>\n                        <td>\n                        <a data-exam-id="<%= proctored_exam_allowance.proctored_exam.id %>"\n                            data-key-name="<%= proctored_exam_allowance.key %>"\n                            data-key-value="<%= proctored_exam_allowance.key_display_name %>"\n                            data-user-name="<%= proctored_exam_allowance.user.username %>"\n                            data-exam-name="<%= proctored_exam_allowance.proctored_exam.exam_name %>"\n                        class="edit_allowance" href="#">Edit</a>\n                        <a data-exam-id="<%= proctored_exam_allowance.proctored_exam.id %>"\n                            data-key-name="<%= proctored_exam_allowance.key %>"\n                            data-user-id="<%= proctored_exam_allowance.user.id %>"\n                        class="remove_allowance" href="#">Delete</a>\n                        </td>\n                        </tr>\n                    <% }); %>\n                    </tbody>\n                </table>\n            <% }); %>\n   </section>\n</div>\n<% } %>\n';
-    this.server = sinon.fakeServer.create();
-    this.server.autoRespond = true;
-    setFixtures('<div class="special-allowance-container" data-course-id="test_course_id"></div>');
+    beforeEach(function() {
+        // eslint-disable-next-line max-len
+        html = '<span class="tip"> <%- gettext("Allowances") %>\n    <span>\n        <a id="add-allowance" href="#"  class="add blue-button">+ <%- gettext("Add Allowance") %></a>\n    </span>\n</span>\n<% var is_allowances = proctored_exam_allowances.length !== 0 %>\n<% if (is_allowances) { %>\n\n<div class="wrapper-content wrapper">\n   <section class="content exam-allowances-content">\n            <% _.each(proctored_exam_allowances, function(student){ %>\n                <div class="accordion-trigger" aria-expanded="false" style="font-size:20px;" data-key-id="<%=generateDomId(student[0].user.username)%>">\n                    <span class="fa fa-chevron-down" aria-hidden="true"></span>\n                    <%=student[0].user.username %>\n                </div>\n                <table class="allowance-table" id="<%=generateDomId(student[0].user.username)%>" style="display:none;">\n                    <tbody>\n                        <tr class="allowance-headings">\n                            <th class="exam-name"><%- gettext("Exam Name") %></th>\n                            <th class="email"><%- gettext("Email") %></th>\n                            <th class="allowance-name"><%- gettext("Allowance Type") %> </th>\n                            <th class="allowance-value"><%- gettext("Allowance Value") %></th>\n                            <th class="c_action"><%- gettext("Actions") %> </th>\n                        </tr>\n                    <% _.each(student, function(proctored_exam_allowance){ %>\n                            <% var key = proctored_exam_allowance.key; %>\n                            <% for (i = 0; i < allowance_types.length; i += 1) { %>\n                                <% if (key === allowance_types[i][0]) { %>\n                                    <% proctored_exam_allowance.key_display_name = allowance_types[i][1]; %>\n                                    <% break; %>\n                                <% }} %>\n                            <% if (!proctored_exam_allowance.key_display_name) { %>\n                                <% proctored_exam_allowance.key_display_name = key;} %>\n                        <tr class="allowance-items">\n                            <td>\n                            <%- proctored_exam_allowance.proctored_exam.exam_name %>\n                            </td>\n                            <td>\n                            <% if (proctored_exam_allowance.user){ %>\n                            <%= proctored_exam_allowance.user.email %>\n                            </td>\n                            <% }else{ %>\n                                <td>N/A</td>\n                                <td>N/A</td>\n                            <% } %>\n                            <td>\n                            <%= proctored_exam_allowance.key_display_name %>\n                            </td>\n                        <td>\n                            <%- proctored_exam_allowance.value %></td>\n                        <td>\n                        <a data-exam-id="<%= proctored_exam_allowance.proctored_exam.id %>"\n                            data-key-name="<%= proctored_exam_allowance.key %>"\n                            data-key-value="<%= proctored_exam_allowance.key_display_name %>"\n                            data-user-name="<%= proctored_exam_allowance.user.username %>"\n                            data-exam-name="<%= proctored_exam_allowance.proctored_exam.exam_name %>"\n                        class="edit_allowance" href="#">Edit</a>\n                        <a data-exam-id="<%= proctored_exam_allowance.proctored_exam.id %>"\n                            data-key-name="<%= proctored_exam_allowance.key %>"\n                            data-user-id="<%= proctored_exam_allowance.user.id %>"\n                        class="remove_allowance" href="#">Delete</a>\n                        </td>\n                        </tr>\n                    <% }); %>\n                    </tbody>\n                </table>\n            <% }); %>\n   </section>\n</div>\n<% } %>\n';
+        this.server = sinon.fakeServer.create();
+        this.server.autoRespond = true;
+        setFixtures('<div class="special-allowance-container" data-course-id="test_course_id"></div>');
 
-    // load the underscore template response before calling the proctored exam allowance view.
-    this.server.respondWith(
-      'GET',
-      '/static/proctoring/templates/course_grouped_allowances.underscore',
-      [
-        200,
-        { 'Content-Type': 'text/html' },
-        html,
-      ],
-    );
-  });
+        // load the underscore template response before calling the proctored exam allowance view.
+        this.server.respondWith('GET', '/static/proctoring/templates/course_grouped_allowances.underscore',
+            [
+                200,
+                {'Content-Type': 'text/html'},
+                html
+            ]
+        );
+    });
 
-  afterEach(async () => {
-    this.server.restore();
-  });
-  it('should render the proctored exam allowance view properly', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/test_course_id/grouped/allowance',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedProctoredAllowanceJson),
-      ],
-    );
+    afterEach(function() {
+        this.server.restore();
+    });
+    it('should render the proctored exam allowance view properly', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/test_course_id/grouped/allowance',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedProctoredAllowanceJson)
+            ]
+        );
 
-    this.proctored_exam_allowance = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
-    this.server.respond();
-    this.server.respond();
-    expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
-      .toContain('testuser1@test.com');
-    expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
-      .toContain('Additional time (minutes)');
-    expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
-      .toContain('Test Exam');
-  });
+        this.proctored_exam_allowance = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
+        this.server.respond();
+        this.server.respond();
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .toContain('testuser1@test.com');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .toContain('Additional time (minutes)');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .toContain('Test Exam');
+    });
 
-  it('should toggle the dropdown correctly', async () => {
-    expectedProctoredAllowanceJson[0].testuser1[0].user.username = 'testuser1@test.com';
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/proctored_exam/test_course_id/grouped/allowance',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedProctoredAllowanceJson),
-      ],
-    );
+    it('should toggle the dropdown correctly', function() {
+        expectedProctoredAllowanceJson[0].testuser1[0].user.username = 'testuser1@test.com';
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/test_course_id/grouped/allowance',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedProctoredAllowanceJson)
+            ]
+        );
 
-    this.proctored_exam_allowance = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
-    this.server.respond();
-    this.server.respond();
-    $('.accordion-trigger').trigger('click');
-    expect($('.accordion-trigger').attr('aria-expanded')).toBe('true');
-  });
+        this.proctored_exam_allowance = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
+        this.server.respond();
+        this.server.respond();
+        $('.accordion-trigger').trigger('click');
+        expect($('.accordion-trigger').attr('aria-expanded')).toBe('true');
+    });
 });

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_global_vars.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_global_vars.js
@@ -7,4 +7,4 @@
  * global variables.
  */
 // eslint-disable-next-line no-unused-vars
-var edx; // eslint-disable-line no-var
+var edx;

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_info_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_info_spec.js
@@ -1,552 +1,522 @@
 /* global LearnerOnboardingModel:false */
-describe('ProctoredExamInfo', () => {
-  'use strict';
+describe('ProctoredExamInfo', function() {
+    'use strict';
 
-  let html = '';
+    var html = '';
 
-  const errorGettingOnboardingProfile = {
-    detail: 'There is no onboarding exam related to this course id.',
-  };
-
-  function expectedProctoredExamInfoJson(status, examReleaseDate) {
-    let releaseDate = examReleaseDate;
-    if (!examReleaseDate) { // default to released a week ago
-      releaseDate = new Date();
-      releaseDate.setDate(new Date().getDate() - 7);
-    }
-    return (
-      {
-        onboarding_status: status,
-        onboarding_link: 'onboarding_link',
-        onboarding_release_date: releaseDate,
-        expiration_date: null,
-        onboarding_past_due: false,
-      }
-    );
-  }
-
-  function expectedOtherCourseApprovedJson(expirationDate) {
-    return (
-      {
-        onboarding_status: 'other_course_approved',
-        onboarding_link: 'onboarding_link',
-        expiration_date: expirationDate,
-      }
-    );
-  }
-
-  beforeEach(() => {
-    html = '<div class="proctoring-info">'
-            + '<h3 class="message-title"> <%= gettext("This course contains proctored exams") %></h3>'
-            + '<% if (onboardingStatusText) { %>'
-            + '<div class="onboarding-status">'
-            + '<span class="onboarding-status"><%= gettext("Current Onboarding Status:") %> '
-            + '<%= onboardingStatusText %></span>'
-            + '</div>'
-            + '<div class="onboarding-status-message">'
-            + '<span class="onboarding-status-message"><%= onboardingMessage %></span>'
-            + '</div>'
-            + '<% if (onboardingDetail) { %>'
-            + '<div class="onboarding-status-detail">'
-            + '<span class="onboarding-status-detail"><%= onboardingDetail %></span>'
-            + '</div>'
-            + '<%} %>'
-            + '<%} %>'
-            + '<div class="onboarding-reminder">'
-            + '<% if (showOnboardingReminder) { %>'
-            + '<h4 class="message-title">'
-            + '<% if (showOnboardingExamLink) { %>'
-            + '<%= gettext("You must complete the onboarding process prior to taking any proctored exam.") %>'
-            + '<% } else { %>'
-            + '<%= gettext("Your submitted profile is in review.") %>'
-            + '<% } %>'
-            + '</h4>'
-            + '<p class="message-copy">'
-            + '<%= gettext("Onboarding profile review, including identity verification, can take 2+ business days.") %>'
-            + '</p>'
-            + '<%} %>'
-            + '</div>'
-            + '<% if (showOnboardingExamLink) { %>'
-            + '<% if (onboardingPastDue) { %>'
-            + '<a class="action action-onboarding action-disabled"><%= gettext("Onboarding Past Due") %></a>'
-            + '<% } else if (onboardingNotReleased) { %>'
-            + '<a class="action action-onboarding action-disabled">'
-            + '<%= gettext("Onboarding Opens") %> <%= onboardingReleaseDate %></a>'
-            + '<%} else { %>'
-            + '<a href="<%= onboardingLink %>" class="action action-onboarding">'
-            + '<%= gettext("Complete Onboarding") %></a>'
-            + '<%} %>'
-            + '<%} %>'
-            + '<a href="https://support.edx.org/hc/en-us/articles/207249428-How-do-proctored-exams-work" '
-            + 'class="action action-info-link">'
-            + '<%= gettext("Review instructions and system requirements for proctored exams") %></a>'
-            + '</div>';
-    this.server = sinon.fakeServer.create();
-    this.server.autoRespond = true;
-    setFixtures('<div class="proctoring-info-panel" data-course-id="test_course_id"></div>');
-
-    // load the underscore template response before calling the proctored exam allowance view.
-    this.server.respondWith(
-      'GET',
-      '/static/proctoring/templates/proctored-exam-info.underscore',
-      [
-        200,
-        { 'Content-Type': 'text/html' },
-        html,
-      ],
-    );
-  });
-
-  afterEach(async () => {
-    this.server.restore();
-  });
-
-  it('should not render proctoring info panel when template is not defined', async () => {
-    this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
-      el: $('.proctoring-info-panel'),
-      model: new LearnerOnboardingModel(),
-    });
-    this.proctored_exam_info.render();
-    expect(this.proctored_exam_info.$el.find('.proctoring-info-panel').html())
-      .toHaveLength(0);
-  });
-
-  it('should not render proctoring info panel if no course id is provided', async () => {
-    setFixtures('<div class="proctoring-info-panel" data-course-id=""></div>');
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status?course_id=',
-      [
-        400,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(errorGettingOnboardingProfile),
-      ],
-    );
-
-    this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
-      el: $('.proctoring-info-panel'),
-      model: new LearnerOnboardingModel(),
-    });
-    this.server.respond();
-    this.server.respond();
-    expect(this.proctored_exam_info.$el.find('.proctoring-info-panel').html())
-      .toHaveLength(0);
-  });
-
-  it('should render if username is provided', async () => {
-    setFixtures(
-      '<div class="proctoring-info-panel" data-course-id="test_course_id" '
-            + 'data-username="test_username"></div>',
-    );
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id&username=test_username',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedProctoredExamInfoJson('verified')),
-      ],
-    );
-
-    this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
-      el: $('.proctoring-info-panel'),
-      model: new LearnerOnboardingModel(),
-    });
-    this.server.respond();
-    this.server.respond();
-    expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
-      .toContain('Verified');
-  });
-
-  it('should not render proctoring info panel for exam with 404 response', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
-      [
-        404,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(errorGettingOnboardingProfile),
-      ],
-    );
-
-    this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
-      el: $('.proctoring-info-panel'),
-      model: new LearnerOnboardingModel(),
-    });
-    this.server.respond();
-    this.server.respond();
-    expect(this.proctored_exam_info.$el.find('.proctoring-info-panel').html())
-      .toHaveLength(0);
-  });
-
-  it('should render proctoring info panel correctly for exam with other status', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedProctoredExamInfoJson('other')),
-      ],
-    );
-
-    this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
-      el: $('.proctoring-info-panel'),
-      model: new LearnerOnboardingModel(),
-    });
-    this.server.respond();
-    this.server.respond();
-    expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
-      .toEqual('5px solid rgb(178, 6, 16)');
-    expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
-      .toContain('other');
-    expect(this.proctored_exam_info.$el.find('.onboarding-status-message').text())
-      .toHaveLength(0);
-    expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
-      .toContain('You must complete the onboarding process');
-    expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
-      .toContain('Complete Onboarding');
-  });
-
-  it('should render proctoring info panel correctly for exam with empty string status', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedProctoredExamInfoJson('')),
-      ],
-    );
-
-    this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
-      el: $('.proctoring-info-panel'),
-      model: new LearnerOnboardingModel(),
-    });
-    this.server.respond();
-    this.server.respond();
-    expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
-      .toEqual('5px solid rgb(178, 6, 16)');
-    expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
-      .toContain('Not Started');
-    expect(this.proctored_exam_info.$el.find('.onboarding-status-message').text())
-      .toHaveLength(0);
-    expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
-      .toContain('You must complete the onboarding process');
-    expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
-      .toContain('Complete Onboarding');
-  });
-
-  it('should render proctoring info panel correctly for exam that has yet to be released', async () => {
-    const tomorrow = new Date();
-    tomorrow.setDate(new Date().getDate() + 1);
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedProctoredExamInfoJson('', tomorrow)),
-      ],
-    );
-
-    this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
-      el: $('.proctoring-info-panel'),
-      model: new LearnerOnboardingModel(),
-    });
-    this.server.respond();
-    this.server.respond();
-    expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
-      .toEqual('5px solid rgb(178, 6, 16)');
-    expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
-      .toContain('Not Started');
-    expect(this.proctored_exam_info.$el.find('.onboarding-status-message').text())
-      .toHaveLength(0);
-    expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
-      .toContain('You must complete the onboarding process');
-    expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
-      .toContain(`Onboarding Opens ${tomorrow.toLocaleDateString()}`);
-  });
-
-  it('should render proctoring info panel correctly for past due exam', async () => {
-    const twoDaysAgo = new Date();
-    const data = {
-      onboarding_status: 'Not Started',
-      onboarding_link: null,
-      onboarding_release_date: twoDaysAgo,
-      expiration_date: null,
-      onboarding_past_due: true,
+    var errorGettingOnboardingProfile = {
+        detail: 'There is no onboarding exam related to this course id.'
     };
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(data),
-      ],
-    );
 
-    this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
-      el: $('.proctoring-info-panel'),
-      model: new LearnerOnboardingModel(),
+    function expectedProctoredExamInfoJson(status, examReleaseDate) {
+        var releaseDate = examReleaseDate;
+        if (!examReleaseDate) { // default to released a week ago
+            releaseDate = new Date();
+            releaseDate.setDate(new Date().getDate() - 7);
+        }
+        return (
+            {
+                onboarding_status: status,
+                onboarding_link: 'onboarding_link',
+                onboarding_release_date: releaseDate,
+                expiration_date: null,
+                onboarding_past_due: false
+            }
+        );
+    }
+
+    function expectedOtherCourseApprovedJson(expirationDate) {
+        return (
+            {
+                onboarding_status: 'other_course_approved',
+                onboarding_link: 'onboarding_link',
+                expiration_date: expirationDate
+            }
+        );
+    }
+
+    beforeEach(function() {
+        html = '<div class="proctoring-info">' +
+            '<h3 class="message-title"> <%= gettext("This course contains proctored exams") %></h3>' +
+            '<% if (onboardingStatusText) { %>' +
+            '<div class="onboarding-status">' +
+            '<span class="onboarding-status"><%= gettext("Current Onboarding Status:") %> ' +
+            '<%= onboardingStatusText %></span>' +
+            '</div>' +
+            '<div class="onboarding-status-message">' +
+            '<span class="onboarding-status-message"><%= onboardingMessage %></span>' +
+            '</div>' +
+            '<% if (onboardingDetail) { %>' +
+            '<div class="onboarding-status-detail">' +
+            '<span class="onboarding-status-detail"><%= onboardingDetail %></span>' +
+            '</div>' +
+            '<%} %>' +
+            '<%} %>' +
+            '<div class="onboarding-reminder">' +
+            '<% if (showOnboardingReminder) { %>' +
+            '<h4 class="message-title">' +
+            '<% if (showOnboardingExamLink) { %>' +
+            '<%= gettext("You must complete the onboarding process prior to taking any proctored exam.") %>' +
+            '<% } else { %>' +
+            '<%= gettext("Your submitted profile is in review.") %>' +
+            '<% } %>' +
+            '</h4>' +
+            '<p class="message-copy">' +
+            '<%= gettext("Onboarding profile review, including identity verification, can take 2+ business days.") %>' +
+            '</p>' +
+            '<%} %>' +
+            '</div>' +
+            '<% if (showOnboardingExamLink) { %>' +
+            '<% if (onboardingPastDue) { %>' +
+            '<a class="action action-onboarding action-disabled"><%= gettext("Onboarding Past Due") %></a>' +
+            '<% } else if (onboardingNotReleased) { %>' +
+            '<a class="action action-onboarding action-disabled">' +
+            '<%= gettext("Onboarding Opens") %> <%= onboardingReleaseDate %></a>' +
+            '<%} else { %>' +
+            '<a href="<%= onboardingLink %>" class="action action-onboarding">' +
+            '<%= gettext("Complete Onboarding") %></a>' +
+            '<%} %>' +
+            '<%} %>' +
+            '<a href="https://support.edx.org/hc/en-us/articles/207249428-How-do-proctored-exams-work" ' +
+            'class="action action-info-link">' +
+            '<%= gettext("Review instructions and system requirements for proctored exams") %></a>' +
+            '</div>';
+        this.server = sinon.fakeServer.create();
+        this.server.autoRespond = true;
+        setFixtures('<div class="proctoring-info-panel" data-course-id="test_course_id"></div>');
+
+        // load the underscore template response before calling the proctored exam allowance view.
+        this.server.respondWith('GET', '/static/proctoring/templates/proctored-exam-info.underscore',
+            [
+                200,
+                {'Content-Type': 'text/html'},
+                html
+            ]
+        );
     });
-    this.server.respond();
-    this.server.respond();
-    expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
-      .toEqual('5px solid rgb(178, 6, 16)');
-    expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
-      .toContain('Not Started');
-    expect(this.proctored_exam_info.$el.find('.onboarding-status-message').text())
-      .toHaveLength(0);
-    expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
-      .toContain('You must complete the onboarding process');
-    expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
-      .toContain('Onboarding Past Due');
-  });
 
-  it('should render proctoring info panel correctly for created exam', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedProctoredExamInfoJson('created')),
-      ],
-    );
-
-    this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
-      el: $('.proctoring-info-panel'),
-      model: new LearnerOnboardingModel(),
+    afterEach(function() {
+        this.server.restore();
     });
-    this.server.respond();
-    this.server.respond();
-    expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
-      .toEqual('5px solid rgb(178, 6, 16)');
-    expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
-      .toContain('Not Started');
-    expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
-      .toContain('You must complete the onboarding process');
-    expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
-      .toContain('Complete Onboarding');
-  });
 
-  it('should render proctoring info panel correctly for started exam', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedProctoredExamInfoJson('started')),
-      ],
-    );
-
-    this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
-      el: $('.proctoring-info-panel'),
-      model: new LearnerOnboardingModel(),
+    it('should not render proctoring info panel when template is not defined', function() {
+        this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
+            el: $('.proctoring-info-panel'),
+            model: new LearnerOnboardingModel()
+        });
+        this.proctored_exam_info.render();
+        expect(this.proctored_exam_info.$el.find('.proctoring-info-panel').html())
+            .toHaveLength(0);
     });
-    this.server.respond();
-    this.server.respond();
-    expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
-      .toEqual('5px solid rgb(178, 6, 16)');
-    expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
-      .toContain('Started');
-    expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
-      .toContain('You must complete the onboarding process');
-    expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
-      .toContain('Complete Onboarding');
-  });
 
-  it('should render proctoring info panel correctly for submitted onboarding exam', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedProctoredExamInfoJson('submitted')),
-      ],
-    );
-    this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
-      el: $('.proctoring-info-panel'),
-      model: new LearnerOnboardingModel(),
-    });
-    this.server.respond();
-    this.server.respond();
-    expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
-      .toEqual('5px solid rgb(13, 78, 108)');
-    expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
-      .toContain('Submitted');
-    expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
-      .toContain('Your submitted profile is in review.');
-    expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
-      .not.toContain('Complete Onboarding');
-  });
+    it('should not render proctoring info panel if no course id is provided', function() {
+        setFixtures('<div class="proctoring-info-panel" data-course-id=""></div>');
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status?course_id=',
+            [
+                400,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(errorGettingOnboardingProfile)
+            ]
+        );
 
-  it('should render proctoring info panel correctly for second_review_required exam', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedProctoredExamInfoJson('second_review_required')),
-      ],
-    );
-    this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
-      el: $('.proctoring-info-panel'),
-      model: new LearnerOnboardingModel(),
+        this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
+            el: $('.proctoring-info-panel'),
+            model: new LearnerOnboardingModel()
+        });
+        this.server.respond();
+        this.server.respond();
+        expect(this.proctored_exam_info.$el.find('.proctoring-info-panel').html())
+            .toHaveLength(0);
     });
-    this.server.respond();
-    this.server.respond();
-    expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
-      .toEqual('5px solid rgb(13, 78, 108)');
-    expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
-      .toContain('Submitted');
-    expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
-      .toContain('Your submitted profile is in review.');
-    expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
-      .not.toContain('Complete Onboarding');
-  });
 
-  it('should render proctoring info panel correctly for verified exam', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedProctoredExamInfoJson('verified')),
-      ],
-    );
-    this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
-      el: $('.proctoring-info-panel'),
-      model: new LearnerOnboardingModel(),
-    });
-    this.server.respond();
-    this.server.respond();
-    expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
-      .toEqual('5px solid rgb(0, 129, 0)');
-    expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
-      .toContain('Verified');
-    expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
-      .not.toContain('You must complete the onboarding process');
-    expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
-      .not.toContain('Complete Onboarding');
-  });
+    it('should render if username is provided', function() {
+        setFixtures(
+            '<div class="proctoring-info-panel" data-course-id="test_course_id" ' +
+            'data-username="test_username"></div>'
+        );
+        this.server.respondWith(
+            'GET',
+            '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id&username=test_username',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedProctoredExamInfoJson('verified'))
+            ]
+        );
 
-  it('should render proctoring info panel correctly for rejected exam', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedProctoredExamInfoJson('rejected')),
-      ],
-    );
-    this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
-      el: $('.proctoring-info-panel'),
-      model: new LearnerOnboardingModel(),
+        this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
+            el: $('.proctoring-info-panel'),
+            model: new LearnerOnboardingModel()
+        });
+        this.server.respond();
+        this.server.respond();
+        expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
+            .toContain('Verified');
     });
-    this.server.respond();
-    this.server.respond();
-    expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
-      .toEqual('5px solid rgb(178, 6, 16)');
-    expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
-      .toContain('Rejected');
-    expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
-      .toContain('You must complete the onboarding process');
-    expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
-      .toContain('Complete Onboarding');
-  });
 
-  it('should render proctoring info panel correctly for other course approved', async () => {
-    const expirationDate = new Date();
-    // Set the expiration date 50 days in the future
-    expirationDate.setTime(expirationDate.getTime() + 3456900000);
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedOtherCourseApprovedJson(expirationDate.toString())),
-      ],
-    );
-    this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
-      el: $('.proctoring-info-panel'),
-      model: new LearnerOnboardingModel(),
-    });
-    this.server.respond();
-    this.server.respond();
-    expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
-      .toContain('Approved in Another Course');
-    expect(this.proctored_exam_info.$el.find('.onboarding-status-message').html())
-      .toContain('Your onboarding exam has been approved in another course');
-    expect(this.proctored_exam_info.$el.find('.onboarding-status-detail').html())
-      .toContain('we recommend that you complete');
-    expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
-      .toContain('Complete Onboarding');
-  });
+    it('should not render proctoring info panel for exam with 404 response', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
+            [
+                404,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(errorGettingOnboardingProfile)
+            ]
+        );
 
-  it('should render proctoring info panel when expiring soon', async () => {
-    const expirationDate = new Date();
-    // This message will render if the expiration date is within 28 days
-    // Set the expiration date 10 days in future
-    expirationDate.setTime(expirationDate.getTime() + 864800000);
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedOtherCourseApprovedJson(expirationDate.toString())),
-      ],
-    );
-    this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
-      el: $('.proctoring-info-panel'),
-      model: new LearnerOnboardingModel(),
+        this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
+            el: $('.proctoring-info-panel'),
+            model: new LearnerOnboardingModel()
+        });
+        this.server.respond();
+        this.server.respond();
+        expect(this.proctored_exam_info.$el.find('.proctoring-info-panel').html())
+            .toHaveLength(0);
     });
-    this.server.respond();
-    this.server.respond();
-    expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
-      .toContain('Expiring Soon');
-    expect(this.proctored_exam_info.$el.find('.onboarding-status-message').html())
-      .toContain('However, your onboarding status is expiring soon.');
-    expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
-      .toContain('Complete Onboarding');
-  });
+
+    it('should render proctoring info panel correctly for exam with other status', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedProctoredExamInfoJson('other'))
+            ]
+        );
+
+        this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
+            el: $('.proctoring-info-panel'),
+            model: new LearnerOnboardingModel()
+        });
+        this.server.respond();
+        this.server.respond();
+        expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
+            .toEqual('5px solid rgb(178, 6, 16)');
+        expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
+            .toContain('other');
+        expect(this.proctored_exam_info.$el.find('.onboarding-status-message').text())
+            .toHaveLength(0);
+        expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
+            .toContain('You must complete the onboarding process');
+        expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
+            .toContain('Complete Onboarding');
+    });
+
+    it('should render proctoring info panel correctly for exam with empty string status', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedProctoredExamInfoJson(''))
+            ]
+        );
+
+        this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
+            el: $('.proctoring-info-panel'),
+            model: new LearnerOnboardingModel()
+        });
+        this.server.respond();
+        this.server.respond();
+        expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
+            .toEqual('5px solid rgb(178, 6, 16)');
+        expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
+            .toContain('Not Started');
+        expect(this.proctored_exam_info.$el.find('.onboarding-status-message').text())
+            .toHaveLength(0);
+        expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
+            .toContain('You must complete the onboarding process');
+        expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
+            .toContain('Complete Onboarding');
+    });
+
+    it('should render proctoring info panel correctly for exam that has yet to be released', function() {
+        var tomorrow = new Date();
+        tomorrow.setDate(new Date().getDate() + 1);
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedProctoredExamInfoJson('', tomorrow))
+            ]
+        );
+
+        this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
+            el: $('.proctoring-info-panel'),
+            model: new LearnerOnboardingModel()
+        });
+        this.server.respond();
+        this.server.respond();
+        expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
+            .toEqual('5px solid rgb(178, 6, 16)');
+        expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
+            .toContain('Not Started');
+        expect(this.proctored_exam_info.$el.find('.onboarding-status-message').text())
+            .toHaveLength(0);
+        expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
+            .toContain('You must complete the onboarding process');
+        expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
+            .toContain('Onboarding Opens ' + tomorrow.toLocaleDateString());
+    });
+
+    it('should render proctoring info panel correctly for past due exam', function() {
+        var twoDaysAgo = new Date();
+        var data = {
+            onboarding_status: status,
+            onboarding_link: null,
+            onboarding_release_date: twoDaysAgo,
+            expiration_date: null,
+            onboarding_past_due: true
+        };
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(data)
+            ]
+        );
+
+        this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
+            el: $('.proctoring-info-panel'),
+            model: new LearnerOnboardingModel()
+        });
+        this.server.respond();
+        this.server.respond();
+        expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
+            .toEqual('5px solid rgb(178, 6, 16)');
+        expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
+            .toContain('Not Started');
+        expect(this.proctored_exam_info.$el.find('.onboarding-status-message').text())
+            .toHaveLength(0);
+        expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
+            .toContain('You must complete the onboarding process');
+        expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
+            .toContain('Onboarding Past Due');
+    });
+
+    it('should render proctoring info panel correctly for created exam', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedProctoredExamInfoJson('created'))
+            ]
+        );
+
+        this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
+            el: $('.proctoring-info-panel'),
+            model: new LearnerOnboardingModel()
+        });
+        this.server.respond();
+        this.server.respond();
+        expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
+            .toEqual('5px solid rgb(178, 6, 16)');
+        expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
+            .toContain('Not Started');
+        expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
+            .toContain('You must complete the onboarding process');
+        expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
+            .toContain('Complete Onboarding');
+    });
+
+    it('should render proctoring info panel correctly for started exam', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedProctoredExamInfoJson('started'))
+            ]
+        );
+
+        this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
+            el: $('.proctoring-info-panel'),
+            model: new LearnerOnboardingModel()
+        });
+        this.server.respond();
+        this.server.respond();
+        expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
+            .toEqual('5px solid rgb(178, 6, 16)');
+        expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
+            .toContain('Started');
+        expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
+            .toContain('You must complete the onboarding process');
+        expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
+            .toContain('Complete Onboarding');
+    });
+
+    it('should render proctoring info panel correctly for submitted onboarding exam', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedProctoredExamInfoJson('submitted'))
+            ]
+        );
+        this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
+            el: $('.proctoring-info-panel'),
+            model: new LearnerOnboardingModel()
+        });
+        this.server.respond();
+        this.server.respond();
+        expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
+            .toEqual('5px solid rgb(13, 78, 108)');
+        expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
+            .toContain('Submitted');
+        expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
+            .toContain('Your submitted profile is in review.');
+        expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
+            .not.toContain('Complete Onboarding');
+    });
+
+    it('should render proctoring info panel correctly for second_review_required exam', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedProctoredExamInfoJson('second_review_required'))
+            ]
+        );
+        this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
+            el: $('.proctoring-info-panel'),
+            model: new LearnerOnboardingModel()
+        });
+        this.server.respond();
+        this.server.respond();
+        expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
+            .toEqual('5px solid rgb(13, 78, 108)');
+        expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
+            .toContain('Submitted');
+        expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
+            .toContain('Your submitted profile is in review.');
+        expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
+            .not.toContain('Complete Onboarding');
+    });
+
+    it('should render proctoring info panel correctly for verified exam', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedProctoredExamInfoJson('verified'))
+            ]
+        );
+        this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
+            el: $('.proctoring-info-panel'),
+            model: new LearnerOnboardingModel()
+        });
+        this.server.respond();
+        this.server.respond();
+        expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
+            .toEqual('5px solid rgb(0, 129, 0)');
+        expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
+            .toContain('Verified');
+        expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
+            .not.toContain('You must complete the onboarding process');
+        expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
+            .not.toContain('Complete Onboarding');
+    });
+
+    it('should render proctoring info panel correctly for rejected exam', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedProctoredExamInfoJson('rejected'))
+            ]
+        );
+        this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
+            el: $('.proctoring-info-panel'),
+            model: new LearnerOnboardingModel()
+        });
+        this.server.respond();
+        this.server.respond();
+        expect(this.proctored_exam_info.$el.find('.proctoring-info').css('border-top'))
+            .toEqual('5px solid rgb(178, 6, 16)');
+        expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
+            .toContain('Rejected');
+        expect(this.proctored_exam_info.$el.find('.onboarding-reminder').html())
+            .toContain('You must complete the onboarding process');
+        expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
+            .toContain('Complete Onboarding');
+    });
+
+    it('should render proctoring info panel correctly for other course approved', function() {
+        var expirationDate = new Date();
+        // Set the expiration date 50 days in the future
+        expirationDate.setTime(expirationDate.getTime() + 3456900000);
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedOtherCourseApprovedJson(expirationDate.toString()))
+            ]
+        );
+        this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
+            el: $('.proctoring-info-panel'),
+            model: new LearnerOnboardingModel()
+        });
+        this.server.respond();
+        this.server.respond();
+        expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
+            .toContain('Approved in Another Course');
+        expect(this.proctored_exam_info.$el.find('.onboarding-status-message').html())
+            .toContain('Your onboarding exam has been approved in another course');
+        expect(this.proctored_exam_info.$el.find('.onboarding-status-detail').html())
+            .toContain('we recommend that you complete');
+        expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
+            .toContain('Complete Onboarding');
+    });
+
+    it('should render proctoring info panel when expiring soon', function() {
+        var expirationDate = new Date();
+        // This message will render if the expiration date is within 28 days
+        // Set the expiration date 10 days in future
+        expirationDate.setTime(expirationDate.getTime() + 864800000);
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedOtherCourseApprovedJson(expirationDate.toString()))
+            ]
+        );
+        this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
+            el: $('.proctoring-info-panel'),
+            model: new LearnerOnboardingModel()
+        });
+        this.server.respond();
+        this.server.respond();
+        expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
+            .toContain('Expiring Soon');
+        expect(this.proctored_exam_info.$el.find('.onboarding-status-message').html())
+            .toContain('However, your onboarding status is expiring soon.');
+        expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
+            .toContain('Complete Onboarding');
+    });
 });

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_onboarding_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_onboarding_spec.js
@@ -1,486 +1,472 @@
-describe('ProctoredExamOnboardingView', () => {
-  'use strict';
+describe('ProctoredExamOnboardingView', function() {
+    'use strict';
 
-  let html = '';
-  const expectedOnboardingDataJson = [{
-    count: 4,
-    previous: null,
-    next: null,
-    num_pages: 1,
-    use_onboarding_profile_api: false,
-    results: [
-      {
-        username: 'testuser1',
-        enrollment_mode: 'verified',
-        status: 'not_started',
-        modified: null,
-      },
-      {
-        username: 'testuser2',
-        enrollment_mode: 'verified',
-        status: 'verified',
-        modified: '2021-01-28T17:59:19.913336Z',
-      },
-      {
-        username: 'testuser3',
-        enrollment_mode: 'masters',
-        status: 'submitted',
-        modified: '2021-01-28T17:46:05.316349Z',
-      },
-      {
-        username: 'testuser4',
-        enrollment_mode: 'executive-education',
-        status: 'other_course_approved',
-        modified: '2021-01-27T17:46:05.316349Z',
-      },
-    ],
-  }];
+    var html = '';
+    var expectedOnboardingDataJson = [{
+        count: 4,
+        previous: null,
+        next: null,
+        num_pages: 1,
+        use_onboarding_profile_api: false,
+        results: [
+            {
+                username: 'testuser1',
+                enrollment_mode: 'verified',
+                status: 'not_started',
+                modified: null
+            },
+            {
+                username: 'testuser2',
+                enrollment_mode: 'verified',
+                status: 'verified',
+                modified: '2021-01-28T17:59:19.913336Z'
+            },
+            {
+                username: 'testuser3',
+                enrollment_mode: 'masters',
+                status: 'submitted',
+                modified: '2021-01-28T17:46:05.316349Z'
+            },
+            {
+                username: 'testuser4',
+                enrollment_mode: 'executive-education',
+                status: 'other_course_approved',
+                modified: '2021-01-27T17:46:05.316349Z'
+            }
+        ]
+    }];
 
-  const noDataJson = [{
-    count: 0,
-    previous: null,
-    next: null,
-    num_pages: 1,
-    results: [],
-    use_onboarding_profile_api: false,
-  }];
+    var noDataJson = [{
+        count: 0,
+        previous: null,
+        next: null,
+        num_pages: 1,
+        results: [],
+        use_onboarding_profile_api: false
+    }];
 
-  beforeEach(() => {
-    html = '<div class="wrapper-content wrapper">'
-        + '<h3 class="error-response" id="error-response"></h3>'
-        + '<% var isOnboardingItems = onboardingItems.length !== 0 %>'
-        + '<div class="content onboarding-status-content">'
-        + '<div class="top-header">'
-        + '<div class="search-onboarding">'
-        + '<input type="text" id="search_onboarding_id" placeholder="e.g johndoe or john.doe@gmail.com"'
-        + '<% if (inSearchMode) { %>'
-        + 'value="<%= searchText %>"'
-        + '<%} %>'
-        + '/>'
-        + '<span class="search">'
-        + '<span class="icon fa fa-search" id="onboarding-search-indicator" aria-hidden="true"></span>'
-        + '<div aria-live="polite" aria-relevant="all">'
-        + '<div id="onboarding-loading-indicator" class="hidden">'
-        + '<span class="icon fa fa-spinner fa-pulse" aria-hidden="true"></span>'
-        + '<span class="sr"><%- gettext("Loading") %></span>'
-        + '</div>'
-        + '</div>'
-        + '</span>'
-        + '<span class="clear-search"><span class="icon fa fa-remove" aria-hidden="true"></span></span>'
-        + '</div>'
-        + '<ul class="pagination">'
-        + '<% if (!previousPage){ %>'
-        + '<li class="disabled">'
-        + '<a aria-label="Previous">'
-        + '<span aria-hidden="true">&laquo;</span>'
-        + '</a>'
-        + '</li>'
-        + '<% } else { %>'
-        + '<li>'
-        + '<a class="target-link " data-page-number="<%= currentPage - 1 %>"'
-        + 'href="#" aria-label="Previous">'
-        + '<span aria-hidden="true">&laquo;</span>'
-        + '</a>'
-        + '</li>'
-        + '<% }%>'
-        + '<% for(var n = startPage; n <= endPage; n++) { %>'
-        + '<li>'
-        + '<a class="target-link <% if (currentPage == n){ %> active <% } %>" data-page-number="<%= n %>" href="#">'
-        + '<%= n %>'
-        + '</a>'
-        + '</li>'
-        + '<% } %>'
-        + '<% if (!nextPage){ %>'
-        + '<li class="disabled">'
-        + '<a aria-label="Next">'
-        + '<span aria-hidden="true">&raquo;</span>'
-        + '</a>'
-        + '</li>'
-        + '<% } else { %>'
-        + '<li>'
-        + '<a class="target-link" href="#" aria-label="Next" data-page-number="<%= currentPage + 1 %>"'
-        + '>'
-        + '<span aria-hidden="true">&raquo;</span>'
-        + '</a>'
-        + '</li>'
-        + '<% }%>'
-        + '</ul>'
-        + '<div class="clearfix"></div>'
-        + '</div>'
-        + '<form class="filter-form">'
-        + '<ul class="status-checkboxes">'
-        + '<% _.each(onboardingStatuses, function(status){ %>'
-        + '<li>'
-        + '<input type="checkbox" id="<%= status %>" value="<%= status %>" '
-        + '<% if (filters.includes(status)) { %>checked="true"<% } %>>'
-        + '<label for="<%= status %>">'
-        + '<%- interpolate(gettext(" %(onboardingStatus)s "), '
-        + '{ onboardingStatus: getReadableString(status) }, true) %>'
-        + '</label>'
-        + '</li>'
-        + '<% }); %>'
-        + '</ul>'
-        + '<button type="submit">Apply Filters</button>'
-        + '<button type="button" class="clear-filters" aria-hidden="true">'
-        + '<span class="icon fa fa-remove"></span>'
-        + '</button>'
-        + '</form>'
-        + '<table class="onboarding-status-table">'
-        + '<thead>'
-        + '<tr class="onboarding-status-headings">'
-        + '<th class="username-heading"><%- gettext("Username") %></th>'
-        + '<th class="enrollment-mode-heading"><%- gettext("Enrollment Mode") %></th>'
-        + '<th class="onboarding-status-heading"><%- gettext("Onboarding Status") %></th>'
-        + '<th class="last-updated-heading"><%- gettext("Last Modified") %> </th>'
-        + '</tr>'
-        + '</thead>'
-        + '<% if (isOnboardingItems) { %>'
-        + '<tbody>'
-        + '<% _.each(onboardingItems, function(item){ %>'
-        + '<tr class="onboarding-items">'
-        + '<td>'
-        + '<%- interpolate(gettext(" %(username)s "), { username: item.username }, true) %>'
-        + '</td>'
-        + '<td>'
-        + '<%- interpolate(gettext(" %(enrollmentMode)s "), '
-        + '{ enrollmentMode: getReadableString(item.enrollment_mode) }, true) %>'
-        + '</td>'
-        + '<td>'
-        + '<%- interpolate(gettext(" %(onboardingStatus)s "), '
-        + '{ onboardingStatus: getReadableString(item.status) }, true) %>'
-        + '</td>'
-        + '<td><%= getDateFormat(item.modified) %></td>'
-        + '</tr>'
-        + '<% }); %>'
-        + '</tbody>'
-        + '<% } %>'
-        + '</table>'
-        + '<% if (!isOnboardingItems) { %>'
-        + '<p class="no-onboarding-data">'
-        + 'There are no learners <% if (filters.length > 0 || searchText) { %>'
-        + 'who fit this criteria.'
-        + '<%} else {%>'
-        + 'in this course who require onboarding exams.'
-        + '<%} %>'
-        + '</p>'
-        + '<% } %>'
-        + '</div>'
-        + '</div>';
-    this.server = sinon.fakeServer.create();
-    this.server.autoRespond = true;
-    setFixtures('<div class="student-onboarding-status-container" data-course-id="test_course_id"></div>');
+    beforeEach(function() {
+        html = '<div class="wrapper-content wrapper">' +
+        '<h3 class="error-response" id="error-response"></h3>' +
+        '<% var isOnboardingItems = onboardingItems.length !== 0 %>' +
+        '<div class="content onboarding-status-content">' +
+        '<div class="top-header">' +
+        '<div class="search-onboarding">' +
+        '<input type="text" id="search_onboarding_id" placeholder="e.g johndoe or john.doe@gmail.com"' +
+        '<% if (inSearchMode) { %>' +
+        'value="<%= searchText %>"' +
+        '<%} %>' +
+        '/>' +
+        '<span class="search">' +
+        '<span class="icon fa fa-search" id="onboarding-search-indicator" aria-hidden="true"></span>' +
+        '<div aria-live="polite" aria-relevant="all">' +
+        '<div id="onboarding-loading-indicator" class="hidden">' +
+        '<span class="icon fa fa-spinner fa-pulse" aria-hidden="true"></span>' +
+        '<span class="sr"><%- gettext("Loading") %></span>' +
+        '</div>' +
+        '</div>' +
+        '</span>' +
+        '<span class="clear-search"><span class="icon fa fa-remove" aria-hidden="true"></span></span>' +
+        '</div>' +
+        '<ul class="pagination">' +
+        '<% if (!previousPage){ %>' +
+        '<li class="disabled">' +
+        '<a aria-label="Previous">' +
+        '<span aria-hidden="true">&laquo;</span>' +
+        '</a>' +
+        '</li>' +
+        '<% } else { %>' +
+        '<li>' +
+        '<a class="target-link " data-page-number="<%= currentPage - 1 %>"' +
+        'href="#" aria-label="Previous">' +
+        '<span aria-hidden="true">&laquo;</span>' +
+        '</a>' +
+        '</li>' +
+        '<% }%>' +
+        '<% for(var n = startPage; n <= endPage; n++) { %>' +
+        '<li>' +
+        '<a class="target-link <% if (currentPage == n){ %> active <% } %>" data-page-number="<%= n %>" href="#">' +
+        '<%= n %>' +
+        '</a>' +
+        '</li>' +
+        '<% } %>' +
+        '<% if (!nextPage){ %>' +
+        '<li class="disabled">' +
+        '<a aria-label="Next">' +
+        '<span aria-hidden="true">&raquo;</span>' +
+        '</a>' +
+        '</li>' +
+        '<% } else { %>' +
+        '<li>' +
+        '<a class="target-link" href="#" aria-label="Next" data-page-number="<%= currentPage + 1 %>"' +
+        '>' +
+        '<span aria-hidden="true">&raquo;</span>' +
+        '</a>' +
+        '</li>' +
+        '<% }%>' +
+        '</ul>' +
+        '<div class="clearfix"></div>' +
+        '</div>' +
+        '<form class="filter-form">' +
+        '<ul class="status-checkboxes">' +
+        '<% _.each(onboardingStatuses, function(status){ %>' +
+        '<li>' +
+        '<input type="checkbox" id="<%= status %>" value="<%= status %>" ' +
+        '<% if (filters.includes(status)) { %>checked="true"<% } %>>' +
+        '<label for="<%= status %>">' +
+        '<%- interpolate(gettext(" %(onboardingStatus)s "), ' +
+        '{ onboardingStatus: getReadableString(status) }, true) %>' +
+        '</label>' +
+        '</li>' +
+        '<% }); %>' +
+        '</ul>' +
+        '<button type="submit">Apply Filters</button>' +
+        '<button type="button" class="clear-filters" aria-hidden="true">' +
+        '<span class="icon fa fa-remove"></span>' +
+        '</button>' +
+        '</form>' +
+        '<table class="onboarding-status-table">' +
+        '<thead>' +
+        '<tr class="onboarding-status-headings">' +
+        '<th class="username-heading"><%- gettext("Username") %></th>' +
+        '<th class="enrollment-mode-heading"><%- gettext("Enrollment Mode") %></th>' +
+        '<th class="onboarding-status-heading"><%- gettext("Onboarding Status") %></th>' +
+        '<th class="last-updated-heading"><%- gettext("Last Modified") %> </th>' +
+        '</tr>' +
+        '</thead>' +
+        '<% if (isOnboardingItems) { %>' +
+        '<tbody>' +
+        '<% _.each(onboardingItems, function(item){ %>' +
+        '<tr class="onboarding-items">' +
+        '<td>' +
+        '<%- interpolate(gettext(" %(username)s "), { username: item.username }, true) %>' +
+        '</td>' +
+        '<td>' +
+        '<%- interpolate(gettext(" %(enrollmentMode)s "), ' +
+        '{ enrollmentMode: getReadableString(item.enrollment_mode) }, true) %>' +
+        '</td>' +
+        '<td>' +
+        '<%- interpolate(gettext(" %(onboardingStatus)s "), ' +
+        '{ onboardingStatus: getReadableString(item.status) }, true) %>' +
+        '</td>' +
+        '<td><%= getDateFormat(item.modified) %></td>' +
+        '</tr>' +
+        '<% }); %>' +
+        '</tbody>' +
+        '<% } %>' +
+        '</table>' +
+        '<% if (!isOnboardingItems) { %>' +
+        '<p class="no-onboarding-data">' +
+        'There are no learners <% if (filters.length > 0 || searchText) { %>' +
+        'who fit this criteria.' +
+        '<%} else {%>' +
+        'in this course who require onboarding exams.' +
+        '<%} %>' +
+        '</p>' +
+        '<% } %>' +
+        '</div>' +
+        '</div>';
+        this.server = sinon.fakeServer.create();
+        this.server.autoRespond = true;
+        setFixtures('<div class="student-onboarding-status-container" data-course-id="test_course_id"></div>');
 
-    // load the underscore template response before calling the onboarding status view.
-    this.server.respondWith(
-      'GET',
-      '/static/proctoring/templates/student-onboarding-status.underscore',
-      [
-        200,
-        { 'Content-Type': 'text/html' },
-        html,
-      ],
-    );
-  });
+        // load the underscore template response before calling the onboarding status view.
+        this.server.respondWith('GET', '/static/proctoring/templates/student-onboarding-status.underscore',
+            [
+                200,
+                {'Content-Type': 'text/html'},
+                html
+            ]
+        );
+    });
 
-  afterEach(async () => {
-    this.server.restore();
-  });
+    afterEach(function() {
+        this.server.restore();
+    });
 
-  it('should render the proctored exam onboarding view properly', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedOnboardingDataJson),
-      ],
-    );
+    it('should render the proctored exam onboarding view properly', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedOnboardingDataJson)
+            ]
+        );
 
-    this.proctored_exam_onboarding_view = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView();
+        this.proctored_exam_onboarding_view = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView();
 
-    this.server.respond();
-    this.server.respond();
+        this.server.respond();
+        this.server.respond();
 
-    expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').length)
-      .toEqual(4);
-    expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').first().html())
-      .toContain('testuser1');
-    expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').first().html())
-      .toContain('Verified');
-    expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').first().html())
-      .toContain('Not Started');
-    expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').first().html())
-      .toContain('---');
-    expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').last().html())
-      .toContain('testuser4');
-    expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').last().html())
-      .toContain('Executive Education');
-  });
+        expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').length)
+            .toEqual(4);
+        expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').first().html())
+            .toContain('testuser1');
+        expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').first().html())
+            .toContain('Verified');
+        expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').first().html())
+            .toContain('Not Started');
+        expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').first().html())
+            .toContain('---');
+        expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').last().html())
+            .toContain('testuser4');
+        expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').last().html())
+            .toContain('Executive Education');
+    });
 
-  it('renders correctly with no data', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(noDataJson),
-      ],
-    );
+    it('renders correctly with no data', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(noDataJson)
+            ]
+        );
 
-    this.proctored_exam_onboarding_view = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView();
+        this.proctored_exam_onboarding_view = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView();
 
-    this.server.respond();
-    this.server.respond();
+        this.server.respond();
+        this.server.respond();
 
-    expect(this.proctored_exam_onboarding_view.$el.find('.no-onboarding-data').html())
-      .toContain('There are no learners');
-  });
+        expect(this.proctored_exam_onboarding_view.$el.find('.no-onboarding-data').html())
+            .toContain('There are no learners');
+    });
 
-  it('filters onboarding statuses', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedOnboardingDataJson),
-      ],
-    );
-    this.proctored_exam_onboarding_view = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView();
+    it('filters onboarding statuses', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedOnboardingDataJson)
+            ]
+        );
+        this.proctored_exam_onboarding_view = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView();
 
-    this.server.respond();
-    this.server.respond();
+        this.server.respond();
+        this.server.respond();
 
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id?page=1&statuses=submitted,verified',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedOnboardingDataJson),
-      ],
-    );
+        this.server.respondWith('GET',
+            '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id?page=1&statuses=submitted,verified',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedOnboardingDataJson)
+            ]
+        );
 
-    spyOnEvent('.filter-form', 'submit');
-    $('.status-checkboxes > li > input#submitted').click();
-    $('.status-checkboxes > li > input#verified').click();
-    $('.filter-form').submit();
+        spyOnEvent('.filter-form', 'submit');
+        $('.status-checkboxes > li > input#submitted').click();
+        $('.status-checkboxes > li > input#verified').click();
+        $('.filter-form').submit();
 
-    this.server.respond();
+        this.server.respond();
 
-    expect(this.proctored_exam_onboarding_view.filters).toEqual(['submitted', 'verified']);
-    expect(this.proctored_exam_onboarding_view.collection.url).toEqual(
-      '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id?page=1&statuses=submitted,verified',
-    );
+        expect(this.proctored_exam_onboarding_view.filters).toEqual(['submitted', 'verified']);
+        expect(this.proctored_exam_onboarding_view.collection.url).toEqual(
+            '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id?page=1&statuses=submitted,verified'
+        );
 
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id?page=1',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedOnboardingDataJson),
-      ],
-    );
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id?page=1',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedOnboardingDataJson)
+            ]
+        );
 
-    spyOnEvent('.clear-filters', 'click');
-    $('.clear-filters').click();
+        spyOnEvent('.clear-filters', 'click');
+        $('.clear-filters').click();
 
-    expect(this.proctored_exam_onboarding_view.filters).toEqual([]);
-    expect(this.proctored_exam_onboarding_view.collection.url).toEqual(
-      '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id?page=1',
-    );
-  });
+        expect(this.proctored_exam_onboarding_view.filters).toEqual([]);
+        expect(this.proctored_exam_onboarding_view.collection.url).toEqual(
+            '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id?page=1'
+        );
+    });
 
-  it('Renders approved in another course correctly', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedOnboardingDataJson),
-      ],
-    );
+    it('Renders approved in another course correctly', function() {
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedOnboardingDataJson)
+            ]
+        );
 
-    this.proctored_exam_onboarding_view = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView();
+        this.proctored_exam_onboarding_view = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView();
 
-    this.server.respond();
-    this.server.respond();
+        this.server.respond();
+        this.server.respond();
 
-    expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').length)
-      .toEqual(4);
-    expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').last().html())
-      .toContain('testuser4');
-    expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').last().html())
-      .toContain('Approved in Another Course');
-  });
+        expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').length)
+            .toEqual(4);
+        expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').last().html())
+            .toContain('testuser4');
+        expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').last().html())
+            .toContain('Approved in Another Course');
+    });
 
-  it('should search for onboarding attempts', async () => {
-    const searchText = 'badSearch';
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(expectedOnboardingDataJson),
-      ],
-    );
-    this.proctored_exam_onboarding_view = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView();
+    it('should search for onboarding attempts', function() {
+        var searchText = 'badSearch';
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedOnboardingDataJson)
+            ]
+        );
+        this.proctored_exam_onboarding_view = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView();
 
-    // Process all requests so far
-    this.server.respond();
-    this.server.respond();
+        // Process all requests so far
+        this.server.respond();
+        this.server.respond();
 
-    expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').html())
-      .toContain('testuser1');
-    expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').html())
-      .toContain('Not Started');
-    expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').html())
-      .toContain('---');
-    expect(this.proctored_exam_onboarding_view.$el.find('#onboarding-search-indicator').hasClass('hidden'))
-      .toEqual(false);
-    expect(this.proctored_exam_onboarding_view.$el.find('#onboarding-loading-indicator').hasClass('hidden'))
-      .toEqual(true);
+        expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').html())
+            .toContain('testuser1');
+        expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').html())
+            .toContain('Not Started');
+        expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-items').html())
+            .toContain('---');
+        expect(this.proctored_exam_onboarding_view.$el.find('#onboarding-search-indicator').hasClass('hidden'))
+            .toEqual(false);
+        expect(this.proctored_exam_onboarding_view.$el.find('#onboarding-loading-indicator').hasClass('hidden'))
+            .toEqual(true);
 
-    $('#search_onboarding_id').val(searchText);
+        $('#search_onboarding_id').val(searchText);
 
-    // search for the proctored exam attempt
-    this.server.respondWith(
-      'GET',
-      `/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id?page=1&text_search=${searchText}`,
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(noDataJson),
-      ],
-    );
+        // search for the proctored exam attempt
+        this.server.respondWith(
+            'GET',
+            '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id?page=1&text_search=' + searchText,
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(noDataJson)
+            ]
+        );
 
-    // trigger the search attempt event.
-    spyOnEvent('.search-onboarding > span.search', 'click');
-    $('.search-onboarding > span.search').trigger('click');
 
-    // check that spinner is visible
-    expect(this.proctored_exam_onboarding_view.$el.find('#onboarding-search-indicator').hasClass('hidden'))
-      .toEqual(true);
-    expect(this.proctored_exam_onboarding_view.$el.find('#onboarding-loading-indicator').hasClass('hidden'))
-      .toEqual(false);
+        // trigger the search attempt event.
+        spyOnEvent('.search-onboarding > span.search', 'click');
+        $('.search-onboarding > span.search').trigger('click');
 
-    // process the search attempt requests.
-    this.server.respond();
+        // check that spinner is visible
+        expect(this.proctored_exam_onboarding_view.$el.find('#onboarding-search-indicator').hasClass('hidden'))
+            .toEqual(true);
+        expect(this.proctored_exam_onboarding_view.$el.find('#onboarding-loading-indicator').hasClass('hidden'))
+            .toEqual(false);
 
-    // check that spinner is hidden again
-    expect(this.proctored_exam_onboarding_view.$el.find('#onboarding-search-indicator').hasClass('hidden'))
-      .toEqual(false);
-    expect(this.proctored_exam_onboarding_view.$el.find('#onboarding-loading-indicator').hasClass('hidden'))
-      .toEqual(true);
-  });
+        // process the search attempt requests.
+        this.server.respond();
 
-  it('Renders correct filters for onboarding API', async () => {
-    setFixtures(
-      '<div class="student-onboarding-status-container"'
-            + 'data-course-id="test_course_id">'
-            + '</div>',
-    );
+        // check that spinner is hidden again
+        expect(this.proctored_exam_onboarding_view.$el.find('#onboarding-search-indicator').hasClass('hidden'))
+            .toEqual(false);
+        expect(this.proctored_exam_onboarding_view.$el.find('#onboarding-loading-indicator').hasClass('hidden'))
+            .toEqual(true);
+    });
 
-    const onboardingData = JSON.parse(JSON.stringify(expectedOnboardingDataJson));
-    onboardingData[0].use_onboarding_profile_api = true;
+    it('Renders correct filters for onboarding API', function() {
+        var onboardingData;
 
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id',
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify(onboardingData),
-      ],
-    );
+        setFixtures(
+            '<div class="student-onboarding-status-container"' +
+            'data-course-id="test_course_id">' +
+            '</div>'
+        );
 
-    this.proctored_exam_onboarding_view = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView();
+        onboardingData = JSON.parse(JSON.stringify(expectedOnboardingDataJson));
+        onboardingData[0].use_onboarding_profile_api = true;
 
-    this.server.respond();
-    this.server.respond();
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(onboardingData)
+            ]
+        );
 
-    expect(this.proctored_exam_onboarding_view.$el.find('.status-checkboxes').html())
-      .toContain('Not Started');
-    expect(this.proctored_exam_onboarding_view.$el.find('.status-checkboxes').html())
-      .toContain('Submitted');
-    expect(this.proctored_exam_onboarding_view.$el.find('.status-checkboxes').html())
-      .toContain('Verified');
-    expect(this.proctored_exam_onboarding_view.$el.find('.status-checkboxes').html())
-      .toContain('Approved in Another Course');
-    expect(this.proctored_exam_onboarding_view.$el.find('.status-checkboxes').html())
-      .toContain('Rejected');
-    expect(this.proctored_exam_onboarding_view.$el.find('.status-checkboxes').html())
-      .not.toContain('Setup Started');
-  });
+        this.proctored_exam_onboarding_view = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView();
 
-  it('renders correctly with 503 response', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id',
-      [
-        503,
-        {
-          'Content-Type': 'application/json',
-        },
-        JSON.stringify({ detail: 'Error message.' }),
-      ],
-    );
+        this.server.respond();
+        this.server.respond();
 
-    this.proctored_exam_onboarding_view = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView();
+        expect(this.proctored_exam_onboarding_view.$el.find('.status-checkboxes').html())
+            .toContain('Not Started');
+        expect(this.proctored_exam_onboarding_view.$el.find('.status-checkboxes').html())
+            .toContain('Submitted');
+        expect(this.proctored_exam_onboarding_view.$el.find('.status-checkboxes').html())
+            .toContain('Verified');
+        expect(this.proctored_exam_onboarding_view.$el.find('.status-checkboxes').html())
+            .toContain('Approved in Another Course');
+        expect(this.proctored_exam_onboarding_view.$el.find('.status-checkboxes').html())
+            .toContain('Rejected');
+        expect(this.proctored_exam_onboarding_view.$el.find('.status-checkboxes').html())
+            .not.toContain('Setup Started');
+    });
 
-    this.server.respond();
-    this.server.respond();
+    it('renders correctly with 503 response', function() {
+        var errorMessage;
 
-    const errorMessage = this.proctored_exam_onboarding_view.$el.find('.error-response');
-    expect(errorMessage.html()).toContain('Error message.');
-    expect(errorMessage).toBeVisible();
-    expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-status-content')).not.toBeVisible();
-  });
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id',
+            [
+                503,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify({detail: 'Error message.'})
+            ]
+        );
 
-  it('renders correctly with non-JSON parseable error message response', async () => {
-    this.server.respondWith(
-      'GET',
-      '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id',
-      [
-        500,
-        {
-          'Content-Type': 'application/json',
-        },
-        '',
-      ],
-    );
+        this.proctored_exam_onboarding_view = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView();
 
-    this.proctored_exam_onboarding_view = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView();
+        this.server.respond();
+        this.server.respond();
 
-    this.server.respond();
-    this.server.respond();
+        errorMessage = this.proctored_exam_onboarding_view.$el.find('.error-response');
+        expect(errorMessage.html()).toContain('Error message.');
+        expect(errorMessage).toBeVisible();
+        expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-status-content')).not.toBeVisible();
+    });
 
-    const errorMessage = this.proctored_exam_onboarding_view.$el.find('.error-response');
-    expect(errorMessage.html()).toContain('An unexpected error occured. Please try again later.');
-    expect(errorMessage).toBeVisible();
-    expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-status-content')).not.toBeVisible();
-  });
+    it('renders correctly with non-JSON parseable error message response', function() {
+        var errorMessage;
+
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id',
+            [
+                500,
+                {
+                    'Content-Type': 'application/json'
+                },
+                ''
+            ]
+        );
+
+        this.proctored_exam_onboarding_view = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView();
+
+        this.server.respond();
+        this.server.respond();
+
+        errorMessage = this.proctored_exam_onboarding_view.$el.find('.error-response');
+        expect(errorMessage.html()).toContain('An unexpected error occured. Please try again later.');
+        expect(errorMessage).toBeVisible();
+        expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-status-content')).not.toBeVisible();
+    });
 });

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_spec.js
@@ -1,253 +1,251 @@
 /* global ProctoredExamModel:false */
-describe('ProctoredExamView', () => {
-  'use strict';
+describe('ProctoredExamView', function() {
+    'use strict';
 
-  beforeEach(() => {
-    this.server = sinon.fakeServer.create();
-    jasmine.clock().install();
-    setFixtures(
-      '<div class="proctored_exam_status">'
-            + '<script type="text/template" id="proctored-exam-status-tpl">'
-            + '<div class="exam-timer">'
-            + '<div class="exam-text js-exam-text" data-show-long="true">'
-            + 'You are taking "'
-            + '<a href="<%= exam_url_path %>"> <%= exam_display_name %> </a>'
-            + '" as a proctored exam.'
-            + '<span class="js-exam-additional-text" aria-hidden="false">'
-            + 'The timer on the right shows the time remaining in the exam'
-            + '</span>'
-            + '<button class="js-toggle-show-more" data-show-more-text="Show More" data-show-less-text="Show Less">'
-            + 'Show Less'
-            + '</button>'
-            + '<span class="exam-timer-clock"> <h3 id="time_remaining_id">'
-            + '<b> </b> </h3>'
-            + '<button role="button" id="toggle_timer" aria-label="Hide Timer" aria-pressed="false">'
-            + '<i class="fa fa-eye-slash" aria-hidden="true"></i></button>'
-            + '</span>'
-            + '</div>'
-            + '</script>'
-            + '</div>',
-    );
-    this.model = new ProctoredExamModel({
-      in_timed_exam: true,
-      is_proctored: true,
-      exam_display_name: 'Midterm',
-      taking_as_proctored: true,
-      exam_url_path: '/test_url',
-      time_remaining_seconds: 45, // 2 * 60 + 15,
-      low_threshold_sec: 30,
-      attempt_id: 2,
-      critically_low_threshold_sec: 15,
-      lastFetched: new Date(),
-    });
-
-    this.proctored_exam_view = new edx.courseware.proctored_exam.ProctoredExamView(
-      {
-        model: this.model,
-        el: $('.proctored_exam_status'),
-        proctored_template: '#proctored-exam-status-tpl',
-      },
-    );
-    this.proctored_exam_view.render();
-  });
-
-  afterEach(async () => {
-    this.server.restore();
-    jasmine.clock().uninstall();
-  });
-
-  it('renders items correctly', async () => {
-    expect(this.proctored_exam_view.$el.find('a')).toHaveAttr('href', this.model.get('exam_url_path'));
-    expect(this.proctored_exam_view.$el.find('a')).toContainHtml(this.model.get('exam_display_name'));
-  });
-  it('changes behavior when clock time decreases low threshold', async () => {
-    this.proctored_exam_view.secondsLeft = 25;
-    this.proctored_exam_view.render();
-    expect(this.proctored_exam_view.$el.find('div.exam-timer')).toHaveClass('low-time warning');
-  });
-  it('changes behavior when clock time decreases critically low threshold', async () => {
-    this.proctored_exam_view.secondsLeft = 5;
-    this.proctored_exam_view.render();
-    expect(this.proctored_exam_view.$el.find('div.exam-timer')).toHaveClass('low-time critical');
-  });
-  it('toggles timer visibility correctly', async () => {
-    const button = this.proctored_exam_view.$el.find('#toggle_timer');
-    const timer = this.proctored_exam_view.$el.find('h3#time_remaining_id b');
-    expect(timer).not.toHaveClass('timer-hidden');
-    button.click();
-    expect(timer).toHaveClass('timer-hidden');
-    button.click();
-    expect(timer).not.toHaveClass('timer-hidden');
-  });
-  it('toggles long text visibility on show more/less', async () => {
-    const button = this.proctored_exam_view.$el.find('.js-toggle-show-more');
-    const textToToggle = this.proctored_exam_view.$el.find('.js-exam-additional-text');
-    const initiallyHidden = textToToggle.hasClass('hidden');
-    button.click();
-    expect(textToToggle.hasClass('hidden')).not.toBe(initiallyHidden);
-    button.click();
-    expect(textToToggle.hasClass('hidden')).toBe(initiallyHidden);
-  });
-  it('toggles initial visibility according to whether media query is satisfied', async () => {
-    const { matchMedia } = window;
-    const fakeMediaQuery = sinon.stub().returns({ matches: true });
-    this.proctored_exam_view.first_time_rendering = true;
-    window.matchMedia = fakeMediaQuery;
-    this.proctored_exam_view.render();
-    expect(this.proctored_exam_view.$el.find('.js-exam-additional-text')).not.toHaveClass('hidden');
-    window.matchMedia = matchMedia;
-  });
-  it('reload the page when the exam time finishes', async () => {
-    // Stubbed out so tests don't reload endlessly when debugging in the browser
-    spyOn(this.proctored_exam_view, 'reloadPage');
-    this.proctored_exam_view.secondsLeft = -10;
-    edx.courseware.proctored_exam.endExam = jasmine.createSpy('endExam').and.returnValue(Promise.resolve());
-    this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
-    expect(edx.courseware.proctored_exam.endExam).toHaveBeenCalled();
-    delete edx.courseware.proctored_exam.endExam;
-  });
-  it('resets the remaining exam time after the ajax response', async () => {
-    this.server.respondWith(
-      'GET',
-      `/api/edx_proctoring/v1/proctored_exam/attempt/${
-        this.proctored_exam_view.model.get('attempt_id')
-      }?sourceid=in_exam&proctored=true`,
-      [
-        200,
-        { 'Content-Type': 'application/json' },
-        JSON.stringify({
-          time_remaining_seconds: -10,
-        }),
-      ],
-    );
-    this.proctored_exam_view.timerTick = this.proctored_exam_view.poll_interval - 1; // to make the ajax call.
-    spyOn(this.proctored_exam_view, 'reloadPage');
-    edx.courseware.proctored_exam.endExam = jasmine.createSpy('endExam').and.returnValue(Promise.resolve());
-    this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
-    this.server.respond();
-    this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
-    expect(edx.courseware.proctored_exam.endExam).toHaveBeenCalled();
-  });
-  it('reloads the page after unauthorized ajax ping', async () => {
-    const reloadPage = spyOn(this.proctored_exam_view, 'reloadPage');
-    this.server.respondWith(
-      'GET',
-      `/api/edx_proctoring/v1/proctored_exam/attempt/${
-        this.proctored_exam_view.model.get('attempt_id')
-      }?sourceid=in_exam&proctored=true`,
-      [
-        403,
-        { 'Content-Type': 'application/json' },
-        JSON.stringify({
-          message: 'Attempted to access attempt_id but user does not have access',
-        }),
-      ],
-    );
-    this.proctored_exam_view.timerTick = this.proctored_exam_view.poll_interval - 1; // to make the ajax call.
-    this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
-    this.server.respond();
-    this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
-    expect(reloadPage).toHaveBeenCalled();
-  });
-  it('reloads the page after error state ajax ping', async () => {
-    const reloadPage = spyOn(this.proctored_exam_view, 'reloadPage');
-    this.server.respondWith(
-      'GET',
-      `/api/edx_proctoring/v1/proctored_exam/attempt/${
-        this.proctored_exam_view.model.get('attempt_id')
-      }?sourceid=in_exam&proctored=true`,
-      [
-        200,
-        { 'Content-Type': 'application/json' },
-        JSON.stringify({
-          status: 'error',
-        }),
-      ],
-    );
-    this.proctored_exam_view.timerTick = this.proctored_exam_view.poll_interval - 1; // to make the ajax call.
-    this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
-    this.server.respond();
-    this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
-    expect(reloadPage).toHaveBeenCalled();
-  });
-  it('does not reload the page on general 400 errors', async () => {
-    const reloadPage = spyOn(this.proctored_exam_view, 'reloadPage');
-    this.server.respondWith(
-      'GET',
-      `/api/edx_proctoring/v1/proctored_exam/attempt/${
-        this.proctored_exam_view.model.get('attempt_id')
-      }?sourceid=in_exam&proctored=true`,
-      [
-        400,
-        { 'Content-Type': 'application/json' },
-        JSON.stringify({
-          message: 'Attempted to access attempt_id but it does not exist',
-        }),
-      ],
-    );
-    this.proctored_exam_view.timerTick = this.proctored_exam_view.poll_interval - 1; // to make the ajax call.
-    this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
-    this.server.respond();
-    this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
-    expect(reloadPage).not.toHaveBeenCalled();
-  });
-  it('calls external js global function on off-beat', async () => {
-    this.proctored_exam_view.model.set('ping_interval', 60);
-    edx.courseware.proctored_exam.pingApplication = jasmine.createSpy().and.returnValue(Promise.resolve());
-    edx.courseware.proctored_exam.configuredWorkerURL = 'nonempty/string.html';
-    this.proctored_exam_view.timerTick = (this.proctored_exam_view.model.get('ping_interval') / 2) - 1;
-    this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
-    expect(edx.courseware.proctored_exam.pingApplication).toHaveBeenCalled();
-    delete edx.courseware.proctored_exam.pingApplication;
-    delete edx.courseware.proctored_exam.configuredWorkerURL;
-  });
-  it('reloads the page after failure-state ajax call', async (done) => {
-    const reloadPage = spyOn(this.proctored_exam_view, 'reloadPage');
-    this.server.respondWith(
-      (request) => {
-        request.respond(
-          200,
-          { 'Content-Type': 'application/json' },
-          '{"exam_attempt_id": "abcde"}',
+    beforeEach(function() {
+        this.server = sinon.fakeServer.create();
+        jasmine.clock().install();
+        setFixtures(
+            '<div class="proctored_exam_status">' +
+            '<script type="text/template" id="proctored-exam-status-tpl">' +
+            '<div class="exam-timer">' +
+            '<div class="exam-text js-exam-text" data-show-long="true">' +
+            'You are taking "' +
+            '<a href="<%= exam_url_path %>"> <%= exam_display_name %> </a>' +
+            '" as a proctored exam.' +
+            '<span class="js-exam-additional-text" aria-hidden="false">' +
+            'The timer on the right shows the time remaining in the exam' +
+            '</span>' +
+            '<button class="js-toggle-show-more" data-show-more-text="Show More" data-show-less-text="Show Less">' +
+            'Show Less' +
+            '</button>' +
+            '<span class="exam-timer-clock"> <h3 id="time_remaining_id">' +
+            '<b> </b> </h3>' +
+            '<button role="button" id="toggle_timer" aria-label="Hide Timer" aria-pressed="false">' +
+            '<i class="fa fa-eye-slash" aria-hidden="true"></i></button>' +
+            '</span>' +
+            '</div>' +
+            '</script>' +
+            '</div>'
         );
-      },
-    );
-    this.proctored_exam_view.endExamForFailureState().done(() => {
-      expect(reloadPage).toHaveBeenCalled();
-      done();
-    });
-    this.server.respond();
-  });
-  it(
-    'does not reload the page after failure-state ajax call when server responds with no attempt id',
-    async (done) => {
-      const reloadPage = spyOn(this.proctored_exam_view, 'reloadPage');
-      // this case mimics current behavior of the server when the
-      // proctoring backend is configured to not block the user for a
-      // failed ping.
-      this.server.respondWith(
-        (request) => {
-          request.respond(
-            200,
-            { 'Content-Type': 'application/json' },
-            '{"exam_attempt_id": false}',
-          );
-        },
-      );
-      this.proctored_exam_view.endExamForFailureState().done(() => {
-        expect(reloadPage).not.toHaveBeenCalled();
-        done();
-      });
-      this.server.respond();
-    },
-  );
+        this.model = new ProctoredExamModel({
+            in_timed_exam: true,
+            is_proctored: true,
+            exam_display_name: 'Midterm',
+            taking_as_proctored: true,
+            exam_url_path: '/test_url',
+            time_remaining_seconds: 45, // 2 * 60 + 15,
+            low_threshold_sec: 30,
+            attempt_id: 2,
+            critically_low_threshold_sec: 15,
+            lastFetched: new Date()
+        });
 
-  it('sets global variable when unset', async () => {
-    expect(window.edx.courseware.proctored_exam.configuredWorkerURL).toBeUndefined();
-    this.proctored_exam_view.model.set('desktop_application_js_url', 'nonempty string');
-    expect(window.edx.courseware.proctored_exam.configuredWorkerURL).not.toBeUndefined();
-    this.proctored_exam_view.model.set('desktop_application_js_url', 'another nonempty string');
-    expect(window.edx.courseware.proctored_exam.configuredWorkerURL).toEqual('nonempty string');
-    delete window.edx.courseware.proctored_exam.configuredWorkerURL;
-  });
+        this.proctored_exam_view = new edx.courseware.proctored_exam.ProctoredExamView(
+            {
+                model: this.model,
+                el: $('.proctored_exam_status'),
+                proctored_template: '#proctored-exam-status-tpl'
+            }
+        );
+        this.proctored_exam_view.render();
+    });
+
+    afterEach(function() {
+        this.server.restore();
+        jasmine.clock().uninstall();
+    });
+
+    it('renders items correctly', function() {
+        expect(this.proctored_exam_view.$el.find('a')).toHaveAttr('href', this.model.get('exam_url_path'));
+        expect(this.proctored_exam_view.$el.find('a')).toContainHtml(this.model.get('exam_display_name'));
+    });
+    it('changes behavior when clock time decreases low threshold', function() {
+        this.proctored_exam_view.secondsLeft = 25;
+        this.proctored_exam_view.render();
+        expect(this.proctored_exam_view.$el.find('div.exam-timer')).toHaveClass('low-time warning');
+    });
+    it('changes behavior when clock time decreases critically low threshold', function() {
+        this.proctored_exam_view.secondsLeft = 5;
+        this.proctored_exam_view.render();
+        expect(this.proctored_exam_view.$el.find('div.exam-timer')).toHaveClass('low-time critical');
+    });
+    it('toggles timer visibility correctly', function() {
+        var button = this.proctored_exam_view.$el.find('#toggle_timer');
+        var timer = this.proctored_exam_view.$el.find('h3#time_remaining_id b');
+        expect(timer).not.toHaveClass('timer-hidden');
+        button.click();
+        expect(timer).toHaveClass('timer-hidden');
+        button.click();
+        expect(timer).not.toHaveClass('timer-hidden');
+    });
+    it('toggles long text visibility on show more/less', function() {
+        var button = this.proctored_exam_view.$el.find('.js-toggle-show-more');
+        var textToToggle = this.proctored_exam_view.$el.find('.js-exam-additional-text');
+        var initiallyHidden = textToToggle.hasClass('hidden');
+        button.click();
+        expect(textToToggle.hasClass('hidden')).not.toBe(initiallyHidden);
+        button.click();
+        expect(textToToggle.hasClass('hidden')).toBe(initiallyHidden);
+    });
+    it('toggles initial visibility according to whether media query is satisfied', function() {
+        var matchMedia = window.matchMedia;
+        var fakeMediaQuery = sinon.stub().returns({matches: true});
+        this.proctored_exam_view.first_time_rendering = true;
+        window.matchMedia = fakeMediaQuery;
+        this.proctored_exam_view.render();
+        expect(this.proctored_exam_view.$el.find('.js-exam-additional-text')).not.toHaveClass('hidden');
+        window.matchMedia = matchMedia;
+    });
+    it('reload the page when the exam time finishes', function() {
+        // Stubbed out so tests don't reload endlessly when debugging in the browser
+        spyOn(this.proctored_exam_view, 'reloadPage');
+        this.proctored_exam_view.secondsLeft = -10;
+        edx.courseware.proctored_exam.endExam =
+          jasmine.createSpy('endExam').and.returnValue(Promise.resolve());
+        this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
+        expect(edx.courseware.proctored_exam.endExam).toHaveBeenCalled();
+        delete edx.courseware.proctored_exam.endExam;
+    });
+    it('resets the remaining exam time after the ajax response', function() {
+        this.server.respondWith(
+            'GET',
+            '/api/edx_proctoring/v1/proctored_exam/attempt/' +
+            this.proctored_exam_view.model.get('attempt_id') +
+            '?sourceid=in_exam&proctored=true',
+            [
+                200,
+                {'Content-Type': 'application/json'},
+                JSON.stringify({
+                    time_remaining_seconds: -10
+                })
+            ]
+        );
+        this.proctored_exam_view.timerTick = this.proctored_exam_view.poll_interval - 1; // to make the ajax call.
+        spyOn(this.proctored_exam_view, 'reloadPage');
+        edx.courseware.proctored_exam.endExam =
+          jasmine.createSpy('endExam').and.returnValue(Promise.resolve());
+        this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
+        this.server.respond();
+        this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
+        expect(edx.courseware.proctored_exam.endExam).toHaveBeenCalled();
+    });
+    it('reloads the page after unauthorized ajax ping', function() {
+        var reloadPage = spyOn(this.proctored_exam_view, 'reloadPage');
+        this.server.respondWith(
+            'GET',
+            '/api/edx_proctoring/v1/proctored_exam/attempt/' +
+            this.proctored_exam_view.model.get('attempt_id') +
+            '?sourceid=in_exam&proctored=true',
+            [
+                403,
+                {'Content-Type': 'application/json'},
+                JSON.stringify({
+                    message: 'Attempted to access attempt_id but user does not have access'
+                })
+            ]
+        );
+        this.proctored_exam_view.timerTick = this.proctored_exam_view.poll_interval - 1; // to make the ajax call.
+        this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
+        this.server.respond();
+        this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
+        expect(reloadPage).toHaveBeenCalled();
+    });
+    it('reloads the page after error state ajax ping', function() {
+        var reloadPage = spyOn(this.proctored_exam_view, 'reloadPage');
+        this.server.respondWith(
+            'GET',
+            '/api/edx_proctoring/v1/proctored_exam/attempt/' +
+            this.proctored_exam_view.model.get('attempt_id') +
+            '?sourceid=in_exam&proctored=true',
+            [
+                200,
+                {'Content-Type': 'application/json'},
+                JSON.stringify({
+                    status: 'error'
+                })
+            ]
+        );
+        this.proctored_exam_view.timerTick = this.proctored_exam_view.poll_interval - 1; // to make the ajax call.
+        this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
+        this.server.respond();
+        this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
+        expect(reloadPage).toHaveBeenCalled();
+    });
+    it('does not reload the page on general 400 errors', function() {
+        var reloadPage = spyOn(this.proctored_exam_view, 'reloadPage');
+        this.server.respondWith(
+            'GET',
+            '/api/edx_proctoring/v1/proctored_exam/attempt/' +
+            this.proctored_exam_view.model.get('attempt_id') +
+            '?sourceid=in_exam&proctored=true',
+            [
+                400,
+                {'Content-Type': 'application/json'},
+                JSON.stringify({
+                    message: 'Attempted to access attempt_id but it does not exist'
+                })
+            ]
+        );
+        this.proctored_exam_view.timerTick = this.proctored_exam_view.poll_interval - 1; // to make the ajax call.
+        this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
+        this.server.respond();
+        this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
+        expect(reloadPage).not.toHaveBeenCalled();
+    });
+    it('calls external js global function on off-beat', function() {
+        this.proctored_exam_view.model.set('ping_interval', 60);
+        edx.courseware.proctored_exam.pingApplication = jasmine.createSpy().and.returnValue(Promise.resolve());
+        edx.courseware.proctored_exam.configuredWorkerURL = 'nonempty/string.html';
+        this.proctored_exam_view.timerTick = (this.proctored_exam_view.model.get('ping_interval') / 2) - 1;
+        this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
+        expect(edx.courseware.proctored_exam.pingApplication).toHaveBeenCalled();
+        delete edx.courseware.proctored_exam.pingApplication;
+        delete edx.courseware.proctored_exam.configuredWorkerURL;
+    });
+    it('reloads the page after failure-state ajax call', function(done) {
+        var reloadPage = spyOn(this.proctored_exam_view, 'reloadPage');
+        this.server.respondWith(
+            function(request) {
+                request.respond(200,
+                    {'Content-Type': 'application/json'},
+                    '{"exam_attempt_id": "abcde"}'
+                );
+            }
+        );
+        this.proctored_exam_view.endExamForFailureState().done(function() {
+            expect(reloadPage).toHaveBeenCalled();
+            done();
+        });
+        this.server.respond();
+    });
+    it('does not reload the page after failure-state ajax call when server responds with no attempt id',
+        function(done) {
+            var reloadPage = spyOn(this.proctored_exam_view, 'reloadPage');
+            // this case mimics current behavior of the server when the
+            // proctoring backend is configured to not block the user for a
+            // failed ping.
+            this.server.respondWith(
+                function(request) {
+                    request.respond(200,
+                        {'Content-Type': 'application/json'},
+                        '{"exam_attempt_id": false}'
+                    );
+                }
+            );
+            this.proctored_exam_view.endExamForFailureState().done(function() {
+                expect(reloadPage).not.toHaveBeenCalled();
+                done();
+            });
+            this.server.respond();
+        });
+
+    it('sets global variable when unset', function() {
+        expect(window.edx.courseware.proctored_exam.configuredWorkerURL).toBeUndefined();
+        this.proctored_exam_view.model.set('desktop_application_js_url', 'nonempty string');
+        expect(window.edx.courseware.proctored_exam.configuredWorkerURL).not.toBeUndefined();
+        this.proctored_exam_view.model.set('desktop_application_js_url', 'another nonempty string');
+        expect(window.edx.courseware.proctored_exam.configuredWorkerURL).toEqual('nonempty string');
+        delete window.edx.courseware.proctored_exam.configuredWorkerURL;
+    });
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,40 +1,43 @@
-const gulp = require('gulp');
-const karma = require('karma').server;
-const path = require('path');
+/* global path:false */
+
+var gulp = require('gulp');
+var karma = require('karma').server;
+var path = require('path');
 
 /**
  * Run test once and exit
  */
-gulp.task('test', (done) => {
-  'use strict';
+gulp.task('test', function(done) {
+    'use strict';
 
-  karma.start({
-    configFile: path.join(__dirname, '/karma.conf.js'),
-    singleRun: true,
-  }, done);
+    karma.start({
+        configFile: path.join(__dirname, '/karma.conf.js'),
+        singleRun: true
+    }, done);
 });
 
 /**
  * Watch for file changes and re-run tests on each change
  */
-gulp.task('tdd', (done) => {
-  'use strict';
+gulp.task('tdd', function(done) {
+    'use strict';
 
-  karma.start({
-    configFile: path.join(__dirname, '/karma.conf.js'),
-  }, done);
+    karma.start({
+        configFile: path.join(__dirname, '/karma.conf.js')
+    }, done);
 });
 
 gulp.task('default', gulp.series('tdd'));
 
+
 /**
  * Run test in debug mode
  */
-gulp.task('debug', (done) => {
-  'use strict';
+gulp.task('debug', function(done) {
+    'use strict';
 
-  karma.start({
-    configFile: path.join(__dirname, '/karma.conf.js'),
-    singleRun: false,
-  }, done);
+    karma.start({
+        configFile: path.join(__dirname, '/karma.conf.js'),
+        singleRun: false
+    }, done);
 });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,100 +1,100 @@
+
 // Add ability to turn coverage off when the tests are run in debug mode
-let sourcePreprocessors = 'coverage';
+var sourcePreprocessors = 'coverage';
 
 function isDebug(argument) {
-  'use strict';
+    'use strict';
 
-  return argument === 'debug';
+    return argument === 'debug';
 }
 if (process.argv.some(isDebug)) {
-  sourcePreprocessors = [];
+    sourcePreprocessors = [];
 }
 
-const puppeteer = require('puppeteer');
 
-process.env.CHROME_BIN = puppeteer.executablePath();
+module.exports = function(config) {
+    'use strict';
 
-module.exports = config => {
-  'use strict';
+    config.set({
 
-  config.set({
+        basePath: '',
 
-    basePath: '',
+        // plugins required for running the karma tests
+        plugins: [
+            'karma-jasmine',
+            'karma-jasmine-jquery-2',
+            'karma-chrome-launcher',
+            'karma-phantomjs-launcher',
+            'karma-coverage',
+            'karma-sinon'
+        ],
 
-    // plugins required for running the karma tests
-    plugins: [
-      'karma-jasmine',
-      'karma-jasmine-jquery-2',
-      'karma-chrome-launcher',
-      // 'karma-phantomjs-launcher',
-      'karma-coverage',
-      'karma-sinon',
-    ],
+        // start the browser
+        browsers: ['PhantomJS'],
 
-    // start the browser
-    browsers: ['ChromeHeadless'],
+        // frameworks to use
+        frameworks: ['jasmine-jquery', 'jasmine', 'sinon'],
 
-    // frameworks to use
-    frameworks: ['jasmine-jquery', 'jasmine', 'sinon'],
+        // patterns to load all files in child folders
+        files: [
+            'edx_proctoring/static/proctoring/spec/proctored_exam_global_vars.js',
+            'node_modules/babel-polyfill/dist/polyfill.js', // polyfills for e.g. Promises
+            'edx_proctoring/static/proctoring/js/vendor/i18n.js',
+            'edx_proctoring/static/proctoring/js/vendor/jquery.js',
+            'edx_proctoring/static/proctoring/js/vendor/underscore.js',
+            'edx_proctoring/static/proctoring/js/vendor/backbone.js',
+            'edx_proctoring/static/proctoring/js/vendor/date.js',
+            'edx_proctoring/static/proctoring/js/models/*.js',
+            'edx_proctoring/static/proctoring/js/collections/*.js',
+            'edx_proctoring/static/proctoring/js/views/*.js',
+            'edx_proctoring/static/proctoring/spec/*.js',
+            'edx_proctoring/static/proctoring/js/dropdown.js'
+        ],
 
-    // patterns to load all files in child folders
-    files: [
-      'edx_proctoring/static/proctoring/spec/proctored_exam_global_vars.js',
-      'node_modules/babel-polyfill/dist/polyfill.js', // polyfills for e.g. Promises
-      'edx_proctoring/static/proctoring/js/vendor/i18n.js',
-      'edx_proctoring/static/proctoring/js/vendor/jquery.js',
-      'edx_proctoring/static/proctoring/js/vendor/underscore.js',
-      'edx_proctoring/static/proctoring/js/vendor/backbone.js',
-      'edx_proctoring/static/proctoring/js/vendor/date.js',
-      'edx_proctoring/static/proctoring/js/models/*.js',
-      'edx_proctoring/static/proctoring/js/collections/*.js',
-      'edx_proctoring/static/proctoring/js/views/*.js',
-      'edx_proctoring/static/proctoring/spec/*.js',
-      'edx_proctoring/static/proctoring/js/dropdown.js',
-    ],
+        // preprocess matching files before serving them to the browser
+        // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+        preprocessors: {
+            'edx_proctoring/static/proctoring/js/models/*.js': sourcePreprocessors,
+            'edx_proctoring/static/proctoring/js/collections/*.js': sourcePreprocessors,
+            'edx_proctoring/static/proctoring/js/views/*.js': sourcePreprocessors
+        },
 
-    // preprocess matching files before serving them to the browser
-    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
-    preprocessors: {
-      'edx_proctoring/static/proctoring/js/models/*.js': sourcePreprocessors,
-      'edx_proctoring/static/proctoring/js/collections/*.js': sourcePreprocessors,
-      'edx_proctoring/static/proctoring/js/views/*.js': sourcePreprocessors,
-    },
+        // test results reporter to use
+        // possible values: 'dots', 'progress'
+        // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+        reporters: ['progress', 'coverage'],
 
-    // test results reporter to use
-    // possible values: 'dots', 'progress'
-    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress', 'coverage'],
+        coverageReporter: {
+            dir: 'build',
+            subdir: 'coverage-js',
+            reporters: [
+                {type: 'html', subdir: 'coverage-js/html'},
+                {type: 'cobertura', file: 'coverage.xml'},
+                {type: 'text-summary'}
+            ]
+        },
 
-    coverageReporter: {
-      dir: 'build',
-      subdir: 'coverage-js',
-      reporters: [
-        { type: 'html', subdir: 'coverage-js/html' },
-        { type: 'cobertura', file: 'coverage.xml' },
-        { type: 'text-summary' },
-      ],
-    },
+        // enable / disable colors in the output (reporters and logs)
+        colors: true,
 
-    // enable / disable colors in the output (reporters and logs)
-    colors: true,
+        // level of logging
+        // possible values: config.LOG_DISABLE ||
+        //                  config.LOG_ERROR ||
+        //                  config.LOG_WARN ||
+        //                  config.LOG_INFO ||
+        //                  config.LOG_DEBUG
+        logLevel: config.LOG_INFO,
 
-    // level of logging
-    // possible values: config.LOG_DISABLE ||
-    //                  config.LOG_ERROR ||
-    //                  config.LOG_WARN ||
-    //                  config.LOG_INFO ||
-    //                  config.LOG_DEBUG
-    logLevel: config.LOG_INFO,
 
-    // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: true,
+        // enable / disable watching file and executing tests whenever any file changes
+        autoWatch: true,
 
-    captureTimeout: 60000,
+        captureTimeout: 60000,
 
-    // Continuous Integration mode
-    // if true, Karma captures browsers, runs the tests and exits
-    singleRun: false,
+        // Continuous Integration mode
+        // if true, Karma captures browsers, runs the tests and exits
+        singleRun: false
 
-  });
+    });
 };
+

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,43 +1,31 @@
 {
   "name": "@edx/edx-proctoring",
-  "version": "4.10.2",
+  "version": "4.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@edx/edx-proctoring",
-      "version": "4.10.2",
+      "version": "4.10.0",
       "license": "GNU Affero GPLv3",
-      "dependencies": {
-        "gulp": "^4.0.2"
-      },
       "devDependencies": {
-        "@edx/eslint-config": "^3.1.0",
         "babel-polyfill": "^6.26.0",
+        "eslint": "^5.9.0",
+        "eslint-config-edx": "^4.0.4",
+        "eslint-config-edx-es5": "^4.0.1",
         "eslint-plugin-jsx-a11y": "^6.5.1",
+        "gulp": "4.0.0",
         "gulp-karma": "0.0.1",
         "jasmine-core": "^2.8.0",
         "karma": "^0.13.0",
-        "karma-chrome-launcher": "^3.1.1",
-        "karma-coverage": "^2.2.0",
+        "karma-chrome-launcher": "^0.2.0",
+        "karma-coverage": "^1.1.1",
         "karma-jasmine": "^0.3.6",
         "karma-jasmine-jquery-2": "latest",
+        "karma-phantomjs-launcher": "^1.0.4",
         "karma-sinon": "^1.0.5",
-        "puppeteer": "^14.1.2",
+        "phantomjs-prebuilt": "^2.1.14",
         "sinon": "^3.2.1"
-      }
-    },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
-      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.1.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -52,192 +40,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/compat-data": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.10.tgz",
-      "integrity": "sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.2.tgz",
-      "integrity": "sha512-A8pri1YJiC5UnkdrWcmfZTJTV85b4UXTAfImGmCfYmax4TR9Cw8sDS0MOk++Gp2mE/BefVJ5nwy5yzqNJbP/DQ==",
-      "dev": true,
-      "dependencies": {
-        "@ampproject/remapping": "^2.1.0",
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.18.2",
-        "@babel/helper-compilation-targets": "^7.18.2",
-        "@babel/helper-module-transforms": "^7.18.0",
-        "@babel/helpers": "^7.18.2",
-        "@babel/parser": "^7.18.0",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.18.2",
-        "@babel/types": "^7.18.2",
-        "convert-source-map": "^1.7.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.1",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/core/node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-      "dev": true,
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.2.tgz",
-      "integrity": "sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.18.2",
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "jsesc": "^2.5.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
-      "integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/set-array": "^1.0.0",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.2.tgz",
-      "integrity": "sha512-s1jnPotJS9uQnzFtiZVBUxe67CuBa679oWFHpxYYnTpRL/1ffhyX44R9uYiXoa/pLXcY9H2moJta0iaanlk/rQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/compat-data": "^7.17.10",
-        "@babel/helper-validator-option": "^7.16.7",
-        "browserslist": "^4.20.2",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.2.tgz",
-      "integrity": "sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
-      "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/template": "^7.16.7",
-        "@babel/types": "^7.17.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
-      "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.0.tgz",
-      "integrity": "sha512-kclUYSUBIjlvnzN2++K9f2qzYKFgjmnmjwL4zlmU5f8ZtzgWe8s0rUPSTGy2HmK4P8T52MQsS+HTQAgZd3dMEA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-simple-access": "^7.17.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.18.0",
-        "@babel/types": "^7.18.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-simple-access": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.2.tgz",
-      "integrity": "sha512-7LIrjYzndorDY88MycupkpQLKS1AFfsVRm2k/9PtKScSy5tZq0McZTj+DiMRynboZfIqOKvo03pmhTaUgiD6fQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.18.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
-      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
@@ -247,33 +49,10 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
-      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.2.tgz",
-      "integrity": "sha512-j+d+u5xT5utcQSzrh9p+PaJX94h++KN+ng9b9WEJq7pkUPAd61FGqhjuUEdfknb3E/uDBb7ruwEeKkIxNJPIrg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.18.2",
-        "@babel/types": "^7.18.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/highlight": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
-      "integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.16.7",
@@ -284,22 +63,10 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/parser": {
-      "version": "7.18.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.4.tgz",
-      "integrity": "sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/runtime": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.3.tgz",
-      "integrity": "sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+      "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
       "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
@@ -309,9 +76,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.18.3.tgz",
-      "integrity": "sha512-l4ddFwrc9rnR+EJsHsh+TJ4A35YqQz/UqcjtlX2ov53hlJYG5CxtQmNZxyajwDVmCxwy++rtvGU5HazCK4W41Q==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.17.8.tgz",
+      "integrity": "sha512-ZbYSUvoSF6dXZmMl/CYTMOvzIFnbGfv4W3SEHYgMvNsFTeLaF2gkGAF4K2ddmtSK4Emej+0aYcnSC6N5dPCXUQ==",
       "dev": true,
       "dependencies": {
         "core-js-pure": "^3.20.2",
@@ -333,54 +100,6 @@
       "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
       "dev": true
     },
-    "node_modules/@babel/template": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
-      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/parser": "^7.16.7",
-        "@babel/types": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.2.tgz",
-      "integrity": "sha512-9eNwoeovJ6KH9zcCNnENY7DMFwTU9JdGCFtqNLfUAqtUHRCOsTOqWoffosP8vKmNYeSBUv3yVJXjfd8ucwOjUA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.18.2",
-        "@babel/helper-environment-visitor": "^7.18.2",
-        "@babel/helper-function-name": "^7.17.9",
-        "@babel/helper-hoist-variables": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.18.0",
-        "@babel/types": "^7.18.2",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.18.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
-      "integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "to-fast-properties": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -399,135 +118,6 @@
         "colorspace": "1.1.x",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
-      }
-    },
-    "node_modules/@edx/eslint-config": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-3.1.0.tgz",
-      "integrity": "sha512-Okv8vkmX+qe+joD7h9DcT9JdRIyy6jJSVWbIHr2dAHKuk5swVFO92JvhC2pYtMg2EPKA1P1Hmz8cmmfw6QoTZw==",
-      "dev": true,
-      "peerDependencies": {
-        "eslint": "^6.8.0 || ^7.0.0 || ^8.0.0",
-        "eslint-config-airbnb": "^18.0.1 || ^19.0.0",
-        "eslint-plugin-import": "^2.20.0",
-        "eslint-plugin-jsx-a11y": "^6.2.3",
-        "eslint-plugin-react": "^7.18.0",
-        "eslint-plugin-react-hooks": "^1.7.0 || ^4.0.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^9.3.2",
-        "globals": "^13.15.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
-      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@humanwhocodes/config-array": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.1",
-        "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=10.10.0"
-      }
-    },
-    "node_modules/@humanwhocodes/object-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
-      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/set-array": "^1.0.0",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
-      "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-      "dev": true
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
-      "integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -569,31 +159,19 @@
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
     },
-    "node_modules/@types/node": {
-      "version": "17.0.38",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.38.tgz",
-      "integrity": "sha512-5jY9RhV7c0Z4Jy09G+NIDTsCZ5G0L5n+Z+p+Y7t5VJHM30bgwzSjVtlcBxqAj+6L/swIlvtOSzr8rBk/aNyV2g==",
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
+    "node_modules/abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "dev": true
     },
     "node_modules/accepts": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-      "integrity": "sha512-AOPopplFOUlmUugwiZUCDpOwmqvSgdCyE8iJVLWI4NcB7qfMKQN34dn5xYtlUU03XGG5egRWW4NW5gIxpa5hEA==",
+      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
       "dev": true,
       "dependencies": {
         "mime-types": "~2.1.11",
@@ -604,11 +182,10 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -621,7 +198,6 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
-      "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -629,7 +205,7 @@
     "node_modules/active-x-obfuscator": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
-      "integrity": "sha512-8gdEZinfLSCfAUulETDth4ZSIDPSchiPgm5PLrXQC6BANf1YFEDrPPM2MdK2zcekMROwtM667QFuYw/H6ZV06Q==",
+      "integrity": "sha1-CJuJs3FF/x2ex0r2UwvlUmyuHxo=",
       "dev": true,
       "dependencies": {
         "zeparser": "0.0.5"
@@ -641,27 +217,14 @@
     "node_modules/after": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha512-QbJ0NTQ/I9DI3uSJA4cbexiwQeRAfjPScqIbSjUDd9TOrcg6pTkdgziesOqxBMBzit8vFCTwrP27t13vFOORRA==",
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
       "dev": true
-    },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
     },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -676,7 +239,7 @@
     "node_modules/amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true,
       "engines": {
         "node": ">=0.4.2"
@@ -686,6 +249,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+      "dev": true,
       "dependencies": {
         "ansi-wrap": "^0.1.0"
       },
@@ -693,10 +257,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ansi-gray": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
-      "integrity": "sha512-HrgGIZUl8h2EHuZaU9hTR/cU5nhKxpVE1V6kdGsQ8e4zirElJ5fvtfc8N7Q1oq1aatO275i8pUFUCpNWCAnVWw==",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
       "dependencies": {
         "ansi-wrap": "0.1.0"
       },
@@ -705,13 +279,12 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "dev": true,
-      "peer": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/ansi-styles": {
@@ -729,7 +302,8 @@
     "node_modules/ansi-wrap": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-      "integrity": "sha512-ZyznvL8k/FZeQHr2T6LzcJ/+vBApDnMNZvfVFy3At0knswWd6rJ3/0Hhmpu8oqa6C92npmozs890sX9Dl6q+Qw==",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -744,178 +318,11 @@
         "normalize-path": "^2.0.0"
       }
     },
-    "node_modules/anymatch/node_modules/arr-diff": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha512-dtXTVMkh6VkEEA7OhXnN1Ecb8aAGFdZ1LFxtOCoqj4qkyOJMt7+qs6Ahdy6p/NQCPYsRSXXivhSB/J5E9jmYKA==",
-      "dev": true,
-      "dependencies": {
-        "arr-flatten": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/anymatch/node_modules/array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/anymatch/node_modules/braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==",
-      "dev": true,
-      "dependencies": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/anymatch/node_modules/expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha512-hxx03P2dJxss6ceIeri9cmYOT4SRs3Zk3afZwWpOsRqLqprhTR8u++SlC+sFGsQr7WGFPdMF7Gjc1njDLDK6UA==",
-      "dev": true,
-      "dependencies": {
-        "is-posix-bracket": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/anymatch/node_modules/expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha512-AFASGfIlnIbkKPQwX1yHaDjFvh/1gyKJODme52V6IORh69uEYgZp0o9C+qsIGNVEiuuhQU0CSSl++Rlegg1qvA==",
-      "dev": true,
-      "dependencies": {
-        "fill-range": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/anymatch/node_modules/extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha512-1FOj1LOwn42TMrruOHGt18HemVnbwAmAak7krWk+wa93KXxGbK+2jpezm+ytJYDaBX0/SPLZFHKM7m+tKobWGg==",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/anymatch/node_modules/fill-range": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-      "dev": true,
-      "dependencies": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^3.0.0",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/anymatch/node_modules/is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/anymatch/node_modules/is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/anymatch/node_modules/is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
-      "dev": true,
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/anymatch/node_modules/isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
-      "dev": true,
-      "dependencies": {
-        "isarray": "1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/anymatch/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dev": true,
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/anymatch/node_modules/micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true,
-      "dependencies": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/append-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
-      "integrity": "sha512-WLbYiXzD3y/ATLZFufV/rZvWdZOs+Z/+5v1rBZ463Jn398pa6kcde27cvozYnBoxXblGZTFfoPpsaEw0orU5BA==",
+      "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+      "dev": true,
       "dependencies": {
         "buffer-equal": "^1.0.0"
       },
@@ -926,32 +333,36 @@
     "node_modules/archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
     },
     "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/aria-query": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.10.2",
-        "@babel/runtime-corejs3": "^7.10.2"
-      },
-      "engines": {
-        "node": ">=6.0"
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-0.7.1.tgz",
+      "integrity": "sha1-Jsu1r/ZBRLCoJb4YRuCxbPoAsR4=",
+      "dev": true,
+      "dependencies": {
+        "ast-types-flow": "0.0.7",
+        "commander": "^2.11.0"
       }
     },
     "node_modules/arr-diff": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "dev": true,
+      "dependencies": {
+        "arr-flatten": "^1.0.1"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -959,7 +370,8 @@
     "node_modules/arr-filter": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
-      "integrity": "sha512-A2BETWCqhsecSvCkWAeVBFLH6sXEUGASuzkpjL3GR1SlL/PWL6M3J8EAAld2Uubmh39tvkJTqC9LeLHCUKmFXA==",
+      "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
+      "dev": true,
       "dependencies": {
         "make-iterator": "^1.0.0"
       },
@@ -971,6 +383,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -978,7 +391,8 @@
     "node_modules/arr-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
-      "integrity": "sha512-tVqVTHt+Q5Xb09qRkbu+DidW1yYzz5izWS2Xm2yFm7qJnmUfz4HPzNxbHkdRJbz2lrqI7S+z17xNYdFcBBO8Hw==",
+      "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+      "dev": true,
       "dependencies": {
         "make-iterator": "^1.0.0"
       },
@@ -989,7 +403,8 @@
     "node_modules/arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -997,7 +412,17 @@
     "node_modules/array-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
-      "integrity": "sha512-zHjL5SZa68hkKHBFBK6DJCTtr9sfTCPCaph/L7tMSLcTFgy+zX7E+6q5UArbtOtMBCtxdICpfTCspRse+ywyXA==",
+      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1005,18 +430,18 @@
     "node_modules/array-from": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "node_modules/array-includes": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
-      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       },
@@ -1030,7 +455,8 @@
     "node_modules/array-initial": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
-      "integrity": "sha512-BC4Yl89vneCYfpLrs5JU2aAu9/a+xWbeKhvISg9PT7eWFB9UlRvI+rKEtk6mgxWr3dSkk9gQ8hCrdqt06NXPdw==",
+      "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
+      "dev": true,
       "dependencies": {
         "array-slice": "^1.0.0",
         "is-number": "^4.0.0"
@@ -1043,6 +469,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
       "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1051,6 +478,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
       "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1059,6 +487,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
       "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
+      "dev": true,
       "dependencies": {
         "is-number": "^4.0.0"
       },
@@ -1070,6 +499,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
       "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1077,7 +507,7 @@
     "node_modules/array-slice": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-      "integrity": "sha512-rlVfZW/1Ph2SNySXwR9QYkChp8EkOEiTMO5Vwx60usw04i4nWemkm9RXmQqgkQFaLHsqLuADvjp6IfgL9l2M8Q==",
+      "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1087,6 +517,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
       "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+      "dev": true,
       "dependencies": {
         "default-compare": "^1.0.0",
         "get-value": "^2.0.6",
@@ -1096,25 +527,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/array-sort/node_modules/kind-of": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/array-unique": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/array.prototype.flat": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
+      "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
-        "es-shim-unscopables": "^1.0.0"
+        "es-abstract": "^1.19.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1124,16 +563,14 @@
       }
     },
     "node_modules/array.prototype.flatmap": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
-      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz",
+      "integrity": "sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
-        "es-shim-unscopables": "^1.0.0"
+        "es-abstract": "^1.19.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1145,13 +582,32 @@
     "node_modules/arraybuffer.slice": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
-      "integrity": "sha512-6ZjfQaBSy6CuIH0+B0NrxMfDE5VIOCP/5gOqSpEIsaAZx9/giszzrXg6PZ7G51U/n88UmlAgYLNQ9wAnII7PJA==",
+      "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco=",
       "dev": true
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1159,19 +615,29 @@
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
-      "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
       "dev": true
     },
+    "node_modules/astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
     "node_modules/async-done": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
       "integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
+      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.2",
@@ -1185,12 +651,14 @@
     "node_modules/async-each": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "dev": true
     },
     "node_modules/async-settle": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
-      "integrity": "sha512-VPXfB4Vk49z1LHHodrEQ6Xf7W4gg1w0dAPROHngx7qgDjqmIQ+fXmwgGXTW/ITLai0YLSvWepJOP9EVpMnEAcw==",
+      "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+      "dev": true,
       "dependencies": {
         "async-done": "^1.2.2"
       },
@@ -1198,10 +666,17 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
     "node_modules/atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true,
       "bin": {
         "atob": "bin/atob.js"
       },
@@ -1221,25 +696,115 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/axe-core": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.2.tgz",
-      "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==",
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "dev": true
+    },
+    "node_modules/axe-core": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
+      "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axobject-query": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
-      "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-0.1.0.tgz",
+      "integrity": "sha1-YvWdvFnJ+SQnWco0mWDnov48NsA=",
+      "dev": true,
+      "dependencies": {
+        "ast-types-flow": "0.0.7"
+      }
+    },
+    "node_modules/babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
+    },
+    "node_modules/babel-code-frame/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/babel-polyfill": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha512-F2rZGQnAdaHWQ8YAoeRbukc7HS9QgdgeyJ0rQDd485v9opwuPvjpPFcOOT/WmkKTdgy9ESgSPXDcTNpzrGr6iQ==",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
       "dependencies": {
         "babel-runtime": "^6.26.0",
@@ -1250,7 +815,7 @@
     "node_modules/babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "dependencies": {
         "core-js": "^2.4.0",
@@ -1266,7 +831,8 @@
     "node_modules/bach": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
-      "integrity": "sha512-bZOOfCb3gXBXbTFXq3OZtGR88LwGeJvzu6szttaIzymOTS4ZttBNOWSv7aLZja2EMycKtRYV0Oa8SNKH/zkxvg==",
+      "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+      "dev": true,
       "dependencies": {
         "arr-filter": "^1.1.1",
         "arr-flatten": "^1.0.1",
@@ -1285,18 +851,20 @@
     "node_modules/backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
       "dev": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
       "dependencies": {
         "cache-base": "^1.0.1",
         "class-utils": "^0.3.5",
@@ -1313,7 +881,8 @@
     "node_modules/base/node_modules/define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "dev": true,
       "dependencies": {
         "is-descriptor": "^1.0.0"
       },
@@ -1324,36 +893,16 @@
     "node_modules/base64-arraybuffer": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-      "integrity": "sha512-437oANT9tP582zZMwSvZGy2nmSeAb8DW2me3y+Uv1Wp2Rulr8Mqlyrv3E7MLxmsiaPSMMDmiDVzgE+e8zlMx9g==",
+      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
       "dev": true,
       "engines": {
         "node": ">= 0.6.0"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/base64id": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
-      "integrity": "sha512-rz8L+d/xByiB/vLVftPkyY215fqNrmasrcJsYkVcm4TgJNz+YXKrFaFAWibSaHkiKoSgMDCb+lipOIRQNGYesw==",
+      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
@@ -1362,13 +911,22 @@
     "node_modules/batch": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
-      "integrity": "sha512-aQgHPLH2DHpFTpBl5/GiVdNzHEqsLCSs1RiPvqkKP1+7RkNJlv71kL8/KXmvvaLqoZ7ylmvqkZhLjjAoRz8Xgw==",
+      "integrity": "sha1-PzQU84AyF0O/wQQvmoP/HVgk1GQ=",
       "dev": true
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "node_modules/better-assert": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-      "integrity": "sha512-bYeph2DFlpK1XmGs6fvlLRUN29QISM3GBuUwSFsMY2XRx4AvC0WNCS57j4c/xGrK2RS24C1w3YoBOsw9fT46tQ==",
+      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
       "dev": true,
       "dependencies": {
         "callsite": "1.0.0"
@@ -1381,6 +939,7 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1389,46 +948,22 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
     },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/blob": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-      "integrity": "sha512-YRc9zvVz4wNaxcXmiSgb9LAg7YYwqQ2xd0Sj6osfA7k/PKmIGVlnOYs3wOFdkRC9/JpQu8sGt/zHgJV7xzerfg==",
+      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
       "dev": true
     },
     "node_modules/bluebird": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-      "integrity": "sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ==",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
       "dev": true
     },
     "node_modules/body-parser": {
@@ -1474,82 +1009,22 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
+      "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
+      "dev": true,
       "dependencies": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
+        "expand-range": "^0.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/browserslist": {
-      "version": "4.20.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
-      "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        }
-      ],
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001332",
-        "electron-to-chromium": "^1.4.118",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.3",
-        "picocolors": "^1.0.0"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-alloc": {
@@ -1571,7 +1046,7 @@
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true,
       "engines": {
         "node": "*"
@@ -1580,7 +1055,8 @@
     "node_modules/buffer-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-      "integrity": "sha512-tcBWO2Dl4e7Asr9hTGcpVrCe+F7DubpmqWCTbj4FHLmjqO2hIaC383acQubWtRJhdceqs5uBHs6Es+Sk//RKiQ==",
+      "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -1588,18 +1064,19 @@
     "node_modules/buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
       "dev": true
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
     },
     "node_modules/build": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/build/-/build-0.1.4.tgz",
-      "integrity": "sha512-KwbDJ/zrsU8KZRRMfoURG14cKIAStUlS8D5jBDvtrZbwO5FEkYqc3oB8HIhRiyD64A48w1lc+sOmQ+mmBw5U/Q==",
+      "integrity": "sha1-cH/gJv/O3crL/c3zVur9pk8VEEY=",
       "dev": true,
       "dependencies": {
         "cssmin": "0.3.x",
@@ -1617,6 +1094,15 @@
         "node": ">v0.4.12"
       }
     },
+    "node_modules/build/node_modules/uglify-js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
+      "integrity": "sha1-S1v/+Rhu/7qoiOTJ6UvZ/EyUkp0=",
+      "dev": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1630,6 +1116,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
       "dependencies": {
         "collection-visit": "^1.0.0",
         "component-emitter": "^1.2.1",
@@ -1649,6 +1136,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -1657,48 +1145,63 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/caller-path/node_modules/callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/callsite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
       "dev": true,
       "engines": {
         "node": "*"
       }
     },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/camelcase": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001344",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz",
-      "integrity": "sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==",
+    "node_modules/camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        }
-      ]
+      "dependencies": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -1714,10 +1217,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "node_modules/chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha512-mk8fAWcRUOxY7btlLtitj3A45jOwSAxH4tOFOoEGbVsl6cL6pPMWUy7dwZ/canfj3QEdP6FHSnf/l1c6/WkzVg==",
+      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "deprecated": "Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.",
       "dev": true,
       "dependencies": {
@@ -1737,7 +1246,7 @@
     "node_modules/chokidar/node_modules/is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1746,7 +1255,7 @@
     "node_modules/chokidar/node_modules/is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "dependencies": {
         "is-extglob": "^1.0.0"
@@ -1755,16 +1264,18 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+    "node_modules/circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "deprecated": "CircularJSON is in maintenance only, flatted is its successor.",
       "dev": true
     },
     "node_modules/class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
       "dependencies": {
         "arr-union": "^3.1.0",
         "define-property": "^0.2.5",
@@ -1778,7 +1289,8 @@
     "node_modules/class-utils/node_modules/define-property": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "dev": true,
       "dependencies": {
         "is-descriptor": "^0.1.0"
       },
@@ -1789,20 +1301,10 @@
     "node_modules/class-utils/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -1811,20 +1313,10 @@
     "node_modules/class-utils/node_modules/is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -1834,6 +1326,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
       "dependencies": {
         "is-accessor-descriptor": "^0.1.6",
         "is-data-descriptor": "^0.1.4",
@@ -1843,10 +1336,38 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/class-utils/node_modules/is-descriptor/node_modules/kind-of": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+      "dev": true
+    },
     "node_modules/cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "dev": true,
       "dependencies": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
@@ -1856,7 +1377,34 @@
     "node_modules/cliui/node_modules/ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1865,6 +1413,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -1875,7 +1424,8 @@
     "node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -1883,7 +1433,8 @@
     "node_modules/clone-buffer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-      "integrity": "sha512-KLLTJWrvwIP+OPfMn0x2PheDEP20RPUcGXj/ERegTgdmPEZylALQldygiqrPPu8P45uNuPs7ckmReLY6v/iA5g==",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+      "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -1891,22 +1442,71 @@
     "node_modules/clone-stats": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-      "integrity": "sha512-au6ydSpg6nsrigcZ4m8Bc9hxjeW+GJ8xh5G3BJCMt4WXe1H10UNaVOamqQTmrx1kjVuxAHIQSNU6hY4Nsn9/ag=="
+      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+      "dev": true
     },
     "node_modules/cloneable-readable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
       "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "process-nextick-args": "^2.0.0",
         "readable-stream": "^2.3.5"
       }
     },
+    "node_modules/cloneable-readable/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/cloneable-readable/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/cloneable-readable/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/cloneable-readable/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true,
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
     "node_modules/code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1914,7 +1514,7 @@
     "node_modules/coffee-script": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.3.tgz",
-      "integrity": "sha512-lpusDYw9xym9ZOqFIeQuzzvTvunm2nlRL++BYhUcLn+77vuidExZG+qDPSKUfDXvuaHeFK6QavntXF+HiOq+/Q==",
+      "integrity": "sha1-Y1XTLPGwTN/2tITl5xF4Ky8MOb4=",
       "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
       "dev": true,
       "bin": {
@@ -1928,7 +1528,8 @@
     "node_modules/collection-map": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
-      "integrity": "sha512-5D2XXSpkOnleOI21TG7p3T0bGAsZ/XknZpKBmGYyluO8pw4zA3K8ZlrBIbC4FXg3m6z/RNFiUFfT2sQK01+UHA==",
+      "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
+      "dev": true,
       "dependencies": {
         "arr-map": "^2.0.2",
         "for-own": "^1.0.0",
@@ -1941,7 +1542,8 @@
     "node_modules/collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
       "dependencies": {
         "map-visit": "^1.0.0",
         "object-visit": "^1.0.0"
@@ -1972,13 +1574,13 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
       "dev": true,
       "dependencies": {
         "color-name": "^1.0.0",
@@ -1989,6 +1591,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
       "bin": {
         "color-support": "bin.js"
       }
@@ -2012,32 +1615,53 @@
         "text-hex": "1.0.x"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
     "node_modules/component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-      "integrity": "sha512-WZveuKPeKAG9qY+FkYDeADzdHyTYdIboXS59ixDeRJL5ZhxpqUnxSOwop4FQjMsiYm3/Or8cegVbpAHNA7pHxw==",
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
       "dev": true
     },
     "node_modules/component-emitter": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
     },
     "node_modules/component-inherit": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-      "integrity": "sha512-w+LhYREhatpVqTESyGFg3NlP6Iu0kEKUHETY9GoZP/pQyW4mHFZuFWRUCIqVPZ36ueVLtoOEZaAqbCF2RDndaA==",
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
       "engines": [
         "node >= 0.8"
       ],
@@ -2048,12 +1672,41 @@
         "typedarray": "^0.0.6"
       }
     },
-    "node_modules/confusing-browser-globals": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
-      "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
+    "node_modules/concat-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "dev": true,
-      "peer": true
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/concat-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/connect": {
       "version": "3.7.0",
@@ -2098,14 +1751,21 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
       "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
       }
     },
+    "node_modules/convert-source-map/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
     "node_modules/cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -2114,13 +1774,14 @@
     "node_modules/cookie-signature": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz",
-      "integrity": "sha512-FMG5ziBzXZ5d4j5obbWOH1X7AtIpsU9ce9mQ+lHo/I1++kzz/isNarOj6T1lBPRspP3mZpuIutc7OVDVcaN1Kg==",
+      "integrity": "sha1-ROByFIrwHm6OJK+/EmkNaK5pjss=",
       "dev": true
     },
     "node_modules/copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2129,6 +1790,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.5.tgz",
       "integrity": "sha512-XBlx8HSqrT0ObQwmSzM7WE5k8FxTV75h1DX1Z3n6NhQ/UYYAvInWYmG06vFt7hQZArE2fuO62aihiWIVQwh1sw==",
+      "dev": true,
       "dependencies": {
         "each-props": "^1.3.2",
         "is-plain-object": "^5.0.0"
@@ -2138,6 +1800,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2151,9 +1814,9 @@
       "hasInstallScript": true
     },
     "node_modules/core-js-pure": {
-      "version": "3.22.7",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.22.7.tgz",
-      "integrity": "sha512-wTriFxiZI+C8msGeh7fJcbC/a0V8fdInN1oS2eK79DMBGs8iIJiXhtFJCiT3rBa8w6zroHWW3p8ArlujZ/Mz+w==",
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.21.1.tgz",
+      "integrity": "sha512-12VZfFIu+wyVbBebyHmRTuEE/tZrB4tJToWcwAMcsp3h4+sHR+fMJWbKpYiCRWlhFBq+KNyO8rIV9rTkeVmznQ==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -2164,67 +1827,57 @@
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
-    "node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "2.6.7"
-      }
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/cross-spawn/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
+        "node": ">=4.8"
       }
     },
     "node_modules/cssmin": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/cssmin/-/cssmin-0.3.2.tgz",
-      "integrity": "sha512-bynxGIAJ8ybrnFobjsQotIjA8HFDDgPwbeUWNXXXfR+B4f9kkxdcUyagJoQCSUOfMV+ZZ6bMn8bvbozlCzUGwQ==",
+      "integrity": "sha1-3c5MVHtRCuDVlKjx+/iq+OLFwA0=",
       "dev": true,
       "bin": {
         "cssmin": "bin/cssmin"
       }
     },
+    "node_modules/currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "dependencies": {
+        "array-find-index": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
-      "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
+      "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
       "dev": true
     },
     "node_modules/d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
       "dependencies": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -2235,6 +1888,18 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -2256,7 +1921,8 @@
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2264,7 +1930,8 @@
     "node_modules/decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -2305,13 +1972,13 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/default-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
       "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
+      "dev": true,
       "dependencies": {
         "kind-of": "^5.0.2"
       },
@@ -2319,39 +1986,56 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/default-compare/node_modules/kind-of": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/default-resolution": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
-      "integrity": "sha512-2xaP6GiwVwOEbXCGoJ4ufgC76m8cj805jrghScewJC2ZDsb9U0b4BIrba+xt/Uytyd0HvQ6+WymSRTfnYj59GQ==",
+      "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
+      "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
     },
     "node_modules/define-properties": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
       "dependencies": {
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
+        "object-keys": "^1.0.12"
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
       "dependencies": {
         "is-descriptor": "^1.0.2",
         "isobject": "^3.0.1"
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -2376,21 +2060,16 @@
     "node_modules/detect-file": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-      "integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/devtools-protocol": {
-      "version": "0.0.982423",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.982423.tgz",
-      "integrity": "sha512-FnVW2nDbjGNw1uD/JRC+9U5768W7e1TfUwqbDTcSsAu1jXFjITSX8w3rkW5FEpHRMPPGpvNSmO1pOpqByiWscA==",
-      "dev": true
-    },
     "node_modules/di": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
-      "integrity": "sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==",
+      "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
       "dev": true
     },
     "node_modules/diff": {
@@ -2403,22 +2082,21 @@
       }
     },
     "node_modules/doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/dom-serialize": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
-      "integrity": "sha512-Yra4DbvoW7/Z6LBN560ZwXMjoNOSAN2wRsKFGc4iBeso+mpIA6qj1vfdf9HpMaKAqG6wXTy+1SYEzmNpKXOSsQ==",
+      "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
       "dev": true,
       "dependencies": {
         "custom-event": "~1.0.0",
@@ -2437,6 +2115,7 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
@@ -2444,31 +2123,72 @@
         "stream-shift": "^1.0.0"
       }
     },
+    "node_modules/duplexify/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/duplexify/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexify/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/duplexify/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/each-props": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/each-props/-/each-props-1.3.2.tgz",
       "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
+      "dev": true,
       "dependencies": {
         "is-plain-object": "^2.0.1",
         "object.defaults": "^1.1.0"
       }
     },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "dev": true
-    },
-    "node_modules/electron-to-chromium": {
-      "version": "1.4.141",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.141.tgz",
-      "integrity": "sha512-mfBcbqc0qc6RlxrsIgLG2wCqkiPAjEezHxGTu7p3dHHFOurH4EjS9rFZndX5axC8264rI1Pcbw8uQP39oZckeA==",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
     "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
+      "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
       "dev": true
     },
     "node_modules/enabled": {
@@ -2480,7 +2200,7 @@
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true,
       "engines": {
         "node": ">= 0.8"
@@ -2490,6 +2210,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -2528,16 +2249,10 @@
         "yeast": "0.1.2"
       }
     },
-    "node_modules/engine.io-client/node_modules/component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha512-jPatnhd33viNplKjqXKRkGU345p263OIWzDL2wH3LGIGp5Kojo+uXizHmOADRvhGFFTnJqX3jBAKP6vvmSDKcA==",
-      "dev": true
-    },
     "node_modules/engine.io-client/node_modules/debug": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-      "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
+      "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
       "dev": true,
       "dependencies": {
         "ms": "0.7.2"
@@ -2552,7 +2267,7 @@
     "node_modules/engine.io-parser": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
-      "integrity": "sha512-3UyTJo+5Jbmr7rd3MosTAApK7BOIo4sjx8dJYSHa3Em5R3A9Y2s9GWu4JFJe6Px0VieJC0hKUA5NBytC+O7k2A==",
+      "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
       "dev": true,
       "dependencies": {
         "after": "0.8.2",
@@ -2566,7 +2281,7 @@
     "node_modules/engine.io/node_modules/debug": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-      "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
+      "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
       "dev": true,
       "dependencies": {
         "ms": "0.7.2"
@@ -2581,46 +2296,50 @@
     "node_modules/ent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
-      "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA==",
+      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
       "dev": true
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/error-ex/node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
     "node_modules/es-abstract": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
-      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.2.tgz",
+      "integrity": "sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
-        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
-        "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
+        "is-shared-array-buffer": "^1.0.1",
         "is-string": "^1.0.7",
         "is-weakref": "^1.0.2",
         "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "regexp.prototype.flags": "^1.4.3",
-        "string.prototype.trimend": "^1.0.5",
-        "string.prototype.trimstart": "^1.0.5",
-        "unbox-primitive": "^1.0.2"
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2654,16 +2373,6 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true
     },
-    "node_modules/es-shim-unscopables": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
-      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "has": "^1.0.3"
-      }
-    },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
@@ -2682,9 +2391,10 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.61",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
-      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+      "version": "0.10.59",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.59.tgz",
+      "integrity": "sha512-cOgyhW0tIJyQY1Kfw6Kr0viu9ZlUctVchRMZ7R0HiH3dxTSp5zJDLecwxUqPUrGKMsgBI1wd1FL+d9Jxfi4cLw==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "es6-iterator": "^2.0.3",
@@ -2698,17 +2408,25 @@
     "node_modules/es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
       }
     },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
+    },
     "node_modules/es6-symbol": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dev": true,
       "dependencies": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
@@ -2718,6 +2436,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
       "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dev": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.46",
@@ -2725,123 +2444,759 @@
         "es6-symbol": "^3.1.1"
       }
     },
-    "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
     },
-    "node_modules/eslint": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.16.0.tgz",
-      "integrity": "sha512-MBndsoXY/PeVTDJeWsYj7kLZ5hQpJOfMYLsF6LicLHQWbRDG19lK5jOix4DPl8yY4SUFcE3txy86OzFLWT+yoA==",
+    "node_modules/escodegen": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.3.0",
-        "@humanwhocodes/config-array": "^0.9.2",
-        "ajv": "^6.10.0",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
-        "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.2",
-        "esquery": "^1.4.0",
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
         "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.2.0"
+      }
+    },
+    "node_modules/escodegen/node_modules/esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/escodegen/node_modules/estraverse": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.9.0.tgz",
+      "integrity": "sha512-g4KWpPdqN0nth+goDNICNXGfJF7nNnepthp46CAlJoJtC5K/cLu3NgCM3AHu1CkJ5Hzt9V0Y0PBAO6Ay/gGb+w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.5.3",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^4.0.0",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
         "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^6.0.1",
-        "globals": "^13.15.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
         "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "js-yaml": "^4.1.0",
+        "inquirer": "^6.1.0",
+        "is-resolvable": "^1.1.0",
+        "js-yaml": "^3.12.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.5",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
-        "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.0.2",
+        "text-table": "^0.2.0"
       },
       "bin": {
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
+        "node": "^6.14.0 || ^8.10.0 || >=9.10.0"
       }
     },
-    "node_modules/eslint-config-airbnb": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz",
-      "integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
+    "node_modules/eslint-config-edx": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-edx/-/eslint-config-edx-4.0.4.tgz",
+      "integrity": "sha512-4xm13P14kcm3IppkjL8X3HDxLgA064l3F50sy7z8ioyB4kDLRepSSXhyDHR8vHDd46yztmnuIPXbEEgVNOL4xg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "eslint-config-airbnb-base": "^15.0.0",
-        "object.assign": "^4.1.2",
-        "object.entries": "^1.1.5"
-      },
-      "engines": {
-        "node": "^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^7.32.0 || ^8.2.0",
-        "eslint-plugin-import": "^2.25.3",
-        "eslint-plugin-jsx-a11y": "^6.5.1",
-        "eslint-plugin-react": "^7.28.0",
-        "eslint-plugin-react-hooks": "^4.3.0"
+        "eslint": "^4.5.0",
+        "eslint-config-airbnb": "^16.1.0",
+        "eslint-plugin-dollar-sign": "^1.0.1",
+        "eslint-plugin-import": "^2.8.0",
+        "eslint-plugin-jsx-a11y": "6.0.3",
+        "eslint-plugin-react": "^7.5.1"
       }
     },
-    "node_modules/eslint-config-airbnb-base": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
-      "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
+    "node_modules/eslint-config-edx-es5": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-edx-es5/-/eslint-config-edx-es5-4.0.1.tgz",
+      "integrity": "sha512-NazW7j4tcm1pxKabWZDKFlvbD/2usN2ZmW3LoYvM+f68fH0+1yX+R2kI/3WB9oatGOs5ScBVN33h05WakjVw5A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "confusing-browser-globals": "^1.0.10",
-        "object.assign": "^4.1.2",
-        "object.entries": "^1.1.5",
-        "semver": "^6.3.0"
+        "eslint": "^4.5.0",
+        "eslint-config-airbnb-base": "^11.3.2",
+        "eslint-plugin-dollar-sign": "1.0.0",
+        "eslint-plugin-import": "^2.7.0"
+      }
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/acorn": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^3.0.4"
+      }
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/acorn-jsx/node_modules/acorn": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "dependencies": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true,
+      "peerDependencies": {
+        "ajv": "^5.0.0"
+      }
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/eslint": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "4.0.2",
+        "text-table": "~0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/eslint-config-airbnb-base": {
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.3.2.tgz",
+      "integrity": "sha512-/fhjt/VqzBA2SRsx7ErDtv6Ayf+XLw9LIOqmpBuHFCVwyJo2EtzGWMB9fYRFBoWWQLxmNmCpenNiH0RxyeS41w==",
+      "dev": true,
+      "dependencies": {
+        "eslint-restricted-globals": "^0.1.1"
+      },
+      "engines": {
+        "node": ">= 4"
       },
       "peerDependencies": {
-        "eslint": "^7.32.0 || ^8.2.0",
-        "eslint-plugin-import": "^2.25.2"
+        "eslint": "^3.19.0 || ^4.5.0",
+        "eslint-plugin-import": "^2.7.0"
+      }
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/eslint-plugin-dollar-sign": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-dollar-sign/-/eslint-plugin-dollar-sign-1.0.0.tgz",
+      "integrity": "sha1-r7pQRZ6d6XpfzXdjJ55MOp4ltaw=",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=1.0.0"
+      }
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/eslint-scope": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/external-editor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "dev": true,
+      "dependencies": {
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
+      }
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/regexpp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-config-edx-es5/node_modules/table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/acorn": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^3.0.4"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/acorn-jsx/node_modules/acorn": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "dependencies": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true,
+      "peerDependencies": {
+        "ajv": "^5.0.0"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
+    "node_modules/eslint-config-edx/node_modules/cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/eslint": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "4.0.2",
+        "text-table": "~0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/eslint-config-airbnb": {
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-16.1.0.tgz",
+      "integrity": "sha512-zLyOhVWhzB/jwbz7IPSbkUuj7X2ox4PHXTcZkEmDqTvd0baJmJyuxlFPDlZOE/Y5bC+HQRaEkT3FoHo9wIdRiw==",
+      "dev": true,
+      "dependencies": {
+        "eslint-config-airbnb-base": "^12.1.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "peerDependencies": {
+        "eslint": "^4.9.0",
+        "eslint-plugin-import": "^2.7.0",
+        "eslint-plugin-jsx-a11y": "^6.0.2",
+        "eslint-plugin-react": "^7.4.0"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/eslint-config-airbnb-base": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz",
+      "integrity": "sha512-/vjm0Px5ZCpmJqnjIzcFb9TKZrKWz0gnuG/7Gfkt0Db1ELJR51xkZth+t14rYdqWgX836XbuxtArbIHlVhbLBA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-restricted-globals": "^0.1.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "peerDependencies": {
+        "eslint": "^4.9.0",
+        "eslint-plugin-import": "^2.7.0"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.3.tgz",
+      "integrity": "sha1-VFg9GuRCSDFi4EDhPMMYZUZRAOU=",
+      "dev": true,
+      "dependencies": {
+        "aria-query": "^0.7.0",
+        "array-includes": "^3.0.3",
+        "ast-types-flow": "0.0.7",
+        "axobject-query": "^0.1.0",
+        "damerau-levenshtein": "^1.0.0",
+        "emoji-regex": "^6.1.0",
+        "jsx-ast-utils": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/eslint-scope": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/external-editor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "dev": true,
+      "dependencies": {
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "node_modules/eslint-config-edx/node_modules/ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true
+    },
+    "node_modules/eslint-config-edx/node_modules/inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "node_modules/eslint-config-edx/node_modules/jsx-ast-utils": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
+      "integrity": "sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.1.1",
+        "object.assign": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/regexpp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-config-edx/node_modules/table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "^2.1.1"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -2849,7 +3204,6 @@
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
       "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "debug": "^3.2.7",
         "resolve": "^1.20.0"
@@ -2860,7 +3214,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -2870,7 +3223,6 @@
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
       "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "debug": "^3.2.7",
         "find-up": "^2.1.0"
@@ -2884,9 +3236,17 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-dollar-sign": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-dollar-sign/-/eslint-plugin-dollar-sign-1.0.2.tgz",
+      "integrity": "sha512-AtA5MJpMAh0kKzSx/u7DuDbPRijIZmlt6n75CR8Q3UQ18Fo4QFfYK15lJ8OhXQQUYR7zTMMB2x37KyP3LnAC/g==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=1.0.0"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -2894,7 +3254,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
       "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.4",
         "array.prototype.flat": "^1.2.5",
@@ -2922,30 +3281,15 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.5.1",
@@ -2973,27 +3317,51 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
-    "node_modules/eslint-plugin-react": {
-      "version": "7.30.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.0.tgz",
-      "integrity": "sha512-RgwH7hjW48BleKsYyHK5vUAvxtE9SMPDKmcPRQgtRCYaZA0XQPt5FSkrU3nhz5ifzMZcA8opwmRJ2cmOO8tr5A==",
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "array-includes": "^3.1.5",
-        "array.prototype.flatmap": "^1.3.0",
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/axobject-query": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
+      "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.4.tgz",
+      "integrity": "sha512-CVCXajliVh509PcZYRFyu/BoUEz452+jtQJq2b3Bae4v3xBUWPLCmtmBM+ZinG4MzwmxJgJ2M5rMqhqLVn7MtQ==",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
         "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
         "object.entries": "^1.1.5",
         "object.fromentries": "^2.0.5",
-        "object.hasown": "^1.1.1",
+        "object.hasown": "^1.1.0",
         "object.values": "^1.1.5",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.7"
+        "string.prototype.matchall": "^4.0.6"
       },
       "engines": {
         "node": ">=4"
@@ -3002,38 +3370,11 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
-    "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
-      "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
       "version": "2.0.0-next.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz",
       "integrity": "sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
@@ -3042,190 +3383,89 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/eslint-scope": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true,
-      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-restricted-globals": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
+      "integrity": "sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc=",
+      "dev": true
+    },
+    "node_modules/eslint-scope": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "dev": true,
       "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/eslint-scope/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
+        "eslint-visitor-keys": "^1.1.0"
       },
       "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
-    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
+        "node": ">=6"
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true,
-      "peer": true,
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/eslint/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/eslint/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/eslint/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/eslint/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/eslint/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "is-glob": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/eslint/node_modules/globals": {
-      "version": "13.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
-      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/espree": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
-      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
+      "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "acorn": "^8.7.1",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.3.0"
+        "acorn": "^6.0.2",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -3233,7 +3473,6 @@
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
       "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -3246,7 +3485,6 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -3259,7 +3497,6 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -3269,7 +3506,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3277,7 +3513,7 @@
     "node_modules/event-stream": {
       "version": "3.0.20",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.0.20.tgz",
-      "integrity": "sha512-u2P2ZUf2wN0LBDY6gDNMH+GvLer2Fpb0IAw7i6abjy8HLZnhdobM10Qohn86mwTKy3lcV9VuUms0aU9kpfBrow==",
+      "integrity": "sha1-A4u7LqnqkDhbJvvBhU0LU58qvqM=",
       "dev": true,
       "dependencies": {
         "duplexer": "~0.1.1",
@@ -3298,7 +3534,7 @@
     "node_modules/expand-braces": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
-      "integrity": "sha512-zOOsEnAhvIxxd0esCNbYG2xerGf46niZ1egS43eV7Fu4t7VIScgPXMcMabCLaPrqkzwvwo6zZipDiX3t0ILF2w==",
+      "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
       "dev": true,
       "dependencies": {
         "array-slice": "^0.2.3",
@@ -3309,129 +3545,22 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/expand-braces/node_modules/array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-braces/node_modules/braces": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
-      "integrity": "sha512-EIMHIv2UXHWFY2xubUGKz+hq9hNkENj4Pjvr7h58cmJgpkK2yMlKA8I484f7MSttkzVAy/lL7X9xDaILd6avzA==",
-      "dev": true,
-      "dependencies": {
-        "expand-range": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/expand-brackets": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-      "integrity": "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "dev": true,
       "dependencies": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "is-posix-bracket": "^0.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/expand-brackets/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/expand-brackets/node_modules/define-property": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
-      "dependencies": {
-        "is-descriptor": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-brackets/node_modules/is-accessor-descriptor": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-brackets/node_modules/is-data-descriptor": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-brackets/node_modules/is-descriptor": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-      "dependencies": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-brackets/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/expand-range": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
-      "integrity": "sha512-busOHJ0t7t5UcutcyNDqmaDX+1cb0XlqsAUgTlmplVv0rIqBaMcBSZRLlkDm0nxtl8O3o/EvRRrdQ/WnyPERLQ==",
+      "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
       "dev": true,
       "dependencies": {
         "is-number": "^0.1.1",
@@ -3441,28 +3570,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/expand-range/node_modules/is-number": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz",
-      "integrity": "sha512-la5kPULwIgkSSaZj9w7/A1uHqOBAgOhDUKQ5CkfL8LZ4Si6r4+2D0hI6b4o60MW4Uj2yNJARWIZUDPxlvOYQcw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-range/node_modules/repeat-string": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz",
-      "integrity": "sha1-x6jTI2BoNiBZp+RlH8aITosftK4=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-      "integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
       "dependencies": {
         "homedir-polyfill": "^1.0.1"
       },
@@ -3474,6 +3586,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
       "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+      "dev": true,
       "dependencies": {
         "type": "^2.5.0"
       }
@@ -3481,77 +3594,119 @@
     "node_modules/ext/node_modules/type": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
-      "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
+      "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==",
+      "dev": true
     },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
       "dependencies": {
-        "is-extendable": "^0.1.0"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extend-shallow/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/extglob": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "dev": true,
       "dependencies": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "is-extglob": "^1.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/extglob/node_modules/define-property": {
+    "node_modules/extglob/node_modules/is-extglob": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
-      "dependencies": {
-        "is-descriptor": "^1.0.0"
-      },
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
       "dev": true,
       "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
         "yauzl": "^2.10.0"
       },
       "bin": {
         "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
       }
+    },
+    "node_modules/extract-zip/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/extract-zip/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ]
     },
     "node_modules/fancy-log": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
       "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
+      "dev": true,
       "dependencies": {
         "ansi-gray": "^0.1.1",
         "color-support": "^1.1.3",
@@ -3566,61 +3721,80 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
     },
     "node_modules/fecha": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
+      "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==",
       "dev": true
     },
-    "node_modules/file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+    "node_modules/figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "flat-cache": "^3.0.4"
+        "escape-string-regexp": "^1.0.5"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/file-entry-cache/node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
       "optional": true
     },
     "node_modules/filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha512-BTCqyBaWBTsauvnHiE8i562+EdJj+oUpkqWp2R1iCoR8f6oo8STRu3of7WJJ0TqWtxN50a5YFpzYK4Jj9esYfQ==",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3629,7 +3803,8 @@
     "node_modules/fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
       "dependencies": {
         "extend-shallow": "^2.0.1",
         "is-number": "^3.0.0",
@@ -3638,6 +3813,39 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fill-range/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fill-range/node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fill-range/node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/finalhandler": {
@@ -3688,9 +3896,8 @@
     "node_modules/find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "locate-path": "^2.0.0"
       },
@@ -3702,6 +3909,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
       "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
+      "dev": true,
       "dependencies": {
         "detect-file": "^1.0.0",
         "is-glob": "^4.0.0",
@@ -3712,10 +3920,266 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/findup-sync/node_modules/arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/braces/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/expand-brackets/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/expand-brackets/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/expand-brackets/node_modules/is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/expand-brackets/node_modules/kind-of": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "dependencies": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/extglob/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/extglob/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/is-accessor-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/is-data-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
     "node_modules/fined": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
       "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
+      "dev": true,
       "dependencies": {
         "expand-tilde": "^2.0.2",
         "is-plain-object": "^2.0.3",
@@ -3731,54 +4195,70 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
       "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
+      "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "flatted": "^3.1.0",
-        "rimraf": "^3.0.2"
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=0.10.0"
       }
-    },
-    "node_modules/flat-cache/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/flatted": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
-      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
       "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
+      }
+    },
+    "node_modules/flush-write-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/flush-write-stream/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/flush-write-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/flush-write-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/fn.name": {
@@ -3788,9 +4268,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "dev": true,
       "funding": [
         {
@@ -3807,19 +4287,11 @@
         }
       }
     },
-    "node_modules/for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "dev": true,
-      "dependencies": {
-        "is-callable": "^1.1.3"
-      }
-    },
     "node_modules/for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3827,7 +4299,8 @@
     "node_modules/for-own": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-      "integrity": "sha512-0OABksIGrxKK8K4kynWkQ7y1zounQxP+CWnyclVwj81KW3vlLlGUx57DKGcP/LH216GzqnstnPocF16Nxs0Ycg==",
+      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+      "dev": true,
       "dependencies": {
         "for-in": "^1.0.1"
       },
@@ -3835,10 +4308,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
     "node_modules/formatio": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-      "integrity": "sha512-YAF05v8+XCxAyHOdiiAmHdgCVPrWO8X744fYIPtBciIorh5LndWfi1gjeJ16sTbJhzek9kd+j3YByhohtz5Wmg==",
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
       "deprecated": "This package is unmaintained. Use @sinonjs/formatio instead",
       "dev": true,
       "dependencies": {
@@ -3848,7 +4350,8 @@
     "node_modules/fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-      "integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
       "dependencies": {
         "map-cache": "^0.2.2"
       },
@@ -3859,25 +4362,43 @@
     "node_modules/fresh": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz",
-      "integrity": "sha512-ckGdAuSRr1wBmnq7CsW7eU37DBwQxHx3vW8foJUIrF56rkOy8Osm6Fe8KSwemwyKejivKki7jVBgpBpBJexmrw==",
+      "integrity": "sha1-v9lALPPfEsSkwxDHn5mj3eE9NKc=",
       "dev": true
     },
     "node_modules/from": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
     },
-    "node_modules/fs-constants": {
+    "node_modules/fs-access": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
+      "dev": true,
+      "dependencies": {
+        "null-check": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fs-extra": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+      "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0"
+      }
     },
     "node_modules/fs-mkdirp-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
-      "integrity": "sha512-+vSd9frUnapVC2RZYfL3FCB2p3g4TBhaUmrsWlSudsGdnxIuUvBB2QM1VZeBtc49QFwrp+wQLrDs3+xxDgI5gQ==",
+      "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.11",
         "through2": "^2.0.3"
@@ -3889,13 +4410,15 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -3912,60 +4435,26 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
-    "node_modules/function.prototype.name": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
-      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0",
-        "functions-have-names": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/functions-have-names": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
     "node_modules/get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
     },
     "node_modules/get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -3975,29 +4464,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+    "node_modules/get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
       "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-stream/node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/get-symbol-description": {
@@ -4019,20 +4492,31 @@
     "node_modules/get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.1.1",
+        "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -4046,7 +4530,7 @@
     "node_modules/glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha512-ab1S1g1EbO7YzauaJLkgLp7DZVAqj9M/dvKlTt8DkXA2tiOIcSMrlVI2J1RZyB5iJVccEscjGn+kpOG9788MHA==",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "dependencies": {
         "glob-parent": "^2.0.0",
@@ -4059,7 +4543,7 @@
     "node_modules/glob-base/node_modules/is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4068,7 +4552,7 @@
     "node_modules/glob-base/node_modules/is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "dependencies": {
         "is-extglob": "^1.0.0"
@@ -4080,7 +4564,7 @@
     "node_modules/glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha512-JDYOvfxio/t42HKdxkAYaCiBN7oYiuxykOxKxdaUW5Qn0zaYN3gRQWolrwdnf0shM9/EP0ebuuTmyoXNr1cC5w==",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "dependencies": {
         "is-glob": "^2.0.0"
@@ -4089,7 +4573,7 @@
     "node_modules/glob-parent/node_modules/is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4098,7 +4582,7 @@
     "node_modules/glob-parent/node_modules/is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "dependencies": {
         "is-extglob": "^1.0.0"
@@ -4110,7 +4594,8 @@
     "node_modules/glob-stream": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
-      "integrity": "sha512-uMbLGAP3S2aDOHUDfdoYcdIePUCfysbAd0IAoWVZbeGU/oNQ8asHVSshLDJUPWxfzj8zsCG7/XeHPHTtow0nsw==",
+      "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
+      "dev": true,
       "dependencies": {
         "extend": "^3.0.0",
         "glob": "^7.1.1",
@@ -4130,7 +4615,8 @@
     "node_modules/glob-stream/node_modules/glob-parent": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
       "dependencies": {
         "is-glob": "^3.1.0",
         "path-dirname": "^1.0.0"
@@ -4139,7 +4625,8 @@
     "node_modules/glob-stream/node_modules/is-glob": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-      "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
+      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.0"
       },
@@ -4147,10 +4634,47 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/glob-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/glob-stream/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/glob-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/glob-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/glob-watcher": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.5.tgz",
       "integrity": "sha512-zOZgGGEHPklZNjZQaZ9f41i7F2YwE+tS5ZHrDhbBCk3stwahn5vQxnFmBJZHoYdusR6R1bLSXeGUy/BhctwKzw==",
+      "dev": true,
       "dependencies": {
         "anymatch": "^2.0.0",
         "async-done": "^1.2.0",
@@ -4168,6 +4692,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "dev": true,
       "dependencies": {
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
@@ -4177,8 +4702,60 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
       "dependencies": {
         "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/braces/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -4189,6 +4766,7 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
       "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
       "deprecated": "Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies",
+      "dev": true,
       "dependencies": {
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
@@ -4206,10 +4784,128 @@
         "fsevents": "^1.2.7"
       }
     },
+    "node_modules/glob-watcher/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/expand-brackets/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/expand-brackets/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/expand-brackets/node_modules/is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/expand-brackets/node_modules/kind-of": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "dependencies": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/extglob/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/extglob/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/glob-watcher/node_modules/glob-parent": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
       "dependencies": {
         "is-glob": "^3.1.0",
         "path-dirname": "^1.0.0"
@@ -4218,7 +4914,8 @@
     "node_modules/glob-watcher/node_modules/glob-parent/node_modules/is-glob": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-      "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
+      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.0"
       },
@@ -4226,10 +4923,98 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/glob-watcher/node_modules/is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/is-accessor-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/is-data-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
     "node_modules/glob-watcher/node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4238,6 +5023,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "dev": true,
       "dependencies": {
         "global-prefix": "^1.0.1",
         "is-windows": "^1.0.1",
@@ -4250,7 +5036,8 @@
     "node_modules/global-prefix": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-      "integrity": "sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "dev": true,
       "dependencies": {
         "expand-tilde": "^2.0.2",
         "homedir-polyfill": "^1.0.1",
@@ -4275,6 +5062,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
       "integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
+      "dev": true,
       "dependencies": {
         "sparkles": "^1.0.0"
       },
@@ -4285,16 +5073,18 @@
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
     },
     "node_modules/gulp": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
-      "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.0.tgz",
+      "integrity": "sha1-lXZsYB2t5Kd+0+eyttwDiBtZY2Y=",
+      "dev": true,
       "dependencies": {
-        "glob-watcher": "^5.0.3",
-        "gulp-cli": "^2.2.0",
-        "undertaker": "^1.2.1",
+        "glob-watcher": "^5.0.0",
+        "gulp-cli": "^2.0.0",
+        "undertaker": "^1.0.0",
         "vinyl-fs": "^3.0.0"
       },
       "bin": {
@@ -4308,6 +5098,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.3.0.tgz",
       "integrity": "sha512-zzGBl5fHo0EKSXsHzjspp3y5CONegCm8ErO5Qh0UzFzk2y4tMvzLWhoDokADbarfZRL2pGpRp7yt6gfJX4ph7A==",
+      "dev": true,
       "dependencies": {
         "ansi-colors": "^1.0.1",
         "archy": "^1.0.0",
@@ -4338,7 +5129,7 @@
     "node_modules/gulp-karma": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/gulp-karma/-/gulp-karma-0.0.1.tgz",
-      "integrity": "sha512-O3Ca4S6UZbjdNu/QDIjPwtqF+7YnJlu/5pMPZWzRB8uT5/fdv8xq38OojlIaZOLzK6IoGFxaVuKWE/t6tJwPjw==",
+      "integrity": "sha1-srK9lpT0eKXytJ0i2AhszCaLCpo=",
       "deprecated": "gulp-karma has been deprecated, use Karma directly instead",
       "dev": true,
       "dependencies": {
@@ -4352,10 +5143,19 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/gulp-karma/node_modules/ansi-styles": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-0.2.0.tgz",
+      "integrity": "sha1-NZq0sV3NZLptdHNLcsNjYKmvLBk=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/gulp-karma/node_modules/base64id": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
-      "integrity": "sha512-DSjtfjhAsHl9J4OJj7e4+toV2zqxJrGwVd3CLlsCp8QmicvOn7irG0Mb8brOc/nur3SdO8lIbNlY1s1ZDJdUKQ==",
+      "integrity": "sha1-As4P3u4M709ACA4ec+g08LG/zj8=",
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
@@ -4364,13 +5164,13 @@
     "node_modules/gulp-karma/node_modules/batch": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz",
-      "integrity": "sha512-avtDJBSxllB5QGphW1OXYF+ujhy/yIGgeFsvK6UiZLU86nWlqsNcZotUKd001wrl9MmZ9QIyVy8WFVEEpRIc5A==",
+      "integrity": "sha1-/S4Fp6XWlrTbkxQBPihdj/NVfsM=",
       "dev": true
     },
     "node_modules/gulp-karma/node_modules/buffer-crc32": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
-      "integrity": "sha512-vMfBIRp/wjlpueSz7Sb0OmO7C5SH58SSmbsT8G4D48YfO/Zgbr29xNXMpZVSC14ujVJfrZZH1Bl+kXYRQPuvfQ==",
+      "integrity": "sha1-vj5TgvwCttYySVasGvmKqYsIU0w=",
       "dev": true,
       "engines": {
         "node": "*"
@@ -4379,13 +5179,26 @@
     "node_modules/gulp-karma/node_modules/bytes": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz",
-      "integrity": "sha512-odbk8/wGazOuC1v8v4phoV285/yx8UN5kfQhhuxaVcceig4OUiCZQBtaEtmA1Q78QSTN9iXOQ7X2EViybrEvtQ==",
+      "integrity": "sha1-VVsIq8sGP4l1kFMCUj5M1P/f3zE=",
       "dev": true
+    },
+    "node_modules/gulp-karma/node_modules/chalk": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
+      "integrity": "sha1-HJhDdzfxGZ68wdTEj9Qbn5yOjyM=",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "~0.2.0",
+        "has-color": "~0.1.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/gulp-karma/node_modules/chokidar": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.8.4.tgz",
-      "integrity": "sha512-auWFkYQV6w4821+YQATR3ueTMRPMAK9qVzl9cyE1O7dM7l2/NI6IIDcvPrER+RzdgoCi5b9aCy3btoZFsLVJbw==",
+      "integrity": "sha1-OytQZoFwhlNLqBoJK9z0viW4vuA=",
       "deprecated": "Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.",
       "dev": true,
       "optionalDependencies": {
@@ -4396,7 +5209,7 @@
     "node_modules/gulp-karma/node_modules/colors": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-      "integrity": "sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw==",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
       "dev": true,
       "engines": {
         "node": ">=0.1.90"
@@ -4405,7 +5218,7 @@
     "node_modules/gulp-karma/node_modules/commander": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
-      "integrity": "sha512-J2wnb6TKniXNOtoHS8TSrG9IOQluPrsmyAJ8oCUJOBmv+uLBCyPYAZkD2jFvw2DCzIXNnISIM01NIvr35TkBMQ==",
+      "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
       "dev": true,
       "engines": {
         "node": ">= 0.6.x"
@@ -4414,7 +5227,7 @@
     "node_modules/gulp-karma/node_modules/connect": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/connect/-/connect-2.12.0.tgz",
-      "integrity": "sha512-i3poGdQamCEvDhvaFuG99KUDCU1Cvv7S2T6YfpY4X2+a0+uDrUcpRk08AQEge3NhtidVKfODQfpoMW4xlbQ0LQ==",
+      "integrity": "sha1-Mdj6DcrN8ZCNgivSkjvootKn7Zo=",
       "deprecated": "connect 2.x series is deprecated",
       "dev": true,
       "dependencies": {
@@ -4441,7 +5254,7 @@
     "node_modules/gulp-karma/node_modules/cookie": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
-      "integrity": "sha512-YSNOBX085/nzHvrTLEHYHoNdkvpLU1MPjU3r1IGawudZJjfuqnRNIFrcOJJ7bfwC+HWbHL1Y4yMkC0O+HWjV7w==",
+      "integrity": "sha1-kOtGndzpBchm3mh+/EMTHYgB+dA=",
       "dev": true,
       "engines": {
         "node": "*"
@@ -4450,7 +5263,7 @@
     "node_modules/gulp-karma/node_modules/debug": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
-      "integrity": "sha512-HlXEJm99YsRjLJ8xmuz0Lq8YUwrv7hAJkTEr6/Em3sUlSUNl0UdFA+1SrY4fnykeq1FVkUEUtwRGHs9VvlYbGA==",
+      "integrity": "sha1-IP9NJvXkIstoobrLu2EDmtjBwTA=",
       "dev": true,
       "engines": {
         "node": "*"
@@ -4459,7 +5272,7 @@
     "node_modules/gulp-karma/node_modules/glob": {
       "version": "3.2.11",
       "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
       "dev": true,
       "dependencies": {
         "inherits": "2",
@@ -4486,17 +5299,32 @@
     "node_modules/gulp-karma/node_modules/graceful-fs": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-      "integrity": "sha512-hcj/NTUWv+C3MbqrVb9F+aH6lvTwEHJdx2foBxlrVq5h6zE8Bfu4pv4CAAqbDcZrw/9Ak5lsRXlY9Ao8/F0Tuw==",
+      "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
       "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
     },
+    "node_modules/gulp-karma/node_modules/gulp-util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-1.2.0.tgz",
+      "integrity": "sha1-OTOhF+F0oD+ebxRvcg7XxtPE8gA=",
+      "deprecated": "gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5",
+      "dev": true,
+      "dependencies": {
+        "chalk": "~0.3.0",
+        "lodash.template": "~2.4.1",
+        "optimist": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/gulp-karma/node_modules/http-proxy": {
       "version": "0.10.4",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.4.tgz",
-      "integrity": "sha512-lb5uBBW+eLzoZ/Tute8ENcbNvibErYYPzNhjZk9IZugBAl87kUSxzVLBwQ7FbU2qBuorbah6VObuXvp2DN1LbA==",
+      "integrity": "sha1-FLoM6qIZf4n6MN6p57CeGc2Twi8=",
       "dev": true,
       "dependencies": {
         "colors": "0.x.x",
@@ -4514,7 +5342,7 @@
     "node_modules/gulp-karma/node_modules/karma": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/karma/-/karma-0.11.14.tgz",
-      "integrity": "sha512-C1/QPwxankTBabz8cysaYm7RogIKBb/dCIbc+XIfSWt7L7ZnwWA53Zg907RDYWU1z2oPaDxTxTkVyRjn1KFLfA==",
+      "integrity": "sha1-L2+BYRv+YuWI1OHWPBTzkolxp3w=",
       "dev": true,
       "dependencies": {
         "chokidar": "~0.8.0",
@@ -4543,17 +5371,70 @@
     "node_modules/gulp-karma/node_modules/lodash": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
       "dev": true,
       "engines": [
         "node",
         "rhino"
       ]
     },
+    "node_modules/gulp-karma/node_modules/lodash._reinterpolate": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+      "integrity": "sha1-TxInqlqHEfxjL1sHofRgequLMiI=",
+      "dev": true
+    },
+    "node_modules/gulp-karma/node_modules/lodash.escape": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+      "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
+      "dev": true,
+      "dependencies": {
+        "lodash._escapehtmlchar": "~2.4.1",
+        "lodash._reunescapedhtml": "~2.4.1",
+        "lodash.keys": "~2.4.1"
+      }
+    },
+    "node_modules/gulp-karma/node_modules/lodash.keys": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+      "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+      "dev": true,
+      "dependencies": {
+        "lodash._isnative": "~2.4.1",
+        "lodash._shimkeys": "~2.4.1",
+        "lodash.isobject": "~2.4.1"
+      }
+    },
+    "node_modules/gulp-karma/node_modules/lodash.template": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+      "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
+      "dev": true,
+      "dependencies": {
+        "lodash._escapestringchar": "~2.4.1",
+        "lodash._reinterpolate": "~2.4.1",
+        "lodash.defaults": "~2.4.1",
+        "lodash.escape": "~2.4.1",
+        "lodash.keys": "~2.4.1",
+        "lodash.templatesettings": "~2.4.1",
+        "lodash.values": "~2.4.1"
+      }
+    },
+    "node_modules/gulp-karma/node_modules/lodash.templatesettings": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
+      "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
+      "dev": true,
+      "dependencies": {
+        "lodash._reinterpolate": "~2.4.1",
+        "lodash.escape": "~2.4.1"
+      }
+    },
     "node_modules/gulp-karma/node_modules/lru-cache": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ==",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
     "node_modules/gulp-karma/node_modules/mime": {
@@ -4689,7 +5570,7 @@
     "node_modules/gulp-karma/node_modules/useragent/node_modules/lru-cache": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
-      "integrity": "sha512-Q5pAgXs+WEAfoEdw2qKQhNFFhMoFMTYqRVKKUMnzuiR7oKFHS7fWo848cPcTKw+4j/IdN17NyzdhVKgabFV0EA==",
+      "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=",
       "dev": true
     },
     "node_modules/gulp-karma/node_modules/ws": {
@@ -4711,47 +5592,11 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/gulp-util": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-1.2.0.tgz",
-      "integrity": "sha512-7RnGVNPv1MhYSTV+85T3g8x5qdqpPUL5KVRvvrnrYqzkFnqqvPSEheKOJ/e8+JPVyYpFnHqWfJbZmhZi9p44Gg==",
-      "deprecated": "gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5",
-      "dev": true,
-      "dependencies": {
-        "chalk": "~0.3.0",
-        "lodash.template": "~2.4.1",
-        "optimist": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/gulp-util/node_modules/ansi-styles": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-0.2.0.tgz",
-      "integrity": "sha512-YyQBeLj0juxUC9uUXRpQ1ZAzPT1dnsn5vVeJLHYFq4Ct1p0rymUSyvckKCXCH9I0bh3jWDIETA5nXIaZVKlDyA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/gulp-util/node_modules/chalk": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
-      "integrity": "sha512-OcfgS16PHpCu2Q4TNMtk0aZNx8PyeNiiB+6AgGH91fhT9hJ3v6pIIJ3lxlaOEDHlTm8t3wDe6bDGamvtIokQTg==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "~0.2.0",
-        "has-color": "~0.1.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/gulplog": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-      "integrity": "sha512-hm6N8nrm3Y08jXie48jsC55eCZz9mnb4OirAStEk2deqeyhXU3C1otDVh+ccttMuc1sBi6RX6ZJ720hs9RCvgw==",
+      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+      "dev": true,
       "dependencies": {
         "glogg": "^1.0.0"
       },
@@ -4759,10 +5604,64 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -4770,10 +5669,31 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-ansi/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/has-bigints": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4782,22 +5702,16 @@
     "node_modules/has-binary": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
-      "integrity": "sha512-k1Umb4/jrBWZbtL+QKSji8qWeoZ7ZTkXdnDXt1wxwBKAFM0//u96wDj43mBIqCIas8rDQMYyrBEvcS8hdGd4Sg==",
+      "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
       "dev": true,
       "dependencies": {
         "isarray": "0.0.1"
       }
     },
-    "node_modules/has-binary/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
-    },
     "node_modules/has-color": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha512-kaNz5OTAYYmt646Hkqw50/qyxP2vFnTVu5AQ1Zmk22Kk5+4Qx6BpO8+u7IKsML5fOsFk0ZT0AcCJNYwcvaLBvw==",
+      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4806,33 +5720,23 @@
     "node_modules/has-cors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-      "integrity": "sha512-g5VNKdkFuUuVCP9gYfDJHjK2nqdQJ7aDLTnycnc2+RvsOQbuLdF5pm7vuE5J76SEBIQjs4kQY/BWq74JUmjbXA==",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
       "dev": true
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-      "dependencies": {
-        "get-intrinsic": "^1.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4858,7 +5762,8 @@
     "node_modules/has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-      "integrity": "sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
       "dependencies": {
         "get-value": "^2.0.6",
         "has-values": "^1.0.0",
@@ -4871,7 +5776,8 @@
     "node_modules/has-values": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-      "integrity": "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
       "dependencies": {
         "is-number": "^3.0.0",
         "kind-of": "^4.0.0"
@@ -4880,12 +5786,50 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/has-values/node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-values/node_modules/is-number/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/has-values/node_modules/kind-of": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-      "integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
+      "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+      "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/hasha": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+      "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
+      "dev": true,
+      "dependencies": {
+        "is-stream": "^1.0.1",
+        "pinkie-promise": "^2.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -4895,6 +5839,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
       "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "dev": true,
       "dependencies": {
         "parse-passwd": "^1.0.0"
       },
@@ -4905,12 +5850,7 @@
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
-    },
-    "node_modules/html-escaper": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "node_modules/http-errors": {
@@ -4952,17 +5892,19 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
       }
     },
     "node_modules/i": {
@@ -4986,73 +5928,47 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "dependencies": {
+        "repeating": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/indexof": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg==",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -5061,12 +5977,59 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
+    },
+    "node_modules/inquirer": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.12",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/inquirer/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
@@ -5086,6 +6049,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -5093,7 +6057,8 @@
     "node_modules/invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5102,6 +6067,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "dev": true,
       "dependencies": {
         "is-relative": "^1.0.0",
         "is-windows": "^1.0.1"
@@ -5114,6 +6080,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
       "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "dev": true,
       "dependencies": {
         "kind-of": "^6.0.0"
       },
@@ -5125,6 +6092,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5146,9 +6114,10 @@
       }
     },
     "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "dev": true
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
@@ -5165,7 +6134,8 @@
     "node_modules/is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
       "dependencies": {
         "binary-extensions": "^1.0.0"
       },
@@ -5192,7 +6162,8 @@
     "node_modules/is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "node_modules/is-callable": {
       "version": "1.2.4",
@@ -5207,9 +6178,10 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "dev": true,
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -5221,6 +6193,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
       "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "dev": true,
       "dependencies": {
         "kind-of": "^6.0.0"
       },
@@ -5232,6 +6205,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5255,6 +6229,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
       "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "dev": true,
       "dependencies": {
         "is-accessor-descriptor": "^1.0.0",
         "is-data-descriptor": "^1.0.0",
@@ -5268,6 +6243,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5275,7 +6251,7 @@
     "node_modules/is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha512-9YclgOGtN/f8zx0Pr4FQYMdibBiTaH3sn52vjYip4ZSf6C4/6RfTEZ+MR4GvKhCxdPh21Bg42/WL55f6KSnKpg==",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5284,7 +6260,7 @@
     "node_modules/is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha512-0EygVC5qPvIyb+gSz7zdD5/AAoS6Qrx1e//6N4yv4oNm30kqvdmG66oZFWVlQHUWe5OjP08FuTw2IdT0EOTcYA==",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "dependencies": {
         "is-primitive": "^2.0.0"
@@ -5296,7 +6272,8 @@
     "node_modules/is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5304,26 +6281,38 @@
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
+    "node_modules/is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -5343,7 +6332,8 @@
     "node_modules/is-negated-glob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-      "integrity": "sha512-czXVVn/QEmgvej1f50BZ648vUI+em0xqMq2Sn+QncCLN4zj1UAxlT+kw/6ggQTOaZPd1HqKQGEqbpQVtJucWug==",
+      "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5361,12 +6351,10 @@
       }
     },
     "node_modules/is-number": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz",
+      "integrity": "sha1-aaevEWlj1HIG7JvZtIoUIW8eOAY=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5386,21 +6374,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-number/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -5411,7 +6389,7 @@
     "node_modules/is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha512-Yu68oeXJ7LeWNmZ3Zov/xg/oDBnBK2RNxwYY1ilNJX+tKKZqgPK+qOn/Gs9jEu66KDY9Netf5XLKNGzas/vPfQ==",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5420,7 +6398,7 @@
     "node_modules/is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha512-N3w1tFaRfk3UrPfqeRyD+GYDASU3W5VinKhlORy8EWVf/sIdDL9GAcew85XmktCfH+ngG7SRXEVDoO18WMdB/Q==",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5446,12 +6424,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "dev": true,
       "dependencies": {
         "is-unc-path": "^1.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
     },
     "node_modules/is-set": {
       "version": "2.0.2",
@@ -5472,6 +6457,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-string": {
@@ -5505,15 +6499,15 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.9.tgz",
-      "integrity": "sha512-kfrlnTTn8pZkfpJMUgYD7YZ3qzeJgWUn8XfVYBARc4wnmNOmLbmuuaAs3q5fvB0UJOn6yHAKaGTPM7d6ezoD/A==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.8.tgz",
+      "integrity": "sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==",
       "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
-        "for-each": "^0.3.3",
+        "es-abstract": "^1.18.5",
+        "foreach": "^2.0.5",
         "has-tostringtag": "^1.0.0"
       },
       "engines": {
@@ -5523,10 +6517,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
     "node_modules/is-unc-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "dev": true,
       "dependencies": {
         "unc-path-regex": "^0.1.2"
       },
@@ -5537,12 +6538,14 @@
     "node_modules/is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q=="
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
     },
     "node_modules/is-valid-glob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-      "integrity": "sha512-AhiROmoEFDSsjx8hW+5sGwgKVIORcXnrlAx/R0ZSeaPw70Vw0CqkGBBhHGL58Uox2eXnU1AnvXJl1XlyedO5bA==",
+      "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5585,14 +6588,16 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "node_modules/isbinaryfile": {
       "version": "3.0.3",
@@ -5609,116 +6614,110 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/istanbul-lib-coverage": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
-      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-instrument": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz",
-      "integrity": "sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-report": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
-      "dev": true,
-      "dependencies": {
-        "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^3.0.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-report/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-report/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/istanbul-reports": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.4.tgz",
-      "integrity": "sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==",
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "node_modules/istanbul": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+      "deprecated": "This module is no longer maintained, try this instead:\n  npm i nyc\nVisit https://istanbul.js.org/integrations for other alternatives.",
       "dev": true,
       "dependencies": {
-        "html-escaper": "^2.0.0",
-        "istanbul-lib-report": "^3.0.0"
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "istanbul": "lib/cli.js"
+      }
+    },
+    "node_modules/istanbul/node_modules/esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istanbul/node_modules/glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "dev": true,
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/istanbul/node_modules/has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istanbul/node_modules/resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "node_modules/istanbul/node_modules/supports-color": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/jasmine-core": {
       "version": "2.99.1",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.99.1.tgz",
-      "integrity": "sha512-ra97U4qu3OCcIxvN6eg3kyy8bLrID/TgxafSGMMICg3SFx5C/sUfDPpiOh7yoIsHdtjrOVdtT9rieYhqOsh9Ww==",
+      "integrity": "sha1-5kAN8ea1bhMLYcS80JPap/boyhU=",
       "dev": true
     },
     "node_modules/js-tokens": {
@@ -5728,34 +6727,28 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "argparse": "^2.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true,
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
     "node_modules/jsmin": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/jsmin/-/jsmin-1.0.1.tgz",
-      "integrity": "sha512-OPuL5X/bFKgVdMvEIX3hnpx3jbVpFCrEM8pKPXjFkZUqg521r41ijdyTz7vACOhW6o1neVlcLyd+wkbK5fNHRg==",
+      "integrity": "sha1-570NzWSWw79IYyNb9GGj2YqjuYw=",
       "dev": true,
       "bin": {
         "jsmin": "bin/jsmin"
@@ -5764,22 +6757,34 @@
         "node": ">=0.1.93"
       }
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "node_modules/json3": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha512-I5YLeauH3rIaE99EE++UeH2M2gSYo8/2TqDac7oZEH6D/DSQ4Woa628Qrfj1X9/OY5Mk5VvIDQaKCDchXaKrmA==",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "deprecated": "Please use the native JSON object instead of JSON 3",
       "dev": true
     },
@@ -5788,7 +6793,6 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -5796,10 +6800,34 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/jsx-ast-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.0.tgz",
-      "integrity": "sha512-XzO9luP6L0xkxwhIJMTJQpZo/eeN60K08jHdexfD569AGxeNug6UketeHXEhROoM8aR7EcUoOQmIhcJQjcuq8Q==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.2.tgz",
+      "integrity": "sha512-HDAyJ4MNQBboGpUnHAVUNJs6X0lh058s6FuixsFGP7MgJYpD6Vasd6nzSG5iIfXu1zAYlHJ/zsOKNlrenTUBnw==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.4",
@@ -5812,7 +6840,8 @@
     "node_modules/just-debounce": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.1.0.tgz",
-      "integrity": "sha512-qpcRocdkUmf+UTNBYx5w6dexX5J31AKK1OmPwH630a83DdVVUIngk55RSAiIGpQyoH0dlr872VHfPjnQnK1qDQ=="
+      "integrity": "sha512-qpcRocdkUmf+UTNBYx5w6dexX5J31AKK1OmPwH630a83DdVVUIngk55RSAiIGpQyoH0dlr872VHfPjnQnK1qDQ==",
+      "dev": true
     },
     "node_modules/just-extend": {
       "version": "4.2.1",
@@ -5823,7 +6852,7 @@
     "node_modules/jxLoader": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jxLoader/-/jxLoader-0.1.1.tgz",
-      "integrity": "sha512-ClEvAj3K68y8uKhub3RgTmcRPo5DfIWvtxqrKQdDPyZ1UVHIIKvVvjrAsJFSVL5wjv0rt5iH9SMCZ0XRKNzeUA==",
+      "integrity": "sha1-ATTqUUTlM7WU/B/yX/GU4jXFPs0=",
       "dev": true,
       "dependencies": {
         "js-yaml": "0.3.x",
@@ -5838,7 +6867,7 @@
     "node_modules/jxLoader/node_modules/js-yaml": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-0.3.7.tgz",
-      "integrity": "sha512-/7PsVDNP2tVe2Z1cF9kTEkjamIwz4aooDpRKmN1+g/9eePCgcxsv4QDvEbxO0EH+gdDD7MLyDoR6BASo3hH51g==",
+      "integrity": "sha1-1znY7oZGHlSzVNan19HyrZoWf2I=",
       "dev": true,
       "engines": {
         "node": "> 0.4.11"
@@ -5847,7 +6876,7 @@
     "node_modules/karma": {
       "version": "0.13.22",
       "resolved": "https://registry.npmjs.org/karma/-/karma-0.13.22.tgz",
-      "integrity": "sha512-A9/7e/IzHUkTcfjnTy5Wzo2P5wPuf7+QZh1JzNdTpYA0AN/vSrxfFjPKtKC3jRYJFZMJ7S1I9L2LItaJS1XMSg==",
+      "integrity": "sha1-B3ULG9Bj1+fnuRvNLmNU2PKqh0Q=",
       "dev": true,
       "dependencies": {
         "batch": "^0.5.3",
@@ -5882,35 +6911,48 @@
       }
     },
     "node_modules/karma-chrome-launcher": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-3.1.1.tgz",
-      "integrity": "sha512-hsIglcq1vtboGPAN+DGCISCFOxW+ZVnIqhDQcCMqqCp+4dmJ0Qpq5QAjkbA0X2L9Mi6OBkHi2Srrbmm7pUKkzQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.2.3.tgz",
+      "integrity": "sha1-TG1wDRY6nTTGGO/YeRi+SeekqMk=",
       "dev": true,
       "dependencies": {
+        "fs-access": "^1.0.0",
         "which": "^1.2.1"
       }
     },
     "node_modules/karma-coverage": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-2.2.0.tgz",
-      "integrity": "sha512-gPVdoZBNDZ08UCzdMHHhEImKrw1+PAOQOIiffv1YsvxFhBjqvo/SVXNk4tqn1SYqX0BJZT6S/59zgxiBe+9OuA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-1.1.2.tgz",
+      "integrity": "sha512-eQawj4Cl3z/CjxslYy9ariU4uDh7cCNFZHNWXWRpl0pNeblY/4wHR7M7boTYXWrn9bY0z2pZmr11eKje/S/hIw==",
       "dev": true,
       "dependencies": {
-        "istanbul-lib-coverage": "^3.2.0",
-        "istanbul-lib-instrument": "^5.1.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^4.0.1",
-        "istanbul-reports": "^3.0.5",
-        "minimatch": "^3.0.4"
+        "dateformat": "^1.0.6",
+        "istanbul": "^0.4.0",
+        "lodash": "^4.17.0",
+        "minimatch": "^3.0.0",
+        "source-map": "^0.5.1"
+      }
+    },
+    "node_modules/karma-coverage/node_modules/dateformat": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+      "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+      "dev": true,
+      "dependencies": {
+        "get-stdin": "^4.0.1",
+        "meow": "^3.3.0"
+      },
+      "bin": {
+        "dateformat": "bin/cli.js"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": "*"
       }
     },
     "node_modules/karma-jasmine": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.8.tgz",
-      "integrity": "sha512-EDNIM4f9FV17XXoF+Rzfw+6uPajd7tOAfEFwe7PIyNVQrM3l1V5OJj2167JDY9KmLDIK/MQZX7tKkK1jVYlfmw==",
+      "integrity": "sha1-W2RXeRrZuJqhc/B54+vhuMgFI2w=",
       "dev": true,
       "peerDependencies": {
         "jasmine-core": "*"
@@ -5919,14 +6961,27 @@
     "node_modules/karma-jasmine-jquery-2": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/karma-jasmine-jquery-2/-/karma-jasmine-jquery-2-0.1.1.tgz",
-      "integrity": "sha512-E5v945nXXIewxj4rMR8v6dx1LOKxT6H7ZA80EIZ0Pu31oAgd0Xx9Bj67n0guGYcUky1lXrftvA3C0k6OL9MFlA==",
+      "integrity": "sha1-/6wtvLXPWWqTMUP+I9fLfr7M0Eg=",
       "dev": true,
       "hasInstallScript": true
+    },
+    "node_modules/karma-phantomjs-launcher": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.4.tgz",
+      "integrity": "sha1-0jyjSAG9qYY60xjju0vUBisTrNI=",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.0.1",
+        "phantomjs-prebuilt": "^2.1.7"
+      },
+      "peerDependencies": {
+        "karma": ">=0.9"
+      }
     },
     "node_modules/karma-sinon": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/karma-sinon/-/karma-sinon-1.0.5.tgz",
-      "integrity": "sha512-wrkyAxJmJbn75Dqy17L/8aILJWFm7znd1CE8gkyxTBFnjMSOe2XTJ3P30T8SkxWZHmoHX0SCaUJTDBEoXs25Og==",
+      "integrity": "sha1-TjRD8oMP3s/2JNN0cWPxIX2qKpo=",
       "dev": true,
       "engines": {
         "node": ">= 0.10.0"
@@ -5939,15 +6994,34 @@
     "node_modules/karma/node_modules/lodash": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
+      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+      "dev": true
+    },
+    "node_modules/kew": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
       "dev": true
     },
     "node_modules/kind-of": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.9"
       }
     },
     "node_modules/kuler": {
@@ -5965,7 +7039,7 @@
     "node_modules/language-tags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
-      "integrity": "sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==",
+      "integrity": "sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=",
       "dev": true,
       "dependencies": {
         "language-subtag-registry": "~0.3.2"
@@ -5974,7 +7048,8 @@
     "node_modules/last-run": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
-      "integrity": "sha512-U/VxvpX4N/rFvPzr3qG5EtLKEnNI0emvIQB3/ecEwv+8GHaUKbIB8vxv1Oai5FAF0d0r7LXHhLLe5K/yChm5GQ==",
+      "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
+      "dev": true,
       "dependencies": {
         "default-resolution": "^2.0.0",
         "es6-weak-map": "^2.0.1"
@@ -5987,6 +7062,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -5994,10 +7070,47 @@
         "node": ">= 0.6.3"
       }
     },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
       "dependencies": {
         "invert-kv": "^1.0.0"
       },
@@ -6008,7 +7121,8 @@
     "node_modules/lead": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
-      "integrity": "sha512-IpSVCk9AYvLHo5ctcIXxOBpMWUe+4TKN3VPWAKUbJikkmsGp0VrSM8IttVc32D6J4WUsiPE6aEFRNmIoF/gdow==",
+      "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+      "dev": true,
       "dependencies": {
         "flush-write-stream": "^1.0.2"
       },
@@ -6017,14 +7131,13 @@
       }
     },
     "node_modules/levn": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "prelude-ls": "^1.2.1",
-        "type-check": "~0.4.0"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -6034,6 +7147,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
       "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
+      "dev": true,
       "dependencies": {
         "extend": "^3.0.0",
         "findup-sync": "^3.0.0",
@@ -6051,7 +7165,8 @@
     "node_modules/load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
@@ -6063,12 +7178,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/load-json-file/node_modules/strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "dependencies": {
+        "is-utf8": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
@@ -6086,7 +7212,7 @@
     "node_modules/lodash._escapehtmlchar": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
-      "integrity": "sha512-eHm2t2Lg476lq5v4FVmm3B5mCaRlDyTE8fnMfPCEq2o46G4au0qNXIKh7YWhjprm1zgSMLcMSs1XHMgkw02PbQ==",
+      "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
       "dev": true,
       "dependencies": {
         "lodash._htmlescapes": "~2.4.1"
@@ -6095,47 +7221,52 @@
     "node_modules/lodash._escapestringchar": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
-      "integrity": "sha512-iZ6Os4iipaE43pr9SBks+UpZgAjJgRC+lGf7onEoByMr1+Nagr1fmR7zCM6Q4RGMB/V3a57raEN0XZl7Uub3/g==",
+      "integrity": "sha1-7P4iYYoq3lC/7qQ5N+Ud9m8O23I=",
       "dev": true
     },
     "node_modules/lodash._htmlescapes": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
-      "integrity": "sha512-g79hNmMOBVyV+4oKIHM7MWy9Awtk3yqf0Twlawr6f+CmG44nTwBh9I5XiLUnk39KTfYoDBpS66glQGgQCnFIuA==",
+      "integrity": "sha1-MtFL8IRLbeb4tioFG09nwii2JMs=",
       "dev": true
     },
     "node_modules/lodash._isnative": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-      "integrity": "sha512-BOlKGKNHhCHswGOWtmVb5zBygyxN7EmTuzVOSQI6QSoGhG+kvv71gICFS1TBpnqvT1n53txK8CDK3u5D2/GZxQ==",
+      "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
       "dev": true
     },
     "node_modules/lodash._objecttypes": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-      "integrity": "sha512-XpqGh1e7hhkOzftBfWE7zt+Yn9mVHFkDhicVttvKLsoCMLVVL+xTQjfjB4X4vtznauxv0QZ5ZAeqjvat0dh62Q==",
-      "dev": true
-    },
-    "node_modules/lodash._reinterpolate": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
-      "integrity": "sha512-QGEOOjJi7W9LIgDAMVgtGBb8Qgo8ieDlSOCoZjtG45ZNRvDJZjwVMTYlfTIWdNRUiR1I9BjIqQ3Zaf1+DYM94g==",
+      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
       "dev": true
     },
     "node_modules/lodash._reunescapedhtml": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
-      "integrity": "sha512-CfmZRU1Mk4E/5jh+Wu8lc7tuc3VkuwWZYVIgdPDH9NRSHgiL4Or3AA4JCIpgrkVzHOM+jKu2OMkAVquruhRHDQ==",
+      "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
       "dev": true,
       "dependencies": {
         "lodash._htmlescapes": "~2.4.1",
         "lodash.keys": "~2.4.1"
       }
     },
+    "node_modules/lodash._reunescapedhtml/node_modules/lodash.keys": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+      "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+      "dev": true,
+      "dependencies": {
+        "lodash._isnative": "~2.4.1",
+        "lodash._shimkeys": "~2.4.1",
+        "lodash.isobject": "~2.4.1"
+      }
+    },
     "node_modules/lodash._shimkeys": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-      "integrity": "sha512-lBrglYxLD/6KAJ8IEa5Lg+YHgNAL7FyKqXg4XOUI+Du/vtniLs1ZqS+yHNKPkK54waAgkdUnDOYaWf+rv4B+AA==",
+      "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
       "dev": true,
       "dependencies": {
         "lodash._objecttypes": "~2.4.1"
@@ -6144,43 +7275,17 @@
     "node_modules/lodash.defaults": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
-      "integrity": "sha512-5wTIPWwGGr07JFysAZB8+7JB2NjJKXDIwogSaRX5zED85zyUAQwtOqUk8AsJkkigUcL3akbHYXd5+BPtTGQPZw==",
+      "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
       "dev": true,
       "dependencies": {
         "lodash._objecttypes": "~2.4.1",
         "lodash.keys": "~2.4.1"
       }
     },
-    "node_modules/lodash.escape": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
-      "integrity": "sha512-PiEStyvZ8gz37qBE+HqME1Yc/ewb/59AMOu8pG7Ztani86foPTxgzckQvMdphmXPY6V5f20Ex/CaNBqHG4/ycQ==",
-      "dev": true,
-      "dependencies": {
-        "lodash._escapehtmlchar": "~2.4.1",
-        "lodash._reunescapedhtml": "~2.4.1",
-        "lodash.keys": "~2.4.1"
-      }
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true
-    },
-    "node_modules/lodash.isobject": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-      "integrity": "sha512-sTebg2a1PoicYEZXD5PBdQcTlIJ6hUslrlWr7iV0O7n+i4596s2NQ9I5CaZ5FbXSfya/9WQsrYLANUJv9paYVA==",
-      "dev": true,
-      "dependencies": {
-        "lodash._objecttypes": "~2.4.1"
-      }
-    },
-    "node_modules/lodash.keys": {
+    "node_modules/lodash.defaults/node_modules/lodash.keys": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-      "integrity": "sha512-ZpJhwvUXHSNL5wYd1RM6CUa2ZuqorG9ngoJ9Ix5Cce+uX7I5O/E06FCJdhSZ33b5dVyeQDnIlWH7B2s5uByZ7g==",
+      "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
       "dev": true,
       "dependencies": {
         "lodash._isnative": "~2.4.1",
@@ -6188,51 +7293,45 @@
         "lodash.isobject": "~2.4.1"
       }
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "peer": true
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
-    "node_modules/lodash.template": {
+    "node_modules/lodash.isobject": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
-      "integrity": "sha512-5yLOQwlS69xbaez3g9dA1i0GMAj8pLDHp8lhA4V7M1vRam1lqD76f0jg5EV+65frbqrXo1WH9ZfKalfYBzJ5yQ==",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+      "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
       "dev": true,
       "dependencies": {
-        "lodash._escapestringchar": "~2.4.1",
-        "lodash._reinterpolate": "~2.4.1",
-        "lodash.defaults": "~2.4.1",
-        "lodash.escape": "~2.4.1",
-        "lodash.keys": "~2.4.1",
-        "lodash.templatesettings": "~2.4.1",
-        "lodash.values": "~2.4.1"
-      }
-    },
-    "node_modules/lodash.templatesettings": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
-      "integrity": "sha512-vY3QQ7GxbeLe8XfTvoYDbaMHO5iyTDJS1KIZrxp00PRMmyBKr8yEcObHSl2ppYTwd8MgqPXAarTvLA14hx8ffw==",
-      "dev": true,
-      "dependencies": {
-        "lodash._reinterpolate": "~2.4.1",
-        "lodash.escape": "~2.4.1"
+        "lodash._objecttypes": "~2.4.1"
       }
     },
     "node_modules/lodash.values": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
-      "integrity": "sha512-fQwubKvj2Nox2gy6YnjFm8C1I6MIlzKUtBB+Pj7JGtloGqDDL5CPRr4DUUFWPwXWwAl2k3f4C3Aw8H1qAPB9ww==",
+      "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
       "dev": true,
       "dependencies": {
         "lodash.keys": "~2.4.1"
       }
     },
+    "node_modules/lodash.values/node_modules/lodash.keys": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+      "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+      "dev": true,
+      "dependencies": {
+        "lodash._isnative": "~2.4.1",
+        "lodash._shimkeys": "~2.4.1",
+        "lodash.isobject": "~2.4.1"
+      }
+    },
     "node_modules/log4js": {
       "version": "0.6.38",
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
-      "integrity": "sha512-Cd+klbx7lkiaamEId9/0odHxv/PFHDz2E12kEfd6/CzIOZD084DzysASR/Dot4i1dYPBQKC3r2XIER+dfbLOmw==",
+      "integrity": "sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=",
       "dev": true,
       "dependencies": {
         "readable-stream": "~1.0.2",
@@ -6240,24 +7339,6 @@
       },
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/log4js/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
-    },
-    "node_modules/log4js/node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
       }
     },
     "node_modules/log4js/node_modules/semver": {
@@ -6268,12 +7349,6 @@
       "bin": {
         "semver": "bin/semver"
       }
-    },
-    "node_modules/log4js/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
     },
     "node_modules/logform": {
       "version": "2.4.0",
@@ -6299,12 +7374,24 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "dependencies": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/lru-cache": {
@@ -6317,25 +7404,11 @@
         "yallist": "^2.1.2"
       }
     },
-    "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/make-iterator": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
       "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
+      "dev": true,
       "dependencies": {
         "kind-of": "^6.0.2"
       },
@@ -6347,6 +7420,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6364,6 +7438,16 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6378,6 +7462,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
       "dependencies": {
         "object-visit": "^1.0.0"
       },
@@ -6389,6 +7474,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
       "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
+      "dev": true,
       "dependencies": {
         "findup-sync": "^2.0.0",
         "micromatch": "^3.0.4",
@@ -6399,10 +7485,179 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/matchdep/node_modules/arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matchdep/node_modules/array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matchdep/node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matchdep/node_modules/braces/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matchdep/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/matchdep/node_modules/expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matchdep/node_modules/expand-brackets/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matchdep/node_modules/expand-brackets/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matchdep/node_modules/expand-brackets/node_modules/is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matchdep/node_modules/expand-brackets/node_modules/kind-of": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matchdep/node_modules/extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "dependencies": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matchdep/node_modules/extglob/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matchdep/node_modules/extglob/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/matchdep/node_modules/findup-sync": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-      "integrity": "sha512-vs+3unmJT45eczmcAZ6zMJtxN3l/QXeccaXQx5cu/MeJMhewVfoWZqibRkOxPnmoR59+Zy5hjabfQc6JLSah4g==",
+      "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+      "dev": true,
       "dependencies": {
         "detect-file": "^1.0.0",
         "is-glob": "^3.1.0",
@@ -6413,10 +7668,59 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/matchdep/node_modules/is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matchdep/node_modules/is-accessor-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matchdep/node_modules/is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matchdep/node_modules/is-data-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/matchdep/node_modules/is-glob": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-      "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
+      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.0"
       },
@@ -6424,31 +7728,20 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/math-random": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
-      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
-      "dev": true
-    },
-    "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+    "node_modules/matchdep/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true,
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=0.10.0"
       }
     },
-    "node_modules/methods": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz",
-      "integrity": "sha1-M11Cnu/SG3us8unJIqjSvRSjDk8=",
-      "dev": true
-    },
-    "node_modules/micromatch": {
+    "node_modules/matchdep/node_modules/micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
       "dependencies": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -6468,35 +7761,187 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/micromatch/node_modules/extend-shallow": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+    "node_modules/matchdep/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/math-random": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+      "dev": true
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
       "dependencies": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/micromatch/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+    "node_modules/meow/node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/methods": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz",
+      "integrity": "sha1-M11Cnu/SG3us8unJIqjSvRSjDk8=",
+      "dev": true
+    },
+    "node_modules/micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "dev": true,
       "dependencies": {
-        "is-plain-object": "^2.0.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/micromatch/node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+    "node_modules/micromatch/node_modules/braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "dev": true,
+      "dependencies": {
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
+      },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/fill-range": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/micromatch/node_modules/isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
+      "dependencies": {
+        "isarray": "1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/mime": {
@@ -6532,10 +7977,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6553,6 +8008,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
       "dependencies": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -6565,6 +8021,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
       "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
       "dependencies": {
         "is-plain-object": "^2.0.4"
       },
@@ -6583,12 +8040,6 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true
     },
     "node_modules/moo-server": {
       "version": "1.3.0",
@@ -6618,12 +8069,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/multiparty/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
-    },
     "node_modules/multiparty/node_modules/readable-stream": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
@@ -6636,30 +8081,33 @@
         "string_decoder": "~0.10.x"
       }
     },
-    "node_modules/multiparty/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
     "node_modules/mute-stdout": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
       "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
     },
+    "node_modules/mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
     "node_modules/nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "dev": true,
       "optional": true
     },
     "node_modules/nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
       "dependencies": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -6677,25 +8125,20 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/nanomatch/node_modules/extend-shallow": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-      "dependencies": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
+    "node_modules/nanomatch/node_modules/arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/nanomatch/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
+    "node_modules/nanomatch/node_modules/array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6704,6 +8147,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6718,8 +8162,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/ncp": {
       "version": "0.4.2",
@@ -6739,10 +8182,23 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
     "node_modules/next-tick": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "dev": true
+    },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
     },
     "node_modules/nise": {
       "version": "1.5.3",
@@ -6766,36 +8222,23 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+    "node_modules/nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "abbrev": "1"
       },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+      "bin": {
+        "nopt": "bin/nopt.js"
       }
-    },
-    "node_modules/node-releases": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
-      "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==",
-      "dev": true
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
       "dependencies": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
@@ -6803,18 +8246,11 @@
         "validate-npm-package-license": "^3.0.1"
       }
     },
-    "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
       "dependencies": {
         "remove-trailing-separator": "^1.0.1"
       },
@@ -6826,6 +8262,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
       "integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.2"
       },
@@ -6833,22 +8270,31 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+    "node_modules/null-check": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
+      "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+    "node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/object-component": {
@@ -6861,6 +8307,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
       "dependencies": {
         "copy-descriptor": "^0.1.0",
         "define-property": "^0.2.5",
@@ -6873,7 +8320,8 @@
     "node_modules/object-copy/node_modules/define-property": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "dev": true,
       "dependencies": {
         "is-descriptor": "^0.1.0"
       },
@@ -6884,7 +8332,8 @@
     "node_modules/object-copy/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
       },
@@ -6895,7 +8344,8 @@
     "node_modules/object-copy/node_modules/is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
       },
@@ -6907,6 +8357,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
       "dependencies": {
         "is-accessor-descriptor": "^0.1.6",
         "is-data-descriptor": "^0.1.4",
@@ -6920,25 +8371,15 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
       "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-copy/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6964,6 +8405,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6972,6 +8414,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
       "dependencies": {
         "isobject": "^3.0.0"
       },
@@ -6983,6 +8426,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
       "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -7000,6 +8444,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+      "dev": true,
       "dependencies": {
         "array-each": "^1.0.1",
         "array-slice": "^1.0.0",
@@ -7014,6 +8459,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
       "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7023,7 +8469,6 @@
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
       "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -7038,7 +8483,6 @@
       "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
       "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -7052,14 +8496,13 @@
       }
     },
     "node_modules/object.hasown": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.1.tgz",
-      "integrity": "sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.0.tgz",
+      "integrity": "sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7069,6 +8512,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+      "dev": true,
       "dependencies": {
         "for-own": "^1.0.0",
         "make-iterator": "^1.0.0"
@@ -7093,7 +8537,7 @@
     "node_modules/object.omit/node_modules/for-own": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "dependencies": {
         "for-in": "^1.0.1"
@@ -7106,6 +8550,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -7117,6 +8562,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object.reduce/-/object.reduce-1.0.1.tgz",
       "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
+      "dev": true,
       "dependencies": {
         "for-own": "^1.0.0",
         "make-iterator": "^1.0.0"
@@ -7130,7 +8576,6 @@
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
       "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -7159,6 +8604,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -7170,6 +8616,18 @@
       "dev": true,
       "dependencies": {
         "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/optimist": {
@@ -7198,18 +8656,17 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "deep-is": "^0.1.3",
-        "fast-levenshtein": "^2.0.6",
-        "levn": "^0.4.1",
-        "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -7228,14 +8685,52 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
       "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
+      "dev": true,
       "dependencies": {
         "readable-stream": "^2.0.1"
+      }
+    },
+    "node_modules/ordered-read-streams/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/ordered-read-streams/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/ordered-read-streams/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/ordered-read-streams/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
       "dependencies": {
         "lcid": "^1.0.0"
       },
@@ -7257,7 +8752,6 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "p-try": "^1.0.0"
       },
@@ -7270,7 +8764,6 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "p-limit": "^1.1.0"
       },
@@ -7283,28 +8776,15 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/parse-filepath": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+      "dev": true,
       "dependencies": {
         "is-absolute": "^1.0.0",
         "map-cache": "^0.2.0",
@@ -7332,7 +8812,7 @@
     "node_modules/parse-glob/node_modules/is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -7341,7 +8821,7 @@
     "node_modules/parse-glob/node_modules/is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "dependencies": {
         "is-extglob": "^1.0.0"
@@ -7354,6 +8834,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
       "dependencies": {
         "error-ex": "^1.2.0"
       },
@@ -7365,6 +8846,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
       "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -7373,6 +8855,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7417,6 +8900,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7424,14 +8908,14 @@
     "node_modules/path-dirname": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
     },
     "node_modules/path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7440,29 +8924,37 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
     "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true,
-      "peer": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/path-root": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "dev": true,
       "dependencies": {
         "path-root-regex": "^0.1.0"
       },
@@ -7474,6 +8966,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7487,16 +8980,11 @@
         "isarray": "0.0.1"
       }
     },
-    "node_modules/path-to-regexp/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
-    },
     "node_modules/path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "pify": "^2.0.0",
@@ -7527,16 +9015,48 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
-    "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
+    },
+    "node_modules/phantomjs-prebuilt": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
+      "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
+      "deprecated": "this package is now deprecated",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "es6-promise": "^4.0.3",
+        "extract-zip": "^1.6.5",
+        "fs-extra": "^1.0.0",
+        "hasha": "^2.2.0",
+        "kew": "^0.7.0",
+        "progress": "^1.1.8",
+        "request": "^2.81.0",
+        "request-progress": "^2.0.1",
+        "which": "^1.2.10"
+      },
+      "bin": {
+        "phantomjs": "bin/phantomjs"
+      }
+    },
+    "node_modules/phantomjs-prebuilt/node_modules/progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7545,6 +9065,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7553,93 +9074,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
       "dependencies": {
         "pinkie": "^2.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/pkginfo": {
@@ -7649,6 +9089,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/policyfile": {
@@ -7664,16 +9113,16 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -7691,6 +9140,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -7698,7 +9148,8 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -7720,18 +9171,20 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+    "node_modules/prop-types/node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",
@@ -7739,10 +9192,17 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
+    "node_modules/psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
+    },
     "node_modules/pump": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -7752,6 +9212,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "dev": true,
       "dependencies": {
         "duplexify": "^3.6.0",
         "inherits": "^2.0.3",
@@ -7763,69 +9224,8 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/puppeteer": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-14.1.2.tgz",
-      "integrity": "sha512-Nsyy1f7pT2KyBb15u8DHi4q3FfrIqOptAV0r4Bd1lAp2pHz8T0o4DO+On1yWZ7jFbcx1w3AqZ/e7nKqnc3Vwyg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "cross-fetch": "3.1.5",
-        "debug": "4.3.4",
-        "devtools-protocol": "0.0.982423",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.1",
-        "pkg-dir": "4.2.0",
-        "progress": "2.0.3",
-        "proxy-from-env": "1.1.0",
-        "rimraf": "3.0.2",
-        "tar-fs": "2.1.1",
-        "unbzip2-stream": "1.4.3",
-        "ws": "8.6.0"
-      },
-      "engines": {
-        "node": ">=14.1.0"
-      }
-    },
-    "node_modules/puppeteer/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/puppeteer/node_modules/ws": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.6.0.tgz",
-      "integrity": "sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/q": {
@@ -7913,13 +9313,13 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
       "dependencies": {
         "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
@@ -7933,6 +9333,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
       "dependencies": {
         "find-up": "^1.0.0",
         "read-pkg": "^1.0.0"
@@ -7944,7 +9345,8 @@
     "node_modules/read-pkg-up/node_modules/find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
       "dependencies": {
         "path-exists": "^2.0.0",
         "pinkie-promise": "^2.0.0"
@@ -7957,6 +9359,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
       "dependencies": {
         "pinkie-promise": "^2.0.0"
       },
@@ -7965,9 +9368,297 @@
       }
     },
     "node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/readdirp/node_modules/arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/braces/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/expand-brackets/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/expand-brackets/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/expand-brackets/node_modules/is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/expand-brackets/node_modules/kind-of": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "dependencies": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/extglob/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/extglob/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/is-accessor-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/is-data-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/readdirp/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/readdirp/node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -7978,23 +9669,26 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/readdirp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+    "node_modules/readdirp/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/readdirp/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10"
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
       "dependencies": {
         "resolve": "^1.1.6"
       },
@@ -8010,6 +9704,19 @@
       "optional": true,
       "engines": {
         "node": ">=0.6.6"
+      }
+    },
+    "node_modules/redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/redis": {
@@ -8044,6 +9751,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
       "dependencies": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
@@ -8052,38 +9760,14 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/regex-not/node_modules/extend-shallow": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-      "dependencies": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/regex-not/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
+      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.1.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8093,22 +9777,19 @@
       }
     },
     "node_modules/regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true,
-      "peer": true,
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
+        "node": ">=6.5.0"
       }
     },
     "node_modules/remove-bom-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
       "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+      "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5",
         "is-utf8": "^0.2.1"
@@ -8121,6 +9802,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
       "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+      "dev": true,
       "dependencies": {
         "remove-bom-buffer": "^3.0.0",
         "safe-buffer": "^5.1.0",
@@ -8133,28 +9815,44 @@
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
     },
     "node_modules/repeat-element": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
       "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz",
+      "integrity": "sha1-x6jTI2BoNiBZp+RlH8aITosftK4=",
+      "dev": true,
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "dependencies": {
+        "is-finite": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/replace-ext": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
       "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -8163,6 +9861,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz",
       "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
+      "dev": true,
       "dependencies": {
         "homedir-polyfill": "^1.0.1",
         "is-absolute": "^1.0.0",
@@ -8172,10 +9871,61 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "dev": true,
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/request-progress": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+      "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
+      "dev": true,
+      "dependencies": {
+        "throttleit": "^1.0.0"
+      }
+    },
+    "node_modules/request/node_modules/qs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8183,7 +9933,30 @@
     "node_modules/require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "node_modules/require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "dependencies": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-uncached/node_modules/resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
@@ -8195,6 +9968,7 @@
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
       "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "dev": true,
       "dependencies": {
         "is-core-module": "^2.8.1",
         "path-parse": "^1.0.7",
@@ -8211,6 +9985,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dev": true,
       "dependencies": {
         "expand-tilde": "^2.0.0",
         "global-modules": "^1.0.0"
@@ -8219,20 +9994,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/resolve-options": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
       "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+      "dev": true,
       "dependencies": {
         "value-or-function": "^3.0.0"
       },
@@ -8244,12 +10010,27 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-      "deprecated": "https://github.com/lydell/resolve-url#deprecated"
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated",
+      "dev": true
+    },
+    "node_modules/restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
       "engines": {
         "node": ">=0.12"
       }
@@ -8266,15 +10047,67 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "node_modules/rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "dependencies": {
+        "rx-lite": "*"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
     "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
       "dependencies": {
         "ret": "~0.1.10"
       }
@@ -8302,18 +10135,19 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
       "bin": {
-        "semver": "bin/semver.js"
+        "semver": "bin/semver"
       }
     },
     "node_modules/semver-greatest-satisfied-range": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
       "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
+      "dev": true,
       "dependencies": {
         "sver-compat": "^1.5.0"
       },
@@ -8342,17 +10176,31 @@
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "node_modules/set-value": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
       "dependencies": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
         "is-plain-object": "^2.0.3",
         "split-string": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/set-value/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -8365,26 +10213,24 @@
       "dev": true
     },
     "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "shebang-regex": "^3.0.0"
+        "shebang-regex": "^1.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true,
-      "peer": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/side-channel": {
@@ -8407,6 +10253,12 @@
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -8415,12 +10267,6 @@
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "dev": true
     },
     "node_modules/sinon": {
       "version": "3.3.0",
@@ -8444,10 +10290,25 @@
         "node": ">=0.1.103"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
       "dependencies": {
         "base": "^0.11.1",
         "debug": "^2.2.0",
@@ -8466,6 +10327,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
       "dependencies": {
         "define-property": "^1.0.0",
         "isobject": "^3.0.0",
@@ -8478,7 +10340,8 @@
     "node_modules/snapdragon-node/node_modules/define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "dev": true,
       "dependencies": {
         "is-descriptor": "^1.0.0"
       },
@@ -8490,19 +10353,9 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
       "dependencies": {
         "kind-of": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon-util/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -8512,6 +10365,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -8519,9 +10373,22 @@
     "node_modules/snapdragon/node_modules/define-property": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "dev": true,
       "dependencies": {
         "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -8530,20 +10397,10 @@
     "node_modules/snapdragon/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -8552,20 +10409,10 @@
     "node_modules/snapdragon/node_modules/is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -8575,6 +10422,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
       "dependencies": {
         "is-accessor-descriptor": "^0.1.6",
         "is-data-descriptor": "^0.1.4",
@@ -8584,10 +10432,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/snapdragon/node_modules/is-descriptor/node_modules/kind-of": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/snapdragon/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "node_modules/socket.io": {
       "version": "1.7.4",
@@ -8617,7 +10475,7 @@
     "node_modules/socket.io-adapter/node_modules/debug": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-      "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
+      "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
       "dev": true,
       "dependencies": {
         "ms": "0.7.2"
@@ -8648,16 +10506,10 @@
         "to-array": "0.1.4"
       }
     },
-    "node_modules/socket.io-client/node_modules/component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha512-jPatnhd33viNplKjqXKRkGU345p263OIWzDL2wH3LGIGp5Kojo+uXizHmOADRvhGFFTnJqX3jBAKP6vvmSDKcA==",
-      "dev": true
-    },
     "node_modules/socket.io-client/node_modules/debug": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-      "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
+      "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
       "dev": true,
       "dependencies": {
         "ms": "0.7.2"
@@ -8684,23 +10536,17 @@
     "node_modules/socket.io-parser/node_modules/component-emitter": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-      "integrity": "sha512-YhIbp3PJiznERfjlIkK0ue4obZxt2S60+0W8z24ZymOHT8sHloOqWOqZRU2eN5OlY8U08VFsP02letcu26FilA==",
+      "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
       "dev": true
     },
     "node_modules/socket.io-parser/node_modules/debug": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-      "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
       "dev": true,
       "dependencies": {
         "ms": "0.7.1"
       }
-    },
-    "node_modules/socket.io-parser/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
     },
     "node_modules/socket.io-parser/node_modules/ms": {
       "version": "0.7.1",
@@ -8711,7 +10557,7 @@
     "node_modules/socket.io/node_modules/debug": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-      "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
+      "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
       "dev": true,
       "dependencies": {
         "ms": "0.7.2"
@@ -8736,6 +10582,7 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8745,6 +10592,7 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
       "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
       "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
+      "dev": true,
       "dependencies": {
         "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0",
@@ -8757,12 +10605,14 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
-      "deprecated": "See https://github.com/lydell/source-map-url#deprecated"
+      "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
+      "dev": true
     },
     "node_modules/sparkles": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
       "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -8771,6 +10621,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
       "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -8779,12 +10630,14 @@
     "node_modules/spdx-exceptions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -8793,7 +10646,8 @@
     "node_modules/spdx-license-ids": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g=="
+      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "dev": true
     },
     "node_modules/split": {
       "version": "0.2.10",
@@ -8811,6 +10665,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
       "dependencies": {
         "extend-shallow": "^3.0.0"
       },
@@ -8818,24 +10673,32 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/split-string/node_modules/extend-shallow": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-      "dependencies": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
-    "node_modules/split-string/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+    "node_modules/sshpk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "dev": true,
       "dependencies": {
-        "is-plain-object": "^2.0.4"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -8845,6 +10708,7 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -8853,6 +10717,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
       "dependencies": {
         "define-property": "^0.2.5",
         "object-copy": "^0.1.0"
@@ -8864,7 +10729,8 @@
     "node_modules/static-extend/node_modules/define-property": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "dev": true,
       "dependencies": {
         "is-descriptor": "^0.1.0"
       },
@@ -8875,20 +10741,10 @@
     "node_modules/static-extend/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -8897,20 +10753,10 @@
     "node_modules/static-extend/node_modules/is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -8920,11 +10766,21 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
       "dependencies": {
         "is-accessor-descriptor": "^0.1.6",
         "is-data-descriptor": "^0.1.4",
         "kind-of": "^5.0.0"
       },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/static-extend/node_modules/is-descriptor/node_modules/kind-of": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8959,12 +10815,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/stream-counter/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
-    },
     "node_modules/stream-counter/node_modules/readable-stream": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
@@ -8977,60 +10827,35 @@
         "string_decoder": "~0.10.x"
       }
     },
-    "node_modules/stream-counter/node_modules/string_decoder": {
+    "node_modules/stream-exhaust": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
+      "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
+      "dev": true
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "dev": true
+    },
+    "node_modules/string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
-    "node_modules/stream-exhaust": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
-      "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw=="
-    },
-    "node_modules/stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
-    },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/string-width/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
       "dependencies": {
-        "ansi-regex": "^2.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=4"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -9038,7 +10863,6 @@
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
       "integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -9054,68 +10878,74 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "define-properties": "^1.1.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "define-properties": "^1.1.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "ansi-regex": "^3.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
       "dependencies": {
-        "is-utf8": "^0.2.0"
+        "get-stdin": "^4.0.1"
+      },
+      "bin": {
+        "strip-indent": "cli.js"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true,
-      "peer": true,
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/supports-color": {
@@ -9134,6 +10964,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -9145,61 +10976,66 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
       "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
+      "dev": true,
       "dependencies": {
         "es6-iterator": "^2.0.1",
         "es6-symbol": "^3.1.1"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+    "node_modules/table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
       "dev": true,
       "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
-    "node_modules/tar-fs/node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "dev": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+      "engines": {
+        "node": ">=6"
       }
     },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+    "node_modules/table/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dev": true,
       "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/tar-stream/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "ansi-regex": "^4.1.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=6"
       }
     },
     "node_modules/text-encoding": {
@@ -9219,8 +11055,13 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true,
-      "peer": true
+      "dev": true
+    },
+    "node_modules/throttleit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+      "dev": true
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -9232,6 +11073,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
       "dependencies": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
@@ -9241,6 +11083,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
       "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
+      "dev": true,
       "dependencies": {
         "through2": "~2.0.0",
         "xtend": "~4.0.0"
@@ -9250,14 +11093,52 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/through2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/through2/node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4"
       }
@@ -9266,6 +11147,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
       "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9310,6 +11192,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
       "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
+      "dev": true,
       "dependencies": {
         "is-absolute": "^1.0.0",
         "is-negated-glob": "^1.0.0"
@@ -9324,32 +11207,13 @@
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
       "dev": true
     },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/to-object-path/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -9359,6 +11223,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
       "dependencies": {
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
@@ -9373,6 +11238,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
       "dependencies": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
@@ -9381,33 +11247,32 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/to-regex/node_modules/extend-shallow": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+    "node_modules/to-regex-range/node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
       "dependencies": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "kind-of": "^3.0.2"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/to-regex/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
+    "node_modules/to-regex-range/node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true,
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=0.10"
       }
     },
     "node_modules/to-through": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
       "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+      "dev": true,
       "dependencies": {
         "through2": "^2.0.3"
       },
@@ -9424,11 +11289,27 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/triple-beam": {
       "version": "1.3.0",
@@ -9441,7 +11322,6 @@
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
       "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
@@ -9449,29 +11329,43 @@
         "strip-bom": "^3.0.0"
       }
     },
-    "node_modules/tsconfig-paths/node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
-      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
       "engines": {
-        "node": ">=4"
+        "node": "*"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "node_modules/type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+      "dev": true
     },
     "node_modules/type-check": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "prelude-ls": "^1.2.1"
+        "prelude-ls": "~1.1.2"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -9484,19 +11378,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -9515,15 +11396,20 @@
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "node_modules/uglify-js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
-      "integrity": "sha1-S1v/+Rhu/7qoiOTJ6UvZ/EyUkp0=",
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
+      "integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
       "dev": true,
+      "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/uid2": {
@@ -9539,34 +11425,25 @@
       "dev": true
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-bigints": "^1.0.2",
-        "has-symbols": "^1.0.3",
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/unbzip2-stream": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-      "dev": true,
-      "dependencies": {
-        "buffer": "^5.2.1",
-        "through": "^2.3.8"
-      }
-    },
     "node_modules/unc-path-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9575,6 +11452,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.3.0.tgz",
       "integrity": "sha512-/RXwi5m/Mu3H6IHQGww3GNt1PNXlbeCuclF2QYR14L/2CHPz3DFZkvB5hZ0N/QUkiXWCACML2jXViIQEQc2MLg==",
+      "dev": true,
       "dependencies": {
         "arr-flatten": "^1.0.1",
         "arr-map": "^2.0.0",
@@ -9595,6 +11473,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
       "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
+      "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -9602,12 +11481,14 @@
     "node_modules/undertaker/node_modules/fast-levenshtein": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.4.tgz",
-      "integrity": "sha512-Ia0sQNrMPXXkqVFt6w6M1n1oKo3NfKs+mvaV811Jwir7vAk9a6PVV9VPYf6X3BU97QiLEmuW3uXH9u87zDFfdw=="
+      "integrity": "sha1-5qdUzI8V5YmHqpy9J69m/W9OWvk=",
+      "dev": true
     },
     "node_modules/union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
       "dependencies": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
@@ -9622,6 +11503,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
       "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
+      "dev": true,
       "dependencies": {
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "through2-filter": "^3.0.0"
@@ -9640,6 +11522,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
       "dependencies": {
         "has-value": "^0.3.1",
         "isobject": "^3.0.0"
@@ -9651,7 +11534,8 @@
     "node_modules/unset-value/node_modules/has-value": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-      "integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
+      "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+      "dev": true,
       "dependencies": {
         "get-value": "^2.0.3",
         "has-values": "^0.1.4",
@@ -9664,7 +11548,8 @@
     "node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
       "dependencies": {
         "isarray": "1.0.0"
       },
@@ -9675,15 +11560,23 @@
     "node_modules/unset-value/node_modules/has-values": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-      "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
+      "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/unset-value/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "node_modules/upath": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "dev": true,
       "engines": {
         "node": ">=4",
         "yarn": "*"
@@ -9694,7 +11587,6 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -9703,12 +11595,14 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-      "deprecated": "Please see https://github.com/lydell/urix#deprecated"
+      "deprecated": "Please see https://github.com/lydell/urix#deprecated",
+      "dev": true
     },
     "node_modules/use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9726,7 +11620,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "node_modules/utile": {
       "version": "0.2.1",
@@ -9745,6 +11640,12 @@
         "node": ">= 0.6.4"
       }
     },
+    "node_modules/utile/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+      "dev": true
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -9754,17 +11655,21 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
-      "peer": true
+      "bin": {
+        "uuid": "bin/uuid"
+      }
     },
     "node_modules/v8flags": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
       "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
+      "dev": true,
       "dependencies": {
         "homedir-polyfill": "^1.0.1"
       },
@@ -9776,6 +11681,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -9785,14 +11691,36 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
       "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
+      "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/verror/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "node_modules/vinyl": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
       "integrity": "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==",
+      "dev": true,
       "dependencies": {
         "clone": "^2.1.1",
         "clone-buffer": "^1.0.0",
@@ -9809,6 +11737,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
       "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
+      "dev": true,
       "dependencies": {
         "fs-mkdirp-stream": "^1.0.0",
         "glob-stream": "^6.1.0",
@@ -9832,10 +11761,47 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/vinyl-fs/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/vinyl-fs/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/vinyl-fs/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/vinyl-fs/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/vinyl-sourcemap": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
       "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+      "dev": true,
       "dependencies": {
         "append-buffer": "^1.0.2",
         "convert-source-map": "^1.5.0",
@@ -9867,26 +11833,11 @@
         "makeerror": "1.0.12"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "dev": true
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dev": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -9928,20 +11879,21 @@
     "node_modules/which-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+      "dev": true
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
-      "integrity": "sha512-Jn4e5PItbcAHyLoRDwvPj1ypu27DJbtdYXUa5zsinrUx77Uvfb0cXwwnGMTn7cjUfhhqgVQnVJCwF+7cgU7tpw==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
+      "integrity": "sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==",
       "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
-        "for-each": "^0.3.3",
+        "es-abstract": "^1.18.5",
+        "foreach": "^2.0.5",
         "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.9"
+        "is-typed-array": "^1.1.7"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9999,6 +11951,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/winston-transport/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/winston/node_modules/async": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
@@ -10031,20 +11992,35 @@
         "node": ">= 6"
       }
     },
+    "node_modules/winston/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "node_modules/wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
       "dependencies": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
@@ -10056,7 +12032,34 @@
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10065,6 +12068,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -10075,7 +12079,8 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "node_modules/wrench": {
       "version": "1.3.9",
@@ -10085,6 +12090,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.1.97"
+      }
+    },
+    "node_modules/write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "dependencies": {
+        "mkdirp": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ws": {
@@ -10142,7 +12159,8 @@
     "node_modules/y18n": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ=="
+      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+      "dev": true
     },
     "node_modules/yallist": {
       "version": "2.1.2",
@@ -10154,6 +12172,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.2.tgz",
       "integrity": "sha512-ZEjj/dQYQy0Zx0lgLMLR8QuaqTihnxirir7EwUHp1Axq4e3+k8jXU5K0VLbNvedv1f4EWtBonDIZm0NUr+jCcA==",
+      "dev": true,
       "dependencies": {
         "camelcase": "^3.0.0",
         "cliui": "^3.2.0",
@@ -10174,9 +12193,75 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.1.tgz",
       "integrity": "sha512-wpav5XYiddjXxirPoCTUPbqM0PXvJ9hiBMvuJgInvo4/lAOTZzUprArw17q2O1P2+GHhbBr18/iQwjL5Z9BqfA==",
+      "dev": true,
       "dependencies": {
         "camelcase": "^3.0.0",
         "object.assign": "^4.1.0"
+      }
+    },
+    "node_modules/yargs-parser/node_modules/camelcase": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yargs/node_modules/camelcase": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/yauzl": {
@@ -10206,16 +12291,6 @@
     }
   },
   "dependencies": {
-    "@ampproject/remapping": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
-      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/gen-mapping": "^0.1.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
     "@babel/code-frame": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
@@ -10225,174 +12300,16 @@
         "@babel/highlight": "^7.16.7"
       }
     },
-    "@babel/compat-data": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.10.tgz",
-      "integrity": "sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw==",
-      "dev": true
-    },
-    "@babel/core": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.2.tgz",
-      "integrity": "sha512-A8pri1YJiC5UnkdrWcmfZTJTV85b4UXTAfImGmCfYmax4TR9Cw8sDS0MOk++Gp2mE/BefVJ5nwy5yzqNJbP/DQ==",
-      "dev": true,
-      "requires": {
-        "@ampproject/remapping": "^2.1.0",
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.18.2",
-        "@babel/helper-compilation-targets": "^7.18.2",
-        "@babel/helper-module-transforms": "^7.18.0",
-        "@babel/helpers": "^7.18.2",
-        "@babel/parser": "^7.18.0",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.18.2",
-        "@babel/types": "^7.18.2",
-        "convert-source-map": "^1.7.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.1",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-          "dev": true
-        }
-      }
-    },
-    "@babel/generator": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.2.tgz",
-      "integrity": "sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.18.2",
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "jsesc": "^2.5.1"
-      },
-      "dependencies": {
-        "@jridgewell/gen-mapping": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
-          "integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
-          "dev": true,
-          "requires": {
-            "@jridgewell/set-array": "^1.0.0",
-            "@jridgewell/sourcemap-codec": "^1.4.10",
-            "@jridgewell/trace-mapping": "^0.3.9"
-          }
-        }
-      }
-    },
-    "@babel/helper-compilation-targets": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.2.tgz",
-      "integrity": "sha512-s1jnPotJS9uQnzFtiZVBUxe67CuBa679oWFHpxYYnTpRL/1ffhyX44R9uYiXoa/pLXcY9H2moJta0iaanlk/rQ==",
-      "dev": true,
-      "requires": {
-        "@babel/compat-data": "^7.17.10",
-        "@babel/helper-validator-option": "^7.16.7",
-        "browserslist": "^4.20.2",
-        "semver": "^6.3.0"
-      }
-    },
-    "@babel/helper-environment-visitor": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.2.tgz",
-      "integrity": "sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ==",
-      "dev": true
-    },
-    "@babel/helper-function-name": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
-      "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
-      "dev": true,
-      "requires": {
-        "@babel/template": "^7.16.7",
-        "@babel/types": "^7.17.0"
-      }
-    },
-    "@babel/helper-hoist-variables": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.7"
-      }
-    },
-    "@babel/helper-module-imports": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
-      "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.7"
-      }
-    },
-    "@babel/helper-module-transforms": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.0.tgz",
-      "integrity": "sha512-kclUYSUBIjlvnzN2++K9f2qzYKFgjmnmjwL4zlmU5f8ZtzgWe8s0rUPSTGy2HmK4P8T52MQsS+HTQAgZd3dMEA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-simple-access": "^7.17.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.18.0",
-        "@babel/types": "^7.18.0"
-      }
-    },
-    "@babel/helper-simple-access": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.2.tgz",
-      "integrity": "sha512-7LIrjYzndorDY88MycupkpQLKS1AFfsVRm2k/9PtKScSy5tZq0McZTj+DiMRynboZfIqOKvo03pmhTaUgiD6fQ==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.18.2"
-      }
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
-      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.7"
-      }
-    },
     "@babel/helper-validator-identifier": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
       "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
       "dev": true
     },
-    "@babel/helper-validator-option": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
-      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
-      "dev": true
-    },
-    "@babel/helpers": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.2.tgz",
-      "integrity": "sha512-j+d+u5xT5utcQSzrh9p+PaJX94h++KN+ng9b9WEJq7pkUPAd61FGqhjuUEdfknb3E/uDBb7ruwEeKkIxNJPIrg==",
-      "dev": true,
-      "requires": {
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.18.2",
-        "@babel/types": "^7.18.2"
-      }
-    },
     "@babel/highlight": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
-      "integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
@@ -10400,16 +12317,10 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "@babel/parser": {
-      "version": "7.18.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.4.tgz",
-      "integrity": "sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==",
-      "dev": true
-    },
     "@babel/runtime": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.3.tgz",
-      "integrity": "sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+      "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
@@ -10424,9 +12335,9 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.18.3.tgz",
-      "integrity": "sha512-l4ddFwrc9rnR+EJsHsh+TJ4A35YqQz/UqcjtlX2ov53hlJYG5CxtQmNZxyajwDVmCxwy++rtvGU5HazCK4W41Q==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.17.8.tgz",
+      "integrity": "sha512-ZbYSUvoSF6dXZmMl/CYTMOvzIFnbGfv4W3SEHYgMvNsFTeLaF2gkGAF4K2ddmtSK4Emej+0aYcnSC6N5dPCXUQ==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.20.2",
@@ -10439,45 +12350,6 @@
           "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
           "dev": true
         }
-      }
-    },
-    "@babel/template": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
-      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/parser": "^7.16.7",
-        "@babel/types": "^7.16.7"
-      }
-    },
-    "@babel/traverse": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.2.tgz",
-      "integrity": "sha512-9eNwoeovJ6KH9zcCNnENY7DMFwTU9JdGCFtqNLfUAqtUHRCOsTOqWoffosP8vKmNYeSBUv3yVJXjfd8ucwOjUA==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.18.2",
-        "@babel/helper-environment-visitor": "^7.18.2",
-        "@babel/helper-function-name": "^7.17.9",
-        "@babel/helper-hoist-variables": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.18.0",
-        "@babel/types": "^7.18.2",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0"
-      }
-    },
-    "@babel/types": {
-      "version": "7.18.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
-      "integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "@colors/colors": {
@@ -10495,106 +12367,6 @@
         "colorspace": "1.1.x",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
-      }
-    },
-    "@edx/eslint-config": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-3.1.0.tgz",
-      "integrity": "sha512-Okv8vkmX+qe+joD7h9DcT9JdRIyy6jJSVWbIHr2dAHKuk5swVFO92JvhC2pYtMg2EPKA1P1Hmz8cmmfw6QoTZw==",
-      "dev": true,
-      "requires": {}
-    },
-    "@eslint/eslintrc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^9.3.2",
-        "globals": "^13.15.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "dependencies": {
-        "globals": {
-          "version": "13.15.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
-          "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "type-fest": "^0.20.2"
-          }
-        }
-      }
-    },
-    "@humanwhocodes/config-array": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@humanwhocodes/object-schema": "^1.2.1",
-        "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
-      }
-    },
-    "@humanwhocodes/object-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-      "dev": true,
-      "peer": true
-    },
-    "@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
-      "dev": true
-    },
-    "@jridgewell/gen-mapping": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
-      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/set-array": "^1.0.0",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "@jridgewell/resolve-uri": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-      "dev": true
-    },
-    "@jridgewell/set-array": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
-      "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
-      "dev": true
-    },
-    "@jridgewell/sourcemap-codec": {
-      "version": "1.4.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-      "dev": true
-    },
-    "@jridgewell/trace-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
-      "integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "@sinonjs/commons": {
@@ -10636,31 +12408,19 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
     },
-    "@types/node": {
-      "version": "17.0.38",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.38.tgz",
-      "integrity": "sha512-5jY9RhV7c0Z4Jy09G+NIDTsCZ5G0L5n+Z+p+Y7t5VJHM30bgwzSjVtlcBxqAj+6L/swIlvtOSzr8rBk/aNyV2g==",
-      "dev": true,
-      "optional": true
-    },
-    "@types/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/node": "*"
-      }
+    "abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "dev": true
     },
     "accepts": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-      "integrity": "sha512-AOPopplFOUlmUugwiZUCDpOwmqvSgdCyE8iJVLWI4NcB7qfMKQN34dn5xYtlUU03XGG5egRWW4NW5gIxpa5hEA==",
+      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
       "dev": true,
       "requires": {
         "mime-types": "~2.1.11",
@@ -10668,24 +12428,22 @@
       }
     },
     "acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
-      "dev": true,
-      "peer": true
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
-      "peer": true,
       "requires": {}
     },
     "active-x-obfuscator": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
-      "integrity": "sha512-8gdEZinfLSCfAUulETDth4ZSIDPSchiPgm5PLrXQC6BANf1YFEDrPPM2MdK2zcekMROwtM667QFuYw/H6ZV06Q==",
+      "integrity": "sha1-CJuJs3FF/x2ex0r2UwvlUmyuHxo=",
       "dev": true,
       "requires": {
         "zeparser": "0.0.5"
@@ -10694,24 +12452,14 @@
     "after": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha512-QbJ0NTQ/I9DI3uSJA4cbexiwQeRAfjPScqIbSjUDd9TOrcg6pTkdgziesOqxBMBzit8vFCTwrP27t13vFOORRA==",
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
       "dev": true
-    },
-    "agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "requires": {
-        "debug": "4"
-      }
     },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -10722,31 +12470,38 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
     "ansi-colors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+      "dev": true,
       "requires": {
         "ansi-wrap": "^0.1.0"
       }
     },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
+    },
     "ansi-gray": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
-      "integrity": "sha512-HrgGIZUl8h2EHuZaU9hTR/cU5nhKxpVE1V6kdGsQ8e4zirElJ5fvtfc8N7Q1oq1aatO275i8pUFUCpNWCAnVWw==",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
       "requires": {
         "ansi-wrap": "0.1.0"
       }
     },
     "ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "peer": true
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -10760,7 +12515,8 @@
     "ansi-wrap": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-      "integrity": "sha512-ZyznvL8k/FZeQHr2T6LzcJ/+vBApDnMNZvfVFy3At0knswWd6rJ3/0Hhmpu8oqa6C92npmozs890sX9Dl6q+Qw=="
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
     },
     "anymatch": {
       "version": "1.3.2",
@@ -10770,143 +12526,13 @@
       "requires": {
         "micromatch": "^2.1.5",
         "normalize-path": "^2.0.0"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha512-dtXTVMkh6VkEEA7OhXnN1Ecb8aAGFdZ1LFxtOCoqj4qkyOJMt7+qs6Ahdy6p/NQCPYsRSXXivhSB/J5E9jmYKA==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
-          "dev": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==",
-          "dev": true,
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha512-hxx03P2dJxss6ceIeri9cmYOT4SRs3Zk3afZwWpOsRqLqprhTR8u++SlC+sFGsQr7WGFPdMF7Gjc1njDLDK6UA==",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "expand-range": {
-          "version": "1.8.2",
-          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-          "integrity": "sha512-AFASGfIlnIbkKPQwX1yHaDjFvh/1gyKJODme52V6IORh69uEYgZp0o9C+qsIGNVEiuuhQU0CSSl++Rlegg1qvA==",
-          "dev": true,
-          "requires": {
-            "fill-range": "^2.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha512-1FOj1LOwn42TMrruOHGt18HemVnbwAmAak7krWk+wa93KXxGbK+2jpezm+ytJYDaBX0/SPLZFHKM7m+tKobWGg==",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "fill-range": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-          "dev": true,
-          "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^3.0.0",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
-        }
       }
     },
     "append-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
-      "integrity": "sha512-WLbYiXzD3y/ATLZFufV/rZvWdZOs+Z/+5v1rBZ463Jn398pa6kcde27cvozYnBoxXblGZTFfoPpsaEw0orU5BA==",
+      "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+      "dev": true,
       "requires": {
         "buffer-equal": "^1.0.0"
       }
@@ -10914,34 +12540,42 @@
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
     },
     "argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "peer": true
-    },
-    "aria-query": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.2",
-        "@babel/runtime-corejs3": "^7.10.2"
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-query": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-0.7.1.tgz",
+      "integrity": "sha1-Jsu1r/ZBRLCoJb4YRuCxbPoAsR4=",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7",
+        "commander": "^2.11.0"
       }
     },
     "arr-diff": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.0.1"
+      }
     },
     "arr-filter": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
-      "integrity": "sha512-A2BETWCqhsecSvCkWAeVBFLH6sXEUGASuzkpjL3GR1SlL/PWL6M3J8EAAld2Uubmh39tvkJTqC9LeLHCUKmFXA==",
+      "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
+      "dev": true,
       "requires": {
         "make-iterator": "^1.0.0"
       }
@@ -10949,12 +12583,14 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
     },
     "arr-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
-      "integrity": "sha512-tVqVTHt+Q5Xb09qRkbu+DidW1yYzz5izWS2Xm2yFm7qJnmUfz4HPzNxbHkdRJbz2lrqI7S+z17xNYdFcBBO8Hw==",
+      "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+      "dev": true,
       "requires": {
         "make-iterator": "^1.0.0"
       }
@@ -10962,28 +12598,36 @@
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q=="
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
     },
     "array-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
-      "integrity": "sha512-zHjL5SZa68hkKHBFBK6DJCTtr9sfTCPCaph/L7tMSLcTFgy+zX7E+6q5UArbtOtMBCtxdICpfTCspRse+ywyXA=="
+      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
     },
     "array-from": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-includes": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
-      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       }
@@ -10991,7 +12635,8 @@
     "array-initial": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
-      "integrity": "sha512-BC4Yl89vneCYfpLrs5JU2aAu9/a+xWbeKhvISg9PT7eWFB9UlRvI+rKEtk6mgxWr3dSkk9gQ8hCrdqt06NXPdw==",
+      "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
+      "dev": true,
       "requires": {
         "array-slice": "^1.0.0",
         "is-number": "^4.0.0"
@@ -11000,12 +12645,14 @@
         "array-slice": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
-          "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w=="
+          "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
+          "dev": true
         },
         "is-number": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
         }
       }
     },
@@ -11013,6 +12660,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
       "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
+      "dev": true,
       "requires": {
         "is-number": "^4.0.0"
       },
@@ -11020,84 +12668,114 @@
         "is-number": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
         }
       }
     },
     "array-slice": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-      "integrity": "sha512-rlVfZW/1Ph2SNySXwR9QYkChp8EkOEiTMO5Vwx60usw04i4nWemkm9RXmQqgkQFaLHsqLuADvjp6IfgL9l2M8Q==",
+      "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
       "dev": true
     },
     "array-sort": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
       "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+      "dev": true,
       "requires": {
         "default-compare": "^1.0.0",
         "get-value": "^2.0.6",
         "kind-of": "^5.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
       }
     },
     "array-unique": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "dev": true
     },
     "array.prototype.flat": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
+      "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
-        "es-shim-unscopables": "^1.0.0"
+        "es-abstract": "^1.19.0"
       }
     },
     "array.prototype.flatmap": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
-      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz",
+      "integrity": "sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
-        "es-shim-unscopables": "^1.0.0"
+        "es-abstract": "^1.19.0"
       }
     },
     "arraybuffer.slice": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
-      "integrity": "sha512-6ZjfQaBSy6CuIH0+B0NrxMfDE5VIOCP/5gOqSpEIsaAZx9/giszzrXg6PZ7G51U/n88UmlAgYLNQ9wAnII7PJA==",
+      "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw=="
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
     },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
-      "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
     "async-done": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
       "integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.2",
@@ -11108,20 +12786,29 @@
     "async-each": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "dev": true
     },
     "async-settle": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
-      "integrity": "sha512-VPXfB4Vk49z1LHHodrEQ6Xf7W4gg1w0dAPROHngx7qgDjqmIQ+fXmwgGXTW/ITLai0YLSvWepJOP9EVpMnEAcw==",
+      "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+      "dev": true,
       "requires": {
         "async-done": "^1.2.2"
       }
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
     },
     "available-typed-arrays": {
       "version": "1.0.5",
@@ -11129,22 +12816,96 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
     },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "dev": true
+    },
     "axe-core": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.2.tgz",
-      "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
+      "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
       "dev": true
     },
     "axobject-query": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
-      "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
-      "dev": true
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-0.1.0.tgz",
+      "integrity": "sha1-YvWdvFnJ+SQnWco0mWDnov48NsA=",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7"
+      }
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
     },
     "babel-polyfill": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha512-F2rZGQnAdaHWQ8YAoeRbukc7HS9QgdgeyJ0rQDd485v9opwuPvjpPFcOOT/WmkKTdgy9ESgSPXDcTNpzrGr6iQ==",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -11155,7 +12916,7 @@
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
         "core-js": "^2.4.0",
@@ -11173,7 +12934,8 @@
     "bach": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
-      "integrity": "sha512-bZOOfCb3gXBXbTFXq3OZtGR88LwGeJvzu6szttaIzymOTS4ZttBNOWSv7aLZja2EMycKtRYV0Oa8SNKH/zkxvg==",
+      "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+      "dev": true,
       "requires": {
         "arr-filter": "^1.1.1",
         "arr-flatten": "^1.0.1",
@@ -11189,18 +12951,20 @@
     "backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
       "dev": true
     },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
       "requires": {
         "cache-base": "^1.0.1",
         "class-utils": "^0.3.5",
@@ -11214,7 +12978,8 @@
         "define-property": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -11224,31 +12989,34 @@
     "base64-arraybuffer": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-      "integrity": "sha512-437oANT9tP582zZMwSvZGy2nmSeAb8DW2me3y+Uv1Wp2Rulr8Mqlyrv3E7MLxmsiaPSMMDmiDVzgE+e8zlMx9g==",
-      "dev": true
-    },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
       "dev": true
     },
     "base64id": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
-      "integrity": "sha512-rz8L+d/xByiB/vLVftPkyY215fqNrmasrcJsYkVcm4TgJNz+YXKrFaFAWibSaHkiKoSgMDCb+lipOIRQNGYesw==",
+      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
       "dev": true
     },
     "batch": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
-      "integrity": "sha512-aQgHPLH2DHpFTpBl5/GiVdNzHEqsLCSs1RiPvqkKP1+7RkNJlv71kL8/KXmvvaLqoZ7ylmvqkZhLjjAoRz8Xgw==",
+      "integrity": "sha1-PzQU84AyF0O/wQQvmoP/HVgk1GQ=",
       "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "better-assert": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-      "integrity": "sha512-bYeph2DFlpK1XmGs6fvlLRUN29QISM3GBuUwSFsMY2XRx4AvC0WNCS57j4c/xGrK2RS24C1w3YoBOsw9fT46tQ==",
+      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
       "dev": true,
       "requires": {
         "callsite": "1.0.0"
@@ -11257,51 +13025,29 @@
     "binary-extensions": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "dev": true
     },
     "bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
       "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
     },
-    "bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
-      "requires": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
     "blob": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-      "integrity": "sha512-YRc9zvVz4wNaxcXmiSgb9LAg7YYwqQ2xd0Sj6osfA7k/PKmIGVlnOYs3wOFdkRC9/JpQu8sGt/zHgJV7xzerfg==",
+      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
       "dev": true
     },
     "bluebird": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-      "integrity": "sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ==",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
       "dev": true
     },
     "body-parser": {
@@ -11345,49 +13091,19 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "braces": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-      "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      }
-    },
-    "browserslist": {
-      "version": "4.20.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
-      "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
+      "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001332",
-        "electron-to-chromium": "^1.4.118",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.3",
-        "picocolors": "^1.0.0"
-      }
-    },
-    "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "expand-range": "^0.1.0"
       }
     },
     "buffer-alloc": {
@@ -11409,29 +13125,31 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
     "buffer-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-      "integrity": "sha512-tcBWO2Dl4e7Asr9hTGcpVrCe+F7DubpmqWCTbj4FHLmjqO2hIaC383acQubWtRJhdceqs5uBHs6Es+Sk//RKiQ=="
+      "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+      "dev": true
     },
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
       "dev": true
     },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
     },
     "build": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/build/-/build-0.1.4.tgz",
-      "integrity": "sha512-KwbDJ/zrsU8KZRRMfoURG14cKIAStUlS8D5jBDvtrZbwO5FEkYqc3oB8HIhRiyD64A48w1lc+sOmQ+mmBw5U/Q==",
+      "integrity": "sha1-cH/gJv/O3crL/c3zVur9pk8VEEY=",
       "dev": true,
       "requires": {
         "cssmin": "0.3.x",
@@ -11444,6 +13162,14 @@
         "walker": "1.x",
         "winston": "*",
         "wrench": "1.3.x"
+      },
+      "dependencies": {
+        "uglify-js": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
+          "integrity": "sha1-S1v/+Rhu/7qoiOTJ6UvZ/EyUkp0=",
+          "dev": true
+        }
       }
     },
     "bytes": {
@@ -11456,6 +13182,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
       "requires": {
         "collection-visit": "^1.0.0",
         "component-emitter": "^1.2.1",
@@ -11472,33 +13199,55 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
       }
     },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "^0.2.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+          "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+          "dev": true
+        }
+      }
+    },
     "callsite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
       "dev": true
     },
-    "callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "peer": true
-    },
     "camelcase": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
     },
-    "caniuse-lite": {
-      "version": "1.0.30001344",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz",
-      "integrity": "sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==",
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "chalk": {
@@ -11512,10 +13261,16 @@
         "supports-color": "^5.3.0"
       }
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha512-mk8fAWcRUOxY7btlLtitj3A45jOwSAxH4tOFOoEGbVsl6cL6pPMWUy7dwZ/canfj3QEdP6FHSnf/l1c6/WkzVg==",
+      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
         "anymatch": "^1.3.0",
@@ -11532,13 +13287,13 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
             "is-extglob": "^1.0.0"
@@ -11546,16 +13301,17 @@
         }
       }
     },
-    "chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "define-property": "^0.2.5",
@@ -11566,7 +13322,8 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -11574,55 +13331,62 @@
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
           }
         },
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
           }
         },
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
             "is-data-descriptor": "^0.1.4",
             "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
           }
         }
       }
     },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+      "dev": true
+    },
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "dev": true,
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
@@ -11632,12 +13396,34 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11647,43 +13433,93 @@
     "clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
     },
     "clone-buffer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-      "integrity": "sha512-KLLTJWrvwIP+OPfMn0x2PheDEP20RPUcGXj/ERegTgdmPEZylALQldygiqrPPu8P45uNuPs7ckmReLY6v/iA5g=="
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+      "dev": true
     },
     "clone-stats": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-      "integrity": "sha512-au6ydSpg6nsrigcZ4m8Bc9hxjeW+GJ8xh5G3BJCMt4WXe1H10UNaVOamqQTmrx1kjVuxAHIQSNU6hY4Nsn9/ag=="
+      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+      "dev": true
     },
     "cloneable-readable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
       "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "process-nextick-args": "^2.0.0",
         "readable-stream": "^2.3.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA=="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "coffee-script": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.3.tgz",
-      "integrity": "sha512-lpusDYw9xym9ZOqFIeQuzzvTvunm2nlRL++BYhUcLn+77vuidExZG+qDPSKUfDXvuaHeFK6QavntXF+HiOq+/Q==",
+      "integrity": "sha1-Y1XTLPGwTN/2tITl5xF4Ky8MOb4=",
       "dev": true
     },
     "collection-map": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
-      "integrity": "sha512-5D2XXSpkOnleOI21TG7p3T0bGAsZ/XknZpKBmGYyluO8pw4zA3K8ZlrBIbC4FXg3m6z/RNFiUFfT2sQK01+UHA==",
+      "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
+      "dev": true,
       "requires": {
         "arr-map": "^2.0.2",
         "for-own": "^1.0.0",
@@ -11693,7 +13529,8 @@
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
       "requires": {
         "map-visit": "^1.0.0",
         "object-visit": "^1.0.0"
@@ -11721,13 +13558,13 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
       "dev": true,
       "requires": {
         "color-name": "^1.0.0",
@@ -11737,7 +13574,8 @@
     "color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
     },
     "colors": {
       "version": "1.4.0",
@@ -11755,45 +13593,94 @@
         "text-hex": "1.0.x"
       }
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
     "component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-      "integrity": "sha512-WZveuKPeKAG9qY+FkYDeADzdHyTYdIboXS59ixDeRJL5ZhxpqUnxSOwop4FQjMsiYm3/Or8cegVbpAHNA7pHxw==",
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
       "dev": true
     },
     "component-emitter": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
     },
     "component-inherit": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-      "integrity": "sha512-w+LhYREhatpVqTESyGFg3NlP6Iu0kEKUHETY9GoZP/pQyW4mHFZuFWRUCIqVPZ36ueVLtoOEZaAqbCF2RDndaA==",
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
-    },
-    "confusing-browser-globals": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
-      "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
-      "dev": true,
-      "peer": true
     },
     "connect": {
       "version": "3.7.0",
@@ -11834,31 +13721,42 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
       "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
       "dev": true
     },
     "cookie-signature": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz",
-      "integrity": "sha512-FMG5ziBzXZ5d4j5obbWOH1X7AtIpsU9ce9mQ+lHo/I1++kzz/isNarOj6T1lBPRspP3mZpuIutc7OVDVcaN1Kg==",
+      "integrity": "sha1-ROByFIrwHm6OJK+/EmkNaK5pjss=",
       "dev": true
     },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw=="
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
     },
     "copy-props": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.5.tgz",
       "integrity": "sha512-XBlx8HSqrT0ObQwmSzM7WE5k8FxTV75h1DX1Z3n6NhQ/UYYAvInWYmG06vFt7hQZArE2fuO62aihiWIVQwh1sw==",
+      "dev": true,
       "requires": {
         "each-props": "^1.3.2",
         "is-plain-object": "^5.0.0"
@@ -11867,7 +13765,8 @@
         "is-plain-object": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+          "dev": true
         }
       }
     },
@@ -11878,65 +13777,56 @@
       "dev": true
     },
     "core-js-pure": {
-      "version": "3.22.7",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.22.7.tgz",
-      "integrity": "sha512-wTriFxiZI+C8msGeh7fJcbC/a0V8fdInN1oS2eK79DMBGs8iIJiXhtFJCiT3rBa8w6zroHWW3p8ArlujZ/Mz+w==",
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.21.1.tgz",
+      "integrity": "sha512-12VZfFIu+wyVbBebyHmRTuEE/tZrB4tJToWcwAMcsp3h4+sHR+fMJWbKpYiCRWlhFBq+KNyO8rIV9rTkeVmznQ==",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
-    "cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "2.6.7"
-      }
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "dependencies": {
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cssmin": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/cssmin/-/cssmin-0.3.2.tgz",
-      "integrity": "sha512-bynxGIAJ8ybrnFobjsQotIjA8HFDDgPwbeUWNXXXfR+B4f9kkxdcUyagJoQCSUOfMV+ZZ6bMn8bvbozlCzUGwQ==",
+      "integrity": "sha1-3c5MVHtRCuDVlKjx+/iq+OLFwA0=",
       "dev": true
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
     },
     "custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
-      "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
+      "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
       "dev": true
     },
     "d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
       "requires": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -11947,6 +13837,15 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "debug": {
       "version": "4.3.4",
@@ -11960,12 +13859,14 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og=="
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "deep-equal": {
       "version": "2.0.5",
@@ -12002,39 +13903,55 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "default-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
       "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
+      "dev": true,
       "requires": {
         "kind-of": "^5.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
       }
     },
     "default-resolution": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
-      "integrity": "sha512-2xaP6GiwVwOEbXCGoJ4ufgC76m8cj805jrghScewJC2ZDsb9U0b4BIrba+xt/Uytyd0HvQ6+WymSRTfnYj59GQ=="
+      "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
+      "dev": true
     },
     "define-properties": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
       "requires": {
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
+        "object-keys": "^1.0.12"
       }
     },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
       "requires": {
         "is-descriptor": "^1.0.2",
         "isobject": "^3.0.1"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "depd": {
       "version": "2.0.0",
@@ -12051,18 +13968,13 @@
     "detect-file": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-      "integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q=="
-    },
-    "devtools-protocol": {
-      "version": "0.0.982423",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.982423.tgz",
-      "integrity": "sha512-FnVW2nDbjGNw1uD/JRC+9U5768W7e1TfUwqbDTcSsAu1jXFjITSX8w3rkW5FEpHRMPPGpvNSmO1pOpqByiWscA==",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
     "di": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
-      "integrity": "sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==",
+      "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
       "dev": true
     },
     "diff": {
@@ -12072,11 +13984,10 @@
       "dev": true
     },
     "doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "esutils": "^2.0.2"
       }
@@ -12084,7 +13995,7 @@
     "dom-serialize": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
-      "integrity": "sha512-Yra4DbvoW7/Z6LBN560ZwXMjoNOSAN2wRsKFGc4iBeso+mpIA6qj1vfdf9HpMaKAqG6wXTy+1SYEzmNpKXOSsQ==",
+      "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
       "dev": true,
       "requires": {
         "custom-event": "~1.0.0",
@@ -12103,38 +14014,82 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "each-props": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/each-props/-/each-props-1.3.2.tgz",
       "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
+      "dev": true,
       "requires": {
         "is-plain-object": "^2.0.1",
         "object.defaults": "^1.1.0"
       }
     },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "dev": true
-    },
-    "electron-to-chromium": {
-      "version": "1.4.141",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.141.tgz",
-      "integrity": "sha512-mfBcbqc0qc6RlxrsIgLG2wCqkiPAjEezHxGTu7p3dHHFOurH4EjS9rFZndX5axC8264rI1Pcbw8uQP39oZckeA==",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
     "emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
+      "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
       "dev": true
     },
     "enabled": {
@@ -12146,13 +14101,14 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -12174,7 +14130,7 @@
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
           "dev": true,
           "requires": {
             "ms": "0.7.2"
@@ -12208,16 +14164,10 @@
         "yeast": "0.1.2"
       },
       "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha512-jPatnhd33viNplKjqXKRkGU345p263OIWzDL2wH3LGIGp5Kojo+uXizHmOADRvhGFFTnJqX3jBAKP6vvmSDKcA==",
-          "dev": true
-        },
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
           "dev": true,
           "requires": {
             "ms": "0.7.2"
@@ -12234,7 +14184,7 @@
     "engine.io-parser": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
-      "integrity": "sha512-3UyTJo+5Jbmr7rd3MosTAApK7BOIo4sjx8dJYSHa3Em5R3A9Y2s9GWu4JFJe6Px0VieJC0hKUA5NBytC+O7k2A==",
+      "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
       "dev": true,
       "requires": {
         "after": "0.8.2",
@@ -12248,46 +14198,52 @@
     "ent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
-      "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA==",
+      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
       "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "dev": true
+        }
       }
     },
     "es-abstract": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
-      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.2.tgz",
+      "integrity": "sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
-        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
-        "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
+        "is-shared-array-buffer": "^1.0.1",
         "is-string": "^1.0.7",
         "is-weakref": "^1.0.2",
         "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "regexp.prototype.flags": "^1.4.3",
-        "string.prototype.trimend": "^1.0.5",
-        "string.prototype.trimstart": "^1.0.5",
-        "unbox-primitive": "^1.0.2"
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.1"
       }
     },
     "es-get-iterator": {
@@ -12314,16 +14270,6 @@
         }
       }
     },
-    "es-shim-unscopables": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
-      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "has": "^1.0.3"
-      }
-    },
     "es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
@@ -12336,9 +14282,10 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.61",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
-      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+      "version": "0.10.59",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.59.tgz",
+      "integrity": "sha512-cOgyhW0tIJyQY1Kfw6Kr0viu9ZlUctVchRMZ7R0HiH3dxTSp5zJDLecwxUqPUrGKMsgBI1wd1FL+d9Jxfi4cLw==",
+      "dev": true,
       "requires": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
@@ -12348,17 +14295,25 @@
     "es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
       }
     },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
+    },
     "es6-symbol": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dev": true,
       "requires": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
@@ -12368,6 +14323,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
       "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.46",
@@ -12375,175 +14331,628 @@
         "es6-symbol": "^3.1.1"
       }
     },
-    "escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
-    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "eslint": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.16.0.tgz",
-      "integrity": "sha512-MBndsoXY/PeVTDJeWsYj7kLZ5hQpJOfMYLsF6LicLHQWbRDG19lK5jOix4DPl8yY4SUFcE3txy86OzFLWT+yoA==",
+    "escodegen": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
-      "peer": true,
       "requires": {
-        "@eslint/eslintrc": "^1.3.0",
-        "@humanwhocodes/config-array": "^0.9.2",
-        "ajv": "^6.10.0",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
-        "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.2",
-        "esquery": "^1.4.0",
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
         "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
-        "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^6.0.1",
-        "globals": "^13.15.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "js-yaml": "^4.1.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
-        "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
+        "estraverse": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
-          "peer": true,
+          "optional": true,
           "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "peer": true
-        },
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "dev": true,
-          "peer": true
-        },
-        "glob-parent": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "is-glob": "^4.0.3"
-          }
-        },
-        "globals": {
-          "version": "13.15.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
-          "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "type-fest": "^0.20.2"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "peer": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "has-flag": "^4.0.0"
+            "amdefine": ">=0.0.4"
           }
         }
       }
     },
-    "eslint-config-airbnb": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz",
-      "integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
+    "eslint": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.9.0.tgz",
+      "integrity": "sha512-g4KWpPdqN0nth+goDNICNXGfJF7nNnepthp46CAlJoJtC5K/cLu3NgCM3AHu1CkJ5Hzt9V0Y0PBAO6Ay/gGb+w==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "eslint-config-airbnb-base": "^15.0.0",
-        "object.assign": "^4.1.2",
-        "object.entries": "^1.1.5"
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.5.3",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^4.0.0",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.1.0",
+        "is-resolvable": "^1.1.0",
+        "js-yaml": "^3.12.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.5",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.0.2",
+        "text-table": "^0.2.0"
       }
     },
-    "eslint-config-airbnb-base": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
-      "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
+    "eslint-config-edx": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-edx/-/eslint-config-edx-4.0.4.tgz",
+      "integrity": "sha512-4xm13P14kcm3IppkjL8X3HDxLgA064l3F50sy7z8ioyB4kDLRepSSXhyDHR8vHDd46yztmnuIPXbEEgVNOL4xg==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "confusing-browser-globals": "^1.0.10",
-        "object.assign": "^4.1.2",
-        "object.entries": "^1.1.5",
-        "semver": "^6.3.0"
+        "eslint": "^4.5.0",
+        "eslint-config-airbnb": "^16.1.0",
+        "eslint-plugin-dollar-sign": "^1.0.1",
+        "eslint-plugin-import": "^2.8.0",
+        "eslint-plugin-jsx-a11y": "6.0.3",
+        "eslint-plugin-react": "^7.5.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+          "dev": true
+        },
+        "acorn-jsx": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+          "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+          "dev": true,
+          "requires": {
+            "acorn": "^3.0.4"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+              "dev": true
+            }
+          }
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "ajv-keywords": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+          "dev": true,
+          "requires": {}
+        },
+        "chardet": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "eslint": {
+          "version": "4.19.1",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+          "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.3.0",
+            "babel-code-frame": "^6.22.0",
+            "chalk": "^2.1.0",
+            "concat-stream": "^1.6.0",
+            "cross-spawn": "^5.1.0",
+            "debug": "^3.1.0",
+            "doctrine": "^2.1.0",
+            "eslint-scope": "^3.7.1",
+            "eslint-visitor-keys": "^1.0.0",
+            "espree": "^3.5.4",
+            "esquery": "^1.0.0",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "functional-red-black-tree": "^1.0.1",
+            "glob": "^7.1.2",
+            "globals": "^11.0.1",
+            "ignore": "^3.3.3",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^3.0.6",
+            "is-resolvable": "^1.0.0",
+            "js-yaml": "^3.9.1",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.2",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.2",
+            "pluralize": "^7.0.0",
+            "progress": "^2.0.0",
+            "regexpp": "^1.0.1",
+            "require-uncached": "^1.0.3",
+            "semver": "^5.3.0",
+            "strip-ansi": "^4.0.0",
+            "strip-json-comments": "~2.0.1",
+            "table": "4.0.2",
+            "text-table": "~0.2.0"
+          }
+        },
+        "eslint-config-airbnb": {
+          "version": "16.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-16.1.0.tgz",
+          "integrity": "sha512-zLyOhVWhzB/jwbz7IPSbkUuj7X2ox4PHXTcZkEmDqTvd0baJmJyuxlFPDlZOE/Y5bC+HQRaEkT3FoHo9wIdRiw==",
+          "dev": true,
+          "requires": {
+            "eslint-config-airbnb-base": "^12.1.0"
+          }
+        },
+        "eslint-config-airbnb-base": {
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz",
+          "integrity": "sha512-/vjm0Px5ZCpmJqnjIzcFb9TKZrKWz0gnuG/7Gfkt0Db1ELJR51xkZth+t14rYdqWgX836XbuxtArbIHlVhbLBA==",
+          "dev": true,
+          "requires": {
+            "eslint-restricted-globals": "^0.1.1"
+          }
+        },
+        "eslint-plugin-jsx-a11y": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.3.tgz",
+          "integrity": "sha1-VFg9GuRCSDFi4EDhPMMYZUZRAOU=",
+          "dev": true,
+          "requires": {
+            "aria-query": "^0.7.0",
+            "array-includes": "^3.0.3",
+            "ast-types-flow": "0.0.7",
+            "axobject-query": "^0.1.0",
+            "damerau-levenshtein": "^1.0.0",
+            "emoji-regex": "^6.1.0",
+            "jsx-ast-utils": "^2.0.0"
+          }
+        },
+        "eslint-scope": {
+          "version": "3.7.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+          "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "espree": {
+          "version": "3.5.4",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+          "dev": true,
+          "requires": {
+            "acorn": "^5.5.0",
+            "acorn-jsx": "^3.0.0"
+          }
+        },
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+          "dev": true
+        },
+        "external-editor": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+          "dev": true,
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        },
+        "jsx-ast-utils": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
+          "integrity": "sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==",
+          "dev": true,
+          "requires": {
+            "array-includes": "^3.1.1",
+            "object.assign": "^4.1.0"
+          }
+        },
+        "regexpp": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+          "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0"
+          }
+        },
+        "table": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+          "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.2.3",
+            "ajv-keywords": "^2.1.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "^2.1.1"
+          }
+        }
+      }
+    },
+    "eslint-config-edx-es5": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-edx-es5/-/eslint-config-edx-es5-4.0.1.tgz",
+      "integrity": "sha512-NazW7j4tcm1pxKabWZDKFlvbD/2usN2ZmW3LoYvM+f68fH0+1yX+R2kI/3WB9oatGOs5ScBVN33h05WakjVw5A==",
+      "dev": true,
+      "requires": {
+        "eslint": "^4.5.0",
+        "eslint-config-airbnb-base": "^11.3.2",
+        "eslint-plugin-dollar-sign": "1.0.0",
+        "eslint-plugin-import": "^2.7.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+          "dev": true
+        },
+        "acorn-jsx": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+          "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+          "dev": true,
+          "requires": {
+            "acorn": "^3.0.4"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+              "dev": true
+            }
+          }
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "ajv-keywords": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+          "dev": true,
+          "requires": {}
+        },
+        "chardet": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "eslint": {
+          "version": "4.19.1",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+          "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.3.0",
+            "babel-code-frame": "^6.22.0",
+            "chalk": "^2.1.0",
+            "concat-stream": "^1.6.0",
+            "cross-spawn": "^5.1.0",
+            "debug": "^3.1.0",
+            "doctrine": "^2.1.0",
+            "eslint-scope": "^3.7.1",
+            "eslint-visitor-keys": "^1.0.0",
+            "espree": "^3.5.4",
+            "esquery": "^1.0.0",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "functional-red-black-tree": "^1.0.1",
+            "glob": "^7.1.2",
+            "globals": "^11.0.1",
+            "ignore": "^3.3.3",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^3.0.6",
+            "is-resolvable": "^1.0.0",
+            "js-yaml": "^3.9.1",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.2",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.2",
+            "pluralize": "^7.0.0",
+            "progress": "^2.0.0",
+            "regexpp": "^1.0.1",
+            "require-uncached": "^1.0.3",
+            "semver": "^5.3.0",
+            "strip-ansi": "^4.0.0",
+            "strip-json-comments": "~2.0.1",
+            "table": "4.0.2",
+            "text-table": "~0.2.0"
+          }
+        },
+        "eslint-config-airbnb-base": {
+          "version": "11.3.2",
+          "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.3.2.tgz",
+          "integrity": "sha512-/fhjt/VqzBA2SRsx7ErDtv6Ayf+XLw9LIOqmpBuHFCVwyJo2EtzGWMB9fYRFBoWWQLxmNmCpenNiH0RxyeS41w==",
+          "dev": true,
+          "requires": {
+            "eslint-restricted-globals": "^0.1.1"
+          }
+        },
+        "eslint-plugin-dollar-sign": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-dollar-sign/-/eslint-plugin-dollar-sign-1.0.0.tgz",
+          "integrity": "sha1-r7pQRZ6d6XpfzXdjJ55MOp4ltaw=",
+          "dev": true,
+          "requires": {}
+        },
+        "eslint-scope": {
+          "version": "3.7.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+          "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "espree": {
+          "version": "3.5.4",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+          "dev": true,
+          "requires": {
+            "acorn": "^5.5.0",
+            "acorn-jsx": "^3.0.0"
+          }
+        },
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+          "dev": true
+        },
+        "external-editor": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+          "dev": true,
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        },
+        "regexpp": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+          "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0"
+          }
+        },
+        "table": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+          "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.2.3",
+            "ajv-keywords": "^2.1.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "^2.1.1"
+          }
+        }
       }
     },
     "eslint-import-resolver-node": {
@@ -12551,7 +14960,6 @@
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
       "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "debug": "^3.2.7",
         "resolve": "^1.20.0"
@@ -12562,7 +14970,6 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
           "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
-          "peer": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -12574,7 +14981,6 @@
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
       "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "debug": "^3.2.7",
         "find-up": "^2.1.0"
@@ -12585,19 +14991,24 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
           "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
-          "peer": true,
           "requires": {
             "ms": "^2.1.1"
           }
         }
       }
     },
+    "eslint-plugin-dollar-sign": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-dollar-sign/-/eslint-plugin-dollar-sign-1.0.2.tgz",
+      "integrity": "sha512-AtA5MJpMAh0kKzSx/u7DuDbPRijIZmlt6n75CR8Q3UQ18Fo4QFfYK15lJ8OhXQQUYR7zTMMB2x37KyP3LnAC/g==",
+      "dev": true,
+      "requires": {}
+    },
     "eslint-plugin-import": {
       "version": "2.26.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
       "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "array-includes": "^3.1.4",
         "array.prototype.flat": "^1.2.5",
@@ -12619,27 +15030,15 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
-          "peer": true,
           "requires": {
             "ms": "2.0.0"
-          }
-        },
-        "doctrine": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "esutils": "^2.0.2"
           }
         },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -12661,117 +15060,133 @@
         "jsx-ast-utils": "^3.2.1",
         "language-tags": "^1.0.5",
         "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "aria-query": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+          "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.10.2",
+            "@babel/runtime-corejs3": "^7.10.2"
+          }
+        },
+        "axobject-query": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
+          "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-react": {
-      "version": "7.30.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.0.tgz",
-      "integrity": "sha512-RgwH7hjW48BleKsYyHK5vUAvxtE9SMPDKmcPRQgtRCYaZA0XQPt5FSkrU3nhz5ifzMZcA8opwmRJ2cmOO8tr5A==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.4.tgz",
+      "integrity": "sha512-CVCXajliVh509PcZYRFyu/BoUEz452+jtQJq2b3Bae4v3xBUWPLCmtmBM+ZinG4MzwmxJgJ2M5rMqhqLVn7MtQ==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "array-includes": "^3.1.5",
-        "array.prototype.flatmap": "^1.3.0",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
         "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
         "object.entries": "^1.1.5",
         "object.fromentries": "^2.0.5",
-        "object.hasown": "^1.1.1",
+        "object.hasown": "^1.1.0",
         "object.values": "^1.1.5",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.7"
+        "string.prototype.matchall": "^4.0.6"
       },
       "dependencies": {
-        "doctrine": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        },
         "resolve": {
           "version": "2.0.0-next.3",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz",
           "integrity": "sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==",
           "dev": true,
-          "peer": true,
           "requires": {
             "is-core-module": "^2.2.0",
             "path-parse": "^1.0.6"
           }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },
-    "eslint-plugin-react-hooks": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
-      "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
-      "dev": true,
-      "peer": true,
-      "requires": {}
+    "eslint-restricted-globals": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
+      "integrity": "sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc=",
+      "dev": true
     },
     "eslint-scope": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+          "dev": true
+        }
       }
     },
     "eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-          "dev": true,
-          "peer": true
-        }
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true,
-      "peer": true
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true
     },
     "espree": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
-      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
+      "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "acorn": "^8.7.1",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.3.0"
+        "acorn": "^6.0.2",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
       }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
       "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "dev": true,
-      "peer": true,
       "requires": {
         "estraverse": "^5.1.0"
       }
@@ -12781,7 +15196,6 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
-      "peer": true,
       "requires": {
         "estraverse": "^5.2.0"
       }
@@ -12790,20 +15204,18 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "event-stream": {
       "version": "3.0.20",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.0.20.tgz",
-      "integrity": "sha512-u2P2ZUf2wN0LBDY6gDNMH+GvLer2Fpb0IAw7i6abjy8HLZnhdobM10Qohn86mwTKy3lcV9VuUms0aU9kpfBrow==",
+      "integrity": "sha1-A4u7LqnqkDhbJvvBhU0LU58qvqM=",
       "dev": true,
       "requires": {
         "duplexer": "~0.1.1",
@@ -12824,142 +15236,38 @@
     "expand-braces": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
-      "integrity": "sha512-zOOsEnAhvIxxd0esCNbYG2xerGf46niZ1egS43eV7Fu4t7VIScgPXMcMabCLaPrqkzwvwo6zZipDiX3t0ILF2w==",
+      "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
       "dev": true,
       "requires": {
         "array-slice": "^0.2.3",
         "array-unique": "^0.2.1",
         "braces": "^0.1.2"
-      },
-      "dependencies": {
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
-          "dev": true
-        },
-        "braces": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
-          "integrity": "sha512-EIMHIv2UXHWFY2xubUGKz+hq9hNkENj4Pjvr7h58cmJgpkK2yMlKA8I484f7MSttkzVAy/lL7X9xDaILd6avzA==",
-          "dev": true,
-          "requires": {
-            "expand-range": "^0.1.0"
-          }
-        }
       }
     },
     "expand-brackets": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-      "integrity": "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "dev": true,
       "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
-      "integrity": "sha512-busOHJ0t7t5UcutcyNDqmaDX+1cb0XlqsAUgTlmplVv0rIqBaMcBSZRLlkDm0nxtl8O3o/EvRRrdQ/WnyPERLQ==",
+      "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
       "dev": true,
       "requires": {
         "is-number": "^0.1.1",
         "repeat-string": "^0.2.2"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz",
-          "integrity": "sha512-la5kPULwIgkSSaZj9w7/A1uHqOBAgOhDUKQ5CkfL8LZ4Si6r4+2D0hI6b4o60MW4Uj2yNJARWIZUDPxlvOYQcw==",
-          "dev": true
-        },
-        "repeat-string": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz",
-          "integrity": "sha1-x6jTI2BoNiBZp+RlH8aITosftK4=",
-          "dev": true
-        }
       }
     },
     "expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-      "integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.1"
       }
@@ -12968,6 +15276,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
       "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+      "dev": true,
       "requires": {
         "type": "^2.5.0"
       },
@@ -12975,64 +15284,106 @@
         "type": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
-          "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
+          "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==",
+          "dev": true
         }
       }
     },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
       "requires": {
-        "is-extendable": "^0.1.0"
-      }
-    },
-    "extglob": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-      "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
-        "define-property": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
     },
-    "extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
       "dev": true,
       "requires": {
-        "@types/yauzl": "^2.9.1",
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
       }
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^1.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        }
+      }
+    },
+    "extract-zip": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
+        "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fancy-log": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
       "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
+      "dev": true,
       "requires": {
         "ansi-gray": "^0.1.1",
         "color-support": "^1.1.3",
@@ -13044,69 +15395,111 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
       }
     },
     "fecha": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
+      "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==",
       "dev": true
     },
-    "file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
-      "peer": true,
       "requires": {
-        "flat-cache": "^3.0.4"
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
       }
     },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
       "optional": true
     },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha512-BTCqyBaWBTsauvnHiE8i562+EdJj+oUpkqWp2R1iCoR8f6oo8STRu3of7WJJ0TqWtxN50a5YFpzYK4Jj9esYfQ==",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true
     },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1",
         "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+          "dev": true
+        }
       }
     },
     "finalhandler": {
@@ -13153,9 +15546,8 @@
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
-      "peer": true,
       "requires": {
         "locate-path": "^2.0.0"
       }
@@ -13164,17 +15556,232 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
       "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
+      "dev": true,
       "requires": {
         "detect-file": "^1.0.0",
         "is-glob": "^4.0.0",
         "micromatch": "^3.0.4",
         "resolve-dir": "^1.0.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "fined": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
       "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
+      "dev": true,
       "requires": {
         "expand-tilde": "^2.0.2",
         "is-plain-object": "^2.0.3",
@@ -13186,45 +15793,67 @@
     "flagged-respawn": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
-      "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q=="
+      "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
+      "dev": true
     },
     "flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "flatted": "^3.1.0",
-        "rimraf": "^3.0.2"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
       }
-    },
-    "flatted": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
-      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
-      "dev": true,
-      "peer": true
     },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
       "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "fn.name": {
@@ -13234,37 +15863,53 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "dev": true
-    },
-    "for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.3"
-      }
     },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ=="
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
     },
     "for-own": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-      "integrity": "sha512-0OABksIGrxKK8K4kynWkQ7y1zounQxP+CWnyclVwj81KW3vlLlGUx57DKGcP/LH216GzqnstnPocF16Nxs0Ycg==",
+      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+      "dev": true,
       "requires": {
         "for-in": "^1.0.1"
+      }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "formatio": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-      "integrity": "sha512-YAF05v8+XCxAyHOdiiAmHdgCVPrWO8X744fYIPtBciIorh5LndWfi1gjeJ16sTbJhzek9kd+j3YByhohtz5Wmg==",
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
       "dev": true,
       "requires": {
         "samsam": "1.x"
@@ -13273,7 +15918,8 @@
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-      "integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
       }
@@ -13281,25 +15927,40 @@
     "fresh": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz",
-      "integrity": "sha512-ckGdAuSRr1wBmnq7CsW7eU37DBwQxHx3vW8foJUIrF56rkOy8Osm6Fe8KSwemwyKejivKki7jVBgpBpBJexmrw==",
+      "integrity": "sha1-v9lALPPfEsSkwxDHn5mj3eE9NKc=",
       "dev": true
     },
     "from": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
     },
-    "fs-constants": {
+    "fs-access": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
+      "dev": true,
+      "requires": {
+        "null-check": "^1.0.0"
+      }
+    },
+    "fs-extra": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+      "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0"
+      }
     },
     "fs-mkdirp-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
-      "integrity": "sha512-+vSd9frUnapVC2RZYfL3FCB2p3g4TBhaUmrsWlSudsGdnxIuUvBB2QM1VZeBtc49QFwrp+wQLrDs3+xxDgI5gQ==",
+      "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
         "through2": "^2.0.3"
@@ -13308,12 +15969,14 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "dev": true,
       "optional": true,
       "requires": {
         "bindings": "^1.5.0",
@@ -13323,74 +15986,37 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
-    "function.prototype.name": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
-      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0",
-        "functions-have-names": "^1.2.2"
-      }
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true,
-      "peer": true
-    },
-    "functions-have-names": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true
-    },
-    "gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
     },
     "get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
       }
     },
-    "get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "requires": {
-        "pump": "^3.0.0"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
-      }
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
     },
     "get-symbol-description": {
       "version": "1.0.0",
@@ -13405,17 +16031,28 @@
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA=="
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.1.1",
+        "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -13423,7 +16060,7 @@
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha512-ab1S1g1EbO7YzauaJLkgLp7DZVAqj9M/dvKlTt8DkXA2tiOIcSMrlVI2J1RZyB5iJVccEscjGn+kpOG9788MHA==",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
         "glob-parent": "^2.0.0",
@@ -13433,13 +16070,13 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
             "is-extglob": "^1.0.0"
@@ -13450,7 +16087,7 @@
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha512-JDYOvfxio/t42HKdxkAYaCiBN7oYiuxykOxKxdaUW5Qn0zaYN3gRQWolrwdnf0shM9/EP0ebuuTmyoXNr1cC5w==",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
         "is-glob": "^2.0.0"
@@ -13459,13 +16096,13 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
             "is-extglob": "^1.0.0"
@@ -13476,7 +16113,8 @@
     "glob-stream": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
-      "integrity": "sha512-uMbLGAP3S2aDOHUDfdoYcdIePUCfysbAd0IAoWVZbeGU/oNQ8asHVSshLDJUPWxfzj8zsCG7/XeHPHTtow0nsw==",
+      "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
+      "dev": true,
       "requires": {
         "extend": "^3.0.0",
         "glob": "^7.1.1",
@@ -13493,7 +16131,8 @@
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
           "requires": {
             "is-glob": "^3.1.0",
             "path-dirname": "^1.0.0"
@@ -13502,9 +16141,46 @@
         "is-glob": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
           "requires": {
             "is-extglob": "^2.1.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -13513,6 +16189,7 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.5.tgz",
       "integrity": "sha512-zOZgGGEHPklZNjZQaZ9f41i7F2YwE+tS5ZHrDhbBCk3stwahn5vQxnFmBJZHoYdusR6R1bLSXeGUy/BhctwKzw==",
+      "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
         "async-done": "^1.2.0",
@@ -13527,6 +16204,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "dev": true,
           "requires": {
             "micromatch": "^3.1.4",
             "normalize-path": "^2.1.1"
@@ -13536,8 +16214,50 @@
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
               "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+              "dev": true,
               "requires": {
                 "remove-trailing-separator": "^1.0.1"
+              }
+            }
+          }
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -13546,6 +16266,7 @@
           "version": "2.1.8",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
           "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+          "dev": true,
           "requires": {
             "anymatch": "^2.0.0",
             "async-each": "^1.0.1",
@@ -13561,10 +16282,108 @@
             "upath": "^1.1.1"
           }
         },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
           "requires": {
             "is-glob": "^3.1.0",
             "path-dirname": "^1.0.0"
@@ -13573,17 +16392,92 @@
             "is-glob": {
               "version": "3.1.0",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-              "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
               "requires": {
                 "is-extglob": "^2.1.0"
               }
             }
           }
         },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
         "normalize-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
         }
       }
     },
@@ -13591,6 +16485,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "dev": true,
       "requires": {
         "global-prefix": "^1.0.1",
         "is-windows": "^1.0.1",
@@ -13600,7 +16495,8 @@
     "global-prefix": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-      "integrity": "sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "dev": true,
       "requires": {
         "expand-tilde": "^2.0.2",
         "homedir-polyfill": "^1.0.1",
@@ -13619,6 +16515,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
       "integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
+      "dev": true,
       "requires": {
         "sparkles": "^1.0.0"
       }
@@ -13626,16 +16523,18 @@
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
     },
     "gulp": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
-      "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.0.tgz",
+      "integrity": "sha1-lXZsYB2t5Kd+0+eyttwDiBtZY2Y=",
+      "dev": true,
       "requires": {
-        "glob-watcher": "^5.0.3",
-        "gulp-cli": "^2.2.0",
-        "undertaker": "^1.2.1",
+        "glob-watcher": "^5.0.0",
+        "gulp-cli": "^2.0.0",
+        "undertaker": "^1.0.0",
         "vinyl-fs": "^3.0.0"
       }
     },
@@ -13643,6 +16542,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.3.0.tgz",
       "integrity": "sha512-zzGBl5fHo0EKSXsHzjspp3y5CONegCm8ErO5Qh0UzFzk2y4tMvzLWhoDokADbarfZRL2pGpRp7yt6gfJX4ph7A==",
+      "dev": true,
       "requires": {
         "ansi-colors": "^1.0.1",
         "archy": "^1.0.0",
@@ -13667,7 +16567,7 @@
     "gulp-karma": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/gulp-karma/-/gulp-karma-0.0.1.tgz",
-      "integrity": "sha512-O3Ca4S6UZbjdNu/QDIjPwtqF+7YnJlu/5pMPZWzRB8uT5/fdv8xq38OojlIaZOLzK6IoGFxaVuKWE/t6tJwPjw==",
+      "integrity": "sha1-srK9lpT0eKXytJ0i2AhszCaLCpo=",
       "dev": true,
       "requires": {
         "event-stream": "~3.0.20",
@@ -13677,34 +16577,50 @@
         "xtend": "~2.1.1"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-0.2.0.tgz",
+          "integrity": "sha1-NZq0sV3NZLptdHNLcsNjYKmvLBk=",
+          "dev": true
+        },
         "base64id": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
-          "integrity": "sha512-DSjtfjhAsHl9J4OJj7e4+toV2zqxJrGwVd3CLlsCp8QmicvOn7irG0Mb8brOc/nur3SdO8lIbNlY1s1ZDJdUKQ==",
+          "integrity": "sha1-As4P3u4M709ACA4ec+g08LG/zj8=",
           "dev": true
         },
         "batch": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz",
-          "integrity": "sha512-avtDJBSxllB5QGphW1OXYF+ujhy/yIGgeFsvK6UiZLU86nWlqsNcZotUKd001wrl9MmZ9QIyVy8WFVEEpRIc5A==",
+          "integrity": "sha1-/S4Fp6XWlrTbkxQBPihdj/NVfsM=",
           "dev": true
         },
         "buffer-crc32": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
-          "integrity": "sha512-vMfBIRp/wjlpueSz7Sb0OmO7C5SH58SSmbsT8G4D48YfO/Zgbr29xNXMpZVSC14ujVJfrZZH1Bl+kXYRQPuvfQ==",
+          "integrity": "sha1-vj5TgvwCttYySVasGvmKqYsIU0w=",
           "dev": true
         },
         "bytes": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz",
-          "integrity": "sha512-odbk8/wGazOuC1v8v4phoV285/yx8UN5kfQhhuxaVcceig4OUiCZQBtaEtmA1Q78QSTN9iXOQ7X2EViybrEvtQ==",
+          "integrity": "sha1-VVsIq8sGP4l1kFMCUj5M1P/f3zE=",
           "dev": true
+        },
+        "chalk": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
+          "integrity": "sha1-HJhDdzfxGZ68wdTEj9Qbn5yOjyM=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "~0.2.0",
+            "has-color": "~0.1.0"
+          }
         },
         "chokidar": {
           "version": "0.8.4",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.8.4.tgz",
-          "integrity": "sha512-auWFkYQV6w4821+YQATR3ueTMRPMAK9qVzl9cyE1O7dM7l2/NI6IIDcvPrER+RzdgoCi5b9aCy3btoZFsLVJbw==",
+          "integrity": "sha1-OytQZoFwhlNLqBoJK9z0viW4vuA=",
           "dev": true,
           "requires": {
             "fsevents": "pipobscure/fsevents#7dcdf9fa3f8956610fd6f69f72c67bace2de7138",
@@ -13714,19 +16630,19 @@
         "colors": {
           "version": "0.6.2",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-          "integrity": "sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw==",
+          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "commander": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
-          "integrity": "sha512-J2wnb6TKniXNOtoHS8TSrG9IOQluPrsmyAJ8oCUJOBmv+uLBCyPYAZkD2jFvw2DCzIXNnISIM01NIvr35TkBMQ==",
+          "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
           "dev": true
         },
         "connect": {
           "version": "2.12.0",
           "resolved": "https://registry.npmjs.org/connect/-/connect-2.12.0.tgz",
-          "integrity": "sha512-i3poGdQamCEvDhvaFuG99KUDCU1Cvv7S2T6YfpY4X2+a0+uDrUcpRk08AQEge3NhtidVKfODQfpoMW4xlbQ0LQ==",
+          "integrity": "sha1-Mdj6DcrN8ZCNgivSkjvootKn7Zo=",
           "dev": true,
           "requires": {
             "batch": "0.5.0",
@@ -13749,19 +16665,19 @@
         "cookie": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
-          "integrity": "sha512-YSNOBX085/nzHvrTLEHYHoNdkvpLU1MPjU3r1IGawudZJjfuqnRNIFrcOJJ7bfwC+HWbHL1Y4yMkC0O+HWjV7w==",
+          "integrity": "sha1-kOtGndzpBchm3mh+/EMTHYgB+dA=",
           "dev": true
         },
         "debug": {
           "version": "0.8.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
-          "integrity": "sha512-HlXEJm99YsRjLJ8xmuz0Lq8YUwrv7hAJkTEr6/Em3sUlSUNl0UdFA+1SrY4fnykeq1FVkUEUtwRGHs9VvlYbGA==",
+          "integrity": "sha1-IP9NJvXkIstoobrLu2EDmtjBwTA=",
           "dev": true
         },
         "glob": {
           "version": "3.2.11",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
             "inherits": "2",
@@ -13783,13 +16699,24 @@
         "graceful-fs": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-          "integrity": "sha512-hcj/NTUWv+C3MbqrVb9F+aH6lvTwEHJdx2foBxlrVq5h6zE8Bfu4pv4CAAqbDcZrw/9Ak5lsRXlY9Ao8/F0Tuw==",
+          "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
           "dev": true
+        },
+        "gulp-util": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-1.2.0.tgz",
+          "integrity": "sha1-OTOhF+F0oD+ebxRvcg7XxtPE8gA=",
+          "dev": true,
+          "requires": {
+            "chalk": "~0.3.0",
+            "lodash.template": "~2.4.1",
+            "optimist": "~0.6.0"
+          }
         },
         "http-proxy": {
           "version": "0.10.4",
           "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.4.tgz",
-          "integrity": "sha512-lb5uBBW+eLzoZ/Tute8ENcbNvibErYYPzNhjZk9IZugBAl87kUSxzVLBwQ7FbU2qBuorbah6VObuXvp2DN1LbA==",
+          "integrity": "sha1-FLoM6qIZf4n6MN6p57CeGc2Twi8=",
           "dev": true,
           "requires": {
             "colors": "0.x.x",
@@ -13801,7 +16728,7 @@
         "karma": {
           "version": "0.11.14",
           "resolved": "https://registry.npmjs.org/karma/-/karma-0.11.14.tgz",
-          "integrity": "sha512-C1/QPwxankTBabz8cysaYm7RogIKBb/dCIbc+XIfSWt7L7ZnwWA53Zg907RDYWU1z2oPaDxTxTkVyRjn1KFLfA==",
+          "integrity": "sha1-L2+BYRv+YuWI1OHWPBTzkolxp3w=",
           "dev": true,
           "requires": {
             "chokidar": "~0.8.0",
@@ -13827,13 +16754,66 @@
         "lodash": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
+        },
+        "lodash._reinterpolate": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+          "integrity": "sha1-TxInqlqHEfxjL1sHofRgequLMiI=",
+          "dev": true
+        },
+        "lodash.escape": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+          "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
+          "dev": true,
+          "requires": {
+            "lodash._escapehtmlchar": "~2.4.1",
+            "lodash._reunescapedhtml": "~2.4.1",
+            "lodash.keys": "~2.4.1"
+          }
+        },
+        "lodash.keys": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+          "dev": true,
+          "requires": {
+            "lodash._isnative": "~2.4.1",
+            "lodash._shimkeys": "~2.4.1",
+            "lodash.isobject": "~2.4.1"
+          }
+        },
+        "lodash.template": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+          "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
+          "dev": true,
+          "requires": {
+            "lodash._escapestringchar": "~2.4.1",
+            "lodash._reinterpolate": "~2.4.1",
+            "lodash.defaults": "~2.4.1",
+            "lodash.escape": "~2.4.1",
+            "lodash.keys": "~2.4.1",
+            "lodash.templatesettings": "~2.4.1",
+            "lodash.values": "~2.4.1"
+          }
+        },
+        "lodash.templatesettings": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
+          "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "~2.4.1",
+            "lodash.escape": "~2.4.1"
+          }
         },
         "lru-cache": {
           "version": "2.7.3",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ==",
+          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
           "dev": true
         },
         "mime": {
@@ -13936,7 +16916,7 @@
             "lru-cache": {
               "version": "2.2.4",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
-              "integrity": "sha512-Q5pAgXs+WEAfoEdw2qKQhNFFhMoFMTYqRVKKUMnzuiR7oKFHS7fWo848cPcTKw+4j/IdN17NyzdhVKgabFV0EA==",
+              "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=",
               "dev": true
             }
           }
@@ -13955,104 +16935,116 @@
         }
       }
     },
-    "gulp-util": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-1.2.0.tgz",
-      "integrity": "sha512-7RnGVNPv1MhYSTV+85T3g8x5qdqpPUL5KVRvvrnrYqzkFnqqvPSEheKOJ/e8+JPVyYpFnHqWfJbZmhZi9p44Gg==",
-      "dev": true,
-      "requires": {
-        "chalk": "~0.3.0",
-        "lodash.template": "~2.4.1",
-        "optimist": "~0.6.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-0.2.0.tgz",
-          "integrity": "sha512-YyQBeLj0juxUC9uUXRpQ1ZAzPT1dnsn5vVeJLHYFq4Ct1p0rymUSyvckKCXCH9I0bh3jWDIETA5nXIaZVKlDyA==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
-          "integrity": "sha512-OcfgS16PHpCu2Q4TNMtk0aZNx8PyeNiiB+6AgGH91fhT9hJ3v6pIIJ3lxlaOEDHlTm8t3wDe6bDGamvtIokQTg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "~0.2.0",
-            "has-color": "~0.1.0"
-          }
-        }
-      }
-    },
     "gulplog": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-      "integrity": "sha512-hm6N8nrm3Y08jXie48jsC55eCZz9mnb4OirAStEk2deqeyhXU3C1otDVh+ccttMuc1sBi6RX6ZJ720hs9RCvgw==",
+      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+      "dev": true,
       "requires": {
         "glogg": "^1.0.0"
+      }
+    },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
     },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
+      }
+    },
     "has-bigints": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
       "dev": true
     },
     "has-binary": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
-      "integrity": "sha512-k1Umb4/jrBWZbtL+QKSji8qWeoZ7ZTkXdnDXt1wxwBKAFM0//u96wDj43mBIqCIas8rDQMYyrBEvcS8hdGd4Sg==",
+      "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
       "dev": true,
       "requires": {
         "isarray": "0.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-          "dev": true
-        }
       }
     },
     "has-color": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha512-kaNz5OTAYYmt646Hkqw50/qyxP2vFnTVu5AQ1Zmk22Kk5+4Qx6BpO8+u7IKsML5fOsFk0ZT0AcCJNYwcvaLBvw==",
+      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
       "dev": true
     },
     "has-cors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-      "integrity": "sha512-g5VNKdkFuUuVCP9gYfDJHjK2nqdQJ7aDLTnycnc2+RvsOQbuLdF5pm7vuE5J76SEBIQjs4kQY/BWq74JUmjbXA==",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
       "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
-    },
-    "has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-      "requires": {
-        "get-intrinsic": "^1.1.1"
-      }
     },
     "has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true
     },
     "has-tostringtag": {
       "version": "1.0.0",
@@ -14066,7 +17058,8 @@
     "has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-      "integrity": "sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
       "requires": {
         "get-value": "^2.0.6",
         "has-values": "^1.0.0",
@@ -14076,26 +17069,59 @@
     "has-values": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-      "integrity": "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
       "requires": {
         "is-number": "^3.0.0",
         "kind-of": "^4.0.0"
       },
       "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
         }
       }
     },
+    "hasha": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+      "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
+      "dev": true,
+      "requires": {
+        "is-stream": "^1.0.1",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
       "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "dev": true,
       "requires": {
         "parse-passwd": "^1.0.0"
       }
@@ -14103,12 +17129,7 @@
     "hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
-    },
-    "html-escaper": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "http-errors": {
@@ -14143,14 +17164,15 @@
         "requires-port": "^1.0.0"
       }
     },
-    "https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "agent-base": "6",
-        "debug": "4"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "i": {
@@ -14168,47 +17190,38 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
-    },
     "ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-      "dev": true,
-      "peer": true
-    },
-    "import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      }
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
-      "peer": true
+      "requires": {
+        "repeating": "^2.0.0"
+      }
     },
     "indexof": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg==",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -14217,12 +17230,52 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.12",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -14238,17 +17291,20 @@
     "interpret": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
     },
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ=="
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
     },
     "is-absolute": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "dev": true,
       "requires": {
         "is-relative": "^1.0.0",
         "is-windows": "^1.0.1"
@@ -14258,6 +17314,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
       "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "dev": true,
       "requires": {
         "kind-of": "^6.0.0"
       },
@@ -14265,7 +17322,8 @@
         "kind-of": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
         }
       }
     },
@@ -14280,9 +17338,10 @@
       }
     },
     "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "dev": true
     },
     "is-bigint": {
       "version": "1.0.4",
@@ -14296,7 +17355,8 @@
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
       "requires": {
         "binary-extensions": "^1.0.0"
       }
@@ -14314,7 +17374,8 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-callable": {
       "version": "1.2.4",
@@ -14323,9 +17384,10 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -14334,6 +17396,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
       "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "dev": true,
       "requires": {
         "kind-of": "^6.0.0"
       },
@@ -14341,7 +17404,8 @@
         "kind-of": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
         }
       }
     },
@@ -14358,6 +17422,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
       "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "dev": true,
       "requires": {
         "is-accessor-descriptor": "^1.0.0",
         "is-data-descriptor": "^1.0.0",
@@ -14367,20 +17432,21 @@
         "kind-of": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
         }
       }
     },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha512-9YclgOGtN/f8zx0Pr4FQYMdibBiTaH3sn52vjYip4ZSf6C4/6RfTEZ+MR4GvKhCxdPh21Bg42/WL55f6KSnKpg==",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
       "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha512-0EygVC5qPvIyb+gSz7zdD5/AAoS6Qrx1e//6N4yv4oNm30kqvdmG66oZFWVlQHUWe5OjP08FuTw2IdT0EOTcYA==",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
         "is-primitive": "^2.0.0"
@@ -14389,25 +17455,32 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -14421,7 +17494,8 @@
     "is-negated-glob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-      "integrity": "sha512-czXVVn/QEmgvej1f50BZ648vUI+em0xqMq2Sn+QncCLN4zj1UAxlT+kw/6ggQTOaZPd1HqKQGEqbpQVtJucWug=="
+      "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+      "dev": true
     },
     "is-negative-zero": {
       "version": "2.0.2",
@@ -14430,22 +17504,10 @@
       "dev": true
     },
     "is-number": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
-      "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz",
+      "integrity": "sha1-aaevEWlj1HIG7JvZtIoUIW8eOAY=",
+      "dev": true
     },
     "is-number-object": {
       "version": "1.0.7",
@@ -14460,6 +17522,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -14467,13 +17530,13 @@
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha512-Yu68oeXJ7LeWNmZ3Zov/xg/oDBnBK2RNxwYY1ilNJX+tKKZqgPK+qOn/Gs9jEu66KDY9Netf5XLKNGzas/vPfQ==",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
       "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha512-N3w1tFaRfk3UrPfqeRyD+GYDASU3W5VinKhlORy8EWVf/sIdDL9GAcew85XmktCfH+ngG7SRXEVDoO18WMdB/Q==",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
     "is-regex": {
@@ -14490,9 +17553,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "dev": true,
       "requires": {
         "is-unc-path": "^1.0.0"
       }
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
     },
     "is-set": {
       "version": "2.0.2",
@@ -14508,6 +17578,12 @@
       "requires": {
         "call-bind": "^1.0.2"
       }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-string": {
       "version": "1.0.7",
@@ -14528,22 +17604,29 @@
       }
     },
     "is-typed-array": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.9.tgz",
-      "integrity": "sha512-kfrlnTTn8pZkfpJMUgYD7YZ3qzeJgWUn8XfVYBARc4wnmNOmLbmuuaAs3q5fvB0UJOn6yHAKaGTPM7d6ezoD/A==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.8.tgz",
+      "integrity": "sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==",
       "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
-        "for-each": "^0.3.3",
+        "es-abstract": "^1.18.5",
+        "foreach": "^2.0.5",
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-unc-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "dev": true,
       "requires": {
         "unc-path-regex": "^0.1.2"
       }
@@ -14551,12 +17634,14 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q=="
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
     },
     "is-valid-glob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-      "integrity": "sha512-AhiROmoEFDSsjx8hW+5sGwgKVIORcXnrlAx/R0ZSeaPw70Vw0CqkGBBhHGL58Uox2eXnU1AnvXJl1XlyedO5bA=="
+      "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
+      "dev": true
     },
     "is-weakmap": {
       "version": "2.0.1",
@@ -14586,12 +17671,14 @@
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
     },
     "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "isbinaryfile": {
       "version": "3.0.3",
@@ -14605,93 +17692,89 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
-    },
-    "istanbul-lib-coverage": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
-      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
-    "istanbul-lib-instrument": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz",
-      "integrity": "sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^6.3.0"
-      }
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
-    "istanbul-lib-report": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+    "istanbul": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^3.0.0",
-        "supports-color": "^7.1.0"
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         },
         "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^4.0.0"
+            "has-flag": "^1.0.0"
           }
         }
-      }
-    },
-    "istanbul-lib-source-maps": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0",
-        "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
-    "istanbul-reports": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.4.tgz",
-      "integrity": "sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==",
-      "dev": true,
-      "requires": {
-        "html-escaper": "^2.0.0",
-        "istanbul-lib-report": "^3.0.0"
       }
     },
     "jasmine-core": {
       "version": "2.99.1",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.99.1.tgz",
-      "integrity": "sha512-ra97U4qu3OCcIxvN6eg3kyy8bLrID/TgxafSGMMICg3SFx5C/sUfDPpiOh7yoIsHdtjrOVdtT9rieYhqOsh9Ww==",
+      "integrity": "sha1-5kAN8ea1bhMLYcS80JPap/boyhU=",
       "dev": true
     },
     "js-tokens": {
@@ -14701,43 +17784,55 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "argparse": "^2.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
-    "jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
     "jsmin": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/jsmin/-/jsmin-1.0.1.tgz",
-      "integrity": "sha512-OPuL5X/bFKgVdMvEIX3hnpx3jbVpFCrEM8pKPXjFkZUqg521r41ijdyTz7vACOhW6o1neVlcLyd+wkbK5fNHRg==",
+      "integrity": "sha1-570NzWSWw79IYyNb9GGj2YqjuYw=",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json3": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha512-I5YLeauH3rIaE99EE++UeH2M2gSYo8/2TqDac7oZEH6D/DSQ4Woa628Qrfj1X9/OY5Mk5VvIDQaKCDchXaKrmA==",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
     "json5": {
@@ -14745,15 +17840,35 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "dev": true,
-      "peer": true,
       "requires": {
         "minimist": "^1.2.0"
       }
     },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      }
+    },
     "jsx-ast-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.0.tgz",
-      "integrity": "sha512-XzO9luP6L0xkxwhIJMTJQpZo/eeN60K08jHdexfD569AGxeNug6UketeHXEhROoM8aR7EcUoOQmIhcJQjcuq8Q==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.2.tgz",
+      "integrity": "sha512-HDAyJ4MNQBboGpUnHAVUNJs6X0lh058s6FuixsFGP7MgJYpD6Vasd6nzSG5iIfXu1zAYlHJ/zsOKNlrenTUBnw==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.4",
@@ -14763,7 +17878,8 @@
     "just-debounce": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.1.0.tgz",
-      "integrity": "sha512-qpcRocdkUmf+UTNBYx5w6dexX5J31AKK1OmPwH630a83DdVVUIngk55RSAiIGpQyoH0dlr872VHfPjnQnK1qDQ=="
+      "integrity": "sha512-qpcRocdkUmf+UTNBYx5w6dexX5J31AKK1OmPwH630a83DdVVUIngk55RSAiIGpQyoH0dlr872VHfPjnQnK1qDQ==",
+      "dev": true
     },
     "just-extend": {
       "version": "4.2.1",
@@ -14774,7 +17890,7 @@
     "jxLoader": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jxLoader/-/jxLoader-0.1.1.tgz",
-      "integrity": "sha512-ClEvAj3K68y8uKhub3RgTmcRPo5DfIWvtxqrKQdDPyZ1UVHIIKvVvjrAsJFSVL5wjv0rt5iH9SMCZ0XRKNzeUA==",
+      "integrity": "sha1-ATTqUUTlM7WU/B/yX/GU4jXFPs0=",
       "dev": true,
       "requires": {
         "js-yaml": "0.3.x",
@@ -14786,7 +17902,7 @@
         "js-yaml": {
           "version": "0.3.7",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-0.3.7.tgz",
-          "integrity": "sha512-/7PsVDNP2tVe2Z1cF9kTEkjamIwz4aooDpRKmN1+g/9eePCgcxsv4QDvEbxO0EH+gdDD7MLyDoR6BASo3hH51g==",
+          "integrity": "sha1-1znY7oZGHlSzVNan19HyrZoWf2I=",
           "dev": true
         }
       }
@@ -14794,7 +17910,7 @@
     "karma": {
       "version": "0.13.22",
       "resolved": "https://registry.npmjs.org/karma/-/karma-0.13.22.tgz",
-      "integrity": "sha512-A9/7e/IzHUkTcfjnTy5Wzo2P5wPuf7+QZh1JzNdTpYA0AN/vSrxfFjPKtKC3jRYJFZMJ7S1I9L2LItaJS1XMSg==",
+      "integrity": "sha1-B3ULG9Bj1+fnuRvNLmNU2PKqh0Q=",
       "dev": true,
       "requires": {
         "batch": "^0.5.3",
@@ -14825,58 +17941,99 @@
         "lodash": {
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
       }
     },
     "karma-chrome-launcher": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-3.1.1.tgz",
-      "integrity": "sha512-hsIglcq1vtboGPAN+DGCISCFOxW+ZVnIqhDQcCMqqCp+4dmJ0Qpq5QAjkbA0X2L9Mi6OBkHi2Srrbmm7pUKkzQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.2.3.tgz",
+      "integrity": "sha1-TG1wDRY6nTTGGO/YeRi+SeekqMk=",
       "dev": true,
       "requires": {
+        "fs-access": "^1.0.0",
         "which": "^1.2.1"
       }
     },
     "karma-coverage": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-2.2.0.tgz",
-      "integrity": "sha512-gPVdoZBNDZ08UCzdMHHhEImKrw1+PAOQOIiffv1YsvxFhBjqvo/SVXNk4tqn1SYqX0BJZT6S/59zgxiBe+9OuA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-1.1.2.tgz",
+      "integrity": "sha512-eQawj4Cl3z/CjxslYy9ariU4uDh7cCNFZHNWXWRpl0pNeblY/4wHR7M7boTYXWrn9bY0z2pZmr11eKje/S/hIw==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "^3.2.0",
-        "istanbul-lib-instrument": "^5.1.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^4.0.1",
-        "istanbul-reports": "^3.0.5",
-        "minimatch": "^3.0.4"
+        "dateformat": "^1.0.6",
+        "istanbul": "^0.4.0",
+        "lodash": "^4.17.0",
+        "minimatch": "^3.0.0",
+        "source-map": "^0.5.1"
+      },
+      "dependencies": {
+        "dateformat": {
+          "version": "1.0.12",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+          "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "^4.0.1",
+            "meow": "^3.3.0"
+          }
+        }
       }
     },
     "karma-jasmine": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.8.tgz",
-      "integrity": "sha512-EDNIM4f9FV17XXoF+Rzfw+6uPajd7tOAfEFwe7PIyNVQrM3l1V5OJj2167JDY9KmLDIK/MQZX7tKkK1jVYlfmw==",
+      "integrity": "sha1-W2RXeRrZuJqhc/B54+vhuMgFI2w=",
       "dev": true,
       "requires": {}
     },
     "karma-jasmine-jquery-2": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/karma-jasmine-jquery-2/-/karma-jasmine-jquery-2-0.1.1.tgz",
-      "integrity": "sha512-E5v945nXXIewxj4rMR8v6dx1LOKxT6H7ZA80EIZ0Pu31oAgd0Xx9Bj67n0guGYcUky1lXrftvA3C0k6OL9MFlA==",
+      "integrity": "sha1-/6wtvLXPWWqTMUP+I9fLfr7M0Eg=",
       "dev": true
+    },
+    "karma-phantomjs-launcher": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.4.tgz",
+      "integrity": "sha1-0jyjSAG9qYY60xjju0vUBisTrNI=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.0.1",
+        "phantomjs-prebuilt": "^2.1.7"
+      }
     },
     "karma-sinon": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/karma-sinon/-/karma-sinon-1.0.5.tgz",
-      "integrity": "sha512-wrkyAxJmJbn75Dqy17L/8aILJWFm7znd1CE8gkyxTBFnjMSOe2XTJ3P30T8SkxWZHmoHX0SCaUJTDBEoXs25Og==",
+      "integrity": "sha1-TjRD8oMP3s/2JNN0cWPxIX2qKpo=",
       "dev": true,
       "requires": {}
     },
+    "kew": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
+      "dev": true
+    },
     "kind-of": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
     },
     "kuler": {
       "version": "2.0.0",
@@ -14893,7 +18050,7 @@
     "language-tags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
-      "integrity": "sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==",
+      "integrity": "sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=",
       "dev": true,
       "requires": {
         "language-subtag-registry": "~0.3.2"
@@ -14902,7 +18059,8 @@
     "last-run": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
-      "integrity": "sha512-U/VxvpX4N/rFvPzr3qG5EtLKEnNI0emvIQB3/ecEwv+8GHaUKbIB8vxv1Oai5FAF0d0r7LXHhLLe5K/yChm5GQ==",
+      "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
+      "dev": true,
       "requires": {
         "default-resolution": "^2.0.0",
         "es6-weak-map": "^2.0.1"
@@ -14912,14 +18070,54 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
       "requires": {
         "readable-stream": "^2.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
       "requires": {
         "invert-kv": "^1.0.0"
       }
@@ -14927,26 +18125,27 @@
     "lead": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
-      "integrity": "sha512-IpSVCk9AYvLHo5ctcIXxOBpMWUe+4TKN3VPWAKUbJikkmsGp0VrSM8IttVc32D6J4WUsiPE6aEFRNmIoF/gdow==",
+      "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+      "dev": true,
       "requires": {
         "flush-write-stream": "^1.0.2"
       }
     },
     "levn": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
-      "peer": true,
       "requires": {
-        "prelude-ls": "^1.2.1",
-        "type-check": "~0.4.0"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "liftoff": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
       "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
+      "dev": true,
       "requires": {
         "extend": "^3.0.0",
         "findup-sync": "^3.0.0",
@@ -14961,21 +18160,32 @@
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0",
         "strip-bom": "^2.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        }
       }
     },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
-      "peer": true,
       "requires": {
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
@@ -14990,7 +18200,7 @@
     "lodash._escapehtmlchar": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
-      "integrity": "sha512-eHm2t2Lg476lq5v4FVmm3B5mCaRlDyTE8fnMfPCEq2o46G4au0qNXIKh7YWhjprm1zgSMLcMSs1XHMgkw02PbQ==",
+      "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
       "dev": true,
       "requires": {
         "lodash._htmlescapes": "~2.4.1"
@@ -14999,47 +18209,54 @@
     "lodash._escapestringchar": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
-      "integrity": "sha512-iZ6Os4iipaE43pr9SBks+UpZgAjJgRC+lGf7onEoByMr1+Nagr1fmR7zCM6Q4RGMB/V3a57raEN0XZl7Uub3/g==",
+      "integrity": "sha1-7P4iYYoq3lC/7qQ5N+Ud9m8O23I=",
       "dev": true
     },
     "lodash._htmlescapes": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
-      "integrity": "sha512-g79hNmMOBVyV+4oKIHM7MWy9Awtk3yqf0Twlawr6f+CmG44nTwBh9I5XiLUnk39KTfYoDBpS66glQGgQCnFIuA==",
+      "integrity": "sha1-MtFL8IRLbeb4tioFG09nwii2JMs=",
       "dev": true
     },
     "lodash._isnative": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-      "integrity": "sha512-BOlKGKNHhCHswGOWtmVb5zBygyxN7EmTuzVOSQI6QSoGhG+kvv71gICFS1TBpnqvT1n53txK8CDK3u5D2/GZxQ==",
+      "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
       "dev": true
     },
     "lodash._objecttypes": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-      "integrity": "sha512-XpqGh1e7hhkOzftBfWE7zt+Yn9mVHFkDhicVttvKLsoCMLVVL+xTQjfjB4X4vtznauxv0QZ5ZAeqjvat0dh62Q==",
-      "dev": true
-    },
-    "lodash._reinterpolate": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
-      "integrity": "sha512-QGEOOjJi7W9LIgDAMVgtGBb8Qgo8ieDlSOCoZjtG45ZNRvDJZjwVMTYlfTIWdNRUiR1I9BjIqQ3Zaf1+DYM94g==",
+      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
       "dev": true
     },
     "lodash._reunescapedhtml": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
-      "integrity": "sha512-CfmZRU1Mk4E/5jh+Wu8lc7tuc3VkuwWZYVIgdPDH9NRSHgiL4Or3AA4JCIpgrkVzHOM+jKu2OMkAVquruhRHDQ==",
+      "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
       "dev": true,
       "requires": {
         "lodash._htmlescapes": "~2.4.1",
         "lodash.keys": "~2.4.1"
+      },
+      "dependencies": {
+        "lodash.keys": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+          "dev": true,
+          "requires": {
+            "lodash._isnative": "~2.4.1",
+            "lodash._shimkeys": "~2.4.1",
+            "lodash.isobject": "~2.4.1"
+          }
+        }
       }
     },
     "lodash._shimkeys": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-      "integrity": "sha512-lBrglYxLD/6KAJ8IEa5Lg+YHgNAL7FyKqXg4XOUI+Du/vtniLs1ZqS+yHNKPkK54waAgkdUnDOYaWf+rv4B+AA==",
+      "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
       "dev": true,
       "requires": {
         "lodash._objecttypes": "~2.4.1"
@@ -15048,129 +18265,77 @@
     "lodash.defaults": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
-      "integrity": "sha512-5wTIPWwGGr07JFysAZB8+7JB2NjJKXDIwogSaRX5zED85zyUAQwtOqUk8AsJkkigUcL3akbHYXd5+BPtTGQPZw==",
+      "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
       "dev": true,
       "requires": {
         "lodash._objecttypes": "~2.4.1",
         "lodash.keys": "~2.4.1"
-      }
-    },
-    "lodash.escape": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
-      "integrity": "sha512-PiEStyvZ8gz37qBE+HqME1Yc/ewb/59AMOu8pG7Ztani86foPTxgzckQvMdphmXPY6V5f20Ex/CaNBqHG4/ycQ==",
-      "dev": true,
-      "requires": {
-        "lodash._escapehtmlchar": "~2.4.1",
-        "lodash._reunescapedhtml": "~2.4.1",
-        "lodash.keys": "~2.4.1"
+      },
+      "dependencies": {
+        "lodash.keys": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+          "dev": true,
+          "requires": {
+            "lodash._isnative": "~2.4.1",
+            "lodash._shimkeys": "~2.4.1",
+            "lodash.isobject": "~2.4.1"
+          }
+        }
       }
     },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.isobject": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-      "integrity": "sha512-sTebg2a1PoicYEZXD5PBdQcTlIJ6hUslrlWr7iV0O7n+i4596s2NQ9I5CaZ5FbXSfya/9WQsrYLANUJv9paYVA==",
+      "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
       "dev": true,
       "requires": {
         "lodash._objecttypes": "~2.4.1"
       }
     },
-    "lodash.keys": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-      "integrity": "sha512-ZpJhwvUXHSNL5wYd1RM6CUa2ZuqorG9ngoJ9Ix5Cce+uX7I5O/E06FCJdhSZ33b5dVyeQDnIlWH7B2s5uByZ7g==",
-      "dev": true,
-      "requires": {
-        "lodash._isnative": "~2.4.1",
-        "lodash._shimkeys": "~2.4.1",
-        "lodash.isobject": "~2.4.1"
-      }
-    },
-    "lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "peer": true
-    },
-    "lodash.template": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
-      "integrity": "sha512-5yLOQwlS69xbaez3g9dA1i0GMAj8pLDHp8lhA4V7M1vRam1lqD76f0jg5EV+65frbqrXo1WH9ZfKalfYBzJ5yQ==",
-      "dev": true,
-      "requires": {
-        "lodash._escapestringchar": "~2.4.1",
-        "lodash._reinterpolate": "~2.4.1",
-        "lodash.defaults": "~2.4.1",
-        "lodash.escape": "~2.4.1",
-        "lodash.keys": "~2.4.1",
-        "lodash.templatesettings": "~2.4.1",
-        "lodash.values": "~2.4.1"
-      }
-    },
-    "lodash.templatesettings": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
-      "integrity": "sha512-vY3QQ7GxbeLe8XfTvoYDbaMHO5iyTDJS1KIZrxp00PRMmyBKr8yEcObHSl2ppYTwd8MgqPXAarTvLA14hx8ffw==",
-      "dev": true,
-      "requires": {
-        "lodash._reinterpolate": "~2.4.1",
-        "lodash.escape": "~2.4.1"
-      }
-    },
     "lodash.values": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
-      "integrity": "sha512-fQwubKvj2Nox2gy6YnjFm8C1I6MIlzKUtBB+Pj7JGtloGqDDL5CPRr4DUUFWPwXWwAl2k3f4C3Aw8H1qAPB9ww==",
+      "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
       "dev": true,
       "requires": {
         "lodash.keys": "~2.4.1"
+      },
+      "dependencies": {
+        "lodash.keys": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+          "dev": true,
+          "requires": {
+            "lodash._isnative": "~2.4.1",
+            "lodash._shimkeys": "~2.4.1",
+            "lodash.isobject": "~2.4.1"
+          }
+        }
       }
     },
     "log4js": {
       "version": "0.6.38",
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
-      "integrity": "sha512-Cd+klbx7lkiaamEId9/0odHxv/PFHDz2E12kEfd6/CzIOZD084DzysASR/Dot4i1dYPBQKC3r2XIER+dfbLOmw==",
+      "integrity": "sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=",
       "dev": true,
       "requires": {
         "readable-stream": "~1.0.2",
         "semver": "~4.3.3"
       },
       "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
         "semver": {
           "version": "4.3.6",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
       }
@@ -15199,9 +18364,18 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
-      "peer": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lru-cache": {
@@ -15214,19 +18388,11 @@
         "yallist": "^2.1.2"
       }
     },
-    "make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
-      "requires": {
-        "semver": "^6.0.0"
-      }
-    },
     "make-iterator": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
       "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
+      "dev": true,
       "requires": {
         "kind-of": "^6.0.2"
       },
@@ -15234,7 +18400,8 @@
         "kind-of": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
         }
       }
     },
@@ -15250,7 +18417,14 @@
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
     },
     "map-stream": {
       "version": "0.0.7",
@@ -15262,6 +18436,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
       }
@@ -15270,6 +18445,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
       "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
+      "dev": true,
       "requires": {
         "findup-sync": "^2.0.0",
         "micromatch": "^3.0.4",
@@ -15277,10 +18453,149 @@
         "stack-trace": "0.0.10"
       },
       "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
         "findup-sync": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-          "integrity": "sha512-vs+3unmJT45eczmcAZ6zMJtxN3l/QXeccaXQx5cu/MeJMhewVfoWZqibRkOxPnmoR59+Zy5hjabfQc6JLSah4g==",
+          "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+          "dev": true,
           "requires": {
             "detect-file": "^1.0.0",
             "is-glob": "^3.1.0",
@@ -15288,13 +18603,87 @@
             "resolve-dir": "^1.0.1"
           }
         },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
         "is-glob": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
           "requires": {
             "is-extglob": "^2.1.0"
           }
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -15310,6 +18699,32 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
+      }
+    },
     "methods": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz",
@@ -15317,46 +18732,103 @@
       "dev": true
     },
     "micromatch": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       },
       "dependencies": {
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+        "expand-range": {
+          "version": "1.8.2",
+          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+          "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "fill-range": "^2.1.0"
           }
         },
-        "kind-of": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+        "fill-range": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+          "dev": true,
+          "requires": {
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^3.0.0",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+          "dev": true
         }
       }
     },
@@ -15381,10 +18853,17 @@
         "mime-db": "1.52.0"
       }
     },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -15399,6 +18878,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
       "requires": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -15408,6 +18888,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -15422,12 +18903,6 @@
       "requires": {
         "minimist": "^1.2.6"
       }
-    },
-    "mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true
     },
     "moo-server": {
       "version": "1.3.0",
@@ -15451,12 +18926,6 @@
         "stream-counter": "~0.2.0"
       },
       "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-          "dev": true
-        },
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
@@ -15468,30 +18937,33 @@
             "isarray": "0.0.1",
             "string_decoder": "~0.10.x"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
         }
       }
     },
     "mute-stdout": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
-      "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg=="
+      "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
     },
     "nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "dev": true,
       "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
       "requires": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -15506,27 +18978,23 @@
         "to-regex": "^3.0.1"
       },
       "dependencies": {
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          }
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
         },
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
         },
         "kind-of": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
         }
       }
     },
@@ -15540,8 +19008,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "ncp": {
       "version": "0.4.2",
@@ -15555,10 +19022,23 @@
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
     },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
     "next-tick": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
     },
     "nise": {
       "version": "1.5.3",
@@ -15584,43 +19064,32 @@
         }
       }
     },
-    "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "whatwg-url": "^5.0.0"
+        "abbrev": "1"
       }
-    },
-    "node-releases": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
-      "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==",
-      "dev": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
       }
     },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -15629,21 +19098,28 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
       "integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
+      "dev": true,
       "requires": {
         "once": "^1.3.2"
       }
     },
+    "null-check": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
+      "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
+      "dev": true
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true,
-      "peer": true
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "object-component": {
       "version": "0.0.3",
@@ -15655,6 +19131,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
       "requires": {
         "copy-descriptor": "^0.1.0",
         "define-property": "^0.2.5",
@@ -15664,7 +19141,8 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -15672,7 +19150,8 @@
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
@@ -15680,7 +19159,8 @@
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
@@ -15689,6 +19169,7 @@
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
             "is-data-descriptor": "^0.1.4",
@@ -15698,24 +19179,17 @@
             "kind-of": {
               "version": "5.1.0",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
             }
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-          "requires": {
-            "is-buffer": "^1.1.5"
           }
         }
       }
     },
     "object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
       "dev": true
     },
     "object-is": {
@@ -15731,12 +19205,14 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
       "requires": {
         "isobject": "^3.0.0"
       }
@@ -15745,6 +19221,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
       "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -15756,6 +19233,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+      "dev": true,
       "requires": {
         "array-each": "^1.0.1",
         "array-slice": "^1.0.0",
@@ -15766,7 +19244,8 @@
         "array-slice": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
-          "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w=="
+          "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
+          "dev": true
         }
       }
     },
@@ -15775,7 +19254,6 @@
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
       "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -15787,7 +19265,6 @@
       "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
       "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -15795,20 +19272,20 @@
       }
     },
     "object.hasown": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.1.tgz",
-      "integrity": "sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.0.tgz",
+      "integrity": "sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
       }
     },
     "object.map": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+      "dev": true,
       "requires": {
         "for-own": "^1.0.0",
         "make-iterator": "^1.0.0"
@@ -15827,7 +19304,7 @@
         "for-own": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-          "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
+          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
           "dev": true,
           "requires": {
             "for-in": "^1.0.1"
@@ -15839,6 +19316,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -15847,6 +19325,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object.reduce/-/object.reduce-1.0.1.tgz",
       "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
+      "dev": true,
       "requires": {
         "for-own": "^1.0.0",
         "make-iterator": "^1.0.0"
@@ -15857,7 +19336,6 @@
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
       "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -15877,6 +19355,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -15888,6 +19367,15 @@
       "dev": true,
       "requires": {
         "fn.name": "1.x.x"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
       }
     },
     "optimist": {
@@ -15915,18 +19403,17 @@
       }
     },
     "optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "deep-is": "^0.1.3",
-        "fast-levenshtein": "^2.0.6",
-        "levn": "^0.4.1",
-        "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
       }
     },
     "options": {
@@ -15939,14 +19426,54 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
       "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
+      "dev": true,
       "requires": {
         "readable-stream": "^2.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
       "requires": {
         "lcid": "^1.0.0"
       }
@@ -15962,7 +19489,6 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
-      "peer": true,
       "requires": {
         "p-try": "^1.0.0"
       }
@@ -15972,7 +19498,6 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
-      "peer": true,
       "requires": {
         "p-limit": "^1.1.0"
       }
@@ -15981,23 +19506,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-      "dev": true,
-      "peer": true
-    },
-    "parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "callsites": "^3.0.0"
-      }
+      "dev": true
     },
     "parse-filepath": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+      "dev": true,
       "requires": {
         "is-absolute": "^1.0.0",
         "map-cache": "^0.2.0",
@@ -16019,13 +19534,13 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
             "is-extglob": "^1.0.0"
@@ -16037,6 +19552,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
       "requires": {
         "error-ex": "^1.2.0"
       }
@@ -16044,12 +19560,14 @@
     "parse-node-version": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
-      "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA=="
+      "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
+      "dev": true
     },
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
     },
     "parsejson": {
       "version": "0.0.3",
@@ -16087,41 +19605,50 @@
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
     },
     "path-dirname": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
     },
     "path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "peer": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "path-root": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "dev": true,
       "requires": {
         "path-root-regex": "^0.1.0"
       }
@@ -16129,7 +19656,8 @@
     "path-root-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
-      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0="
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "1.8.0",
@@ -16138,20 +19666,13 @@
       "dev": true,
       "requires": {
         "isarray": "0.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-          "dev": true
-        }
       }
     },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "pify": "^2.0.0",
@@ -16179,94 +19700,68 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
-    "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
+    },
+    "phantomjs-prebuilt": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
+      "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^4.0.3",
+        "extract-zip": "^1.6.5",
+        "fs-extra": "^1.0.0",
+        "hasha": "^2.2.0",
+        "kew": "^0.7.0",
+        "progress": "^1.1.8",
+        "request": "^2.81.0",
+        "request-progress": "^2.0.1",
+        "which": "^1.2.10"
+      },
+      "dependencies": {
+        "progress": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+          "dev": true
+        }
+      }
     },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
-    },
-    "pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "dev": true,
       "requires": {
-        "find-up": "^4.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        }
+        "pinkie": "^2.0.0"
       }
     },
     "pkginfo": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
       "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
+      "dev": true
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "policyfile": {
@@ -16278,14 +19773,14 @@
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
     },
     "prelude-ls": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true,
-      "peer": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
     },
     "preserve": {
       "version": "0.2.0",
@@ -16296,12 +19791,14 @@
     "pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
+      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -16320,18 +19817,19 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
       }
-    },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -16339,10 +19837,17 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
+    },
     "pump": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -16352,6 +19857,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "dev": true,
       "requires": {
         "duplexify": "^3.6.0",
         "inherits": "^2.0.3",
@@ -16362,46 +19868,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
-      "peer": true
-    },
-    "puppeteer": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-14.1.2.tgz",
-      "integrity": "sha512-Nsyy1f7pT2KyBb15u8DHi4q3FfrIqOptAV0r4Bd1lAp2pHz8T0o4DO+On1yWZ7jFbcx1w3AqZ/e7nKqnc3Vwyg==",
-      "dev": true,
-      "requires": {
-        "cross-fetch": "3.1.5",
-        "debug": "4.3.4",
-        "devtools-protocol": "0.0.982423",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.1",
-        "pkg-dir": "4.2.0",
-        "progress": "2.0.3",
-        "proxy-from-env": "1.1.0",
-        "rimraf": "3.0.2",
-        "tar-fs": "2.1.1",
-        "unbzip2-stream": "1.4.3",
-        "ws": "8.6.0"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "ws": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.6.0.tgz",
-          "integrity": "sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==",
-          "dev": true,
-          "requires": {}
-        }
-      }
+      "dev": true
     },
     "q": {
       "version": "0.9.7",
@@ -16465,13 +19932,13 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
       "requires": {
         "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
@@ -16482,6 +19949,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
       "requires": {
         "find-up": "^1.0.0",
         "read-pkg": "^1.0.0"
@@ -16490,7 +19958,8 @@
         "find-up": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
           "requires": {
             "path-exists": "^2.0.0",
             "pinkie-promise": "^2.0.0"
@@ -16500,6 +19969,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
           "requires": {
             "pinkie-promise": "^2.0.0"
           }
@@ -16507,33 +19977,282 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
       }
     },
     "readdirp": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
       "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
       "requires": {
         "resolve": "^1.1.6"
       }
@@ -16544,6 +20263,16 @@
       "integrity": "sha1-C8R9xIOOZG3M+6BQe15X/7/zX3w=",
       "dev": true,
       "optional": true
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      }
     },
     "redis": {
       "version": "0.7.3",
@@ -16571,52 +20300,33 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          }
-        },
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        }
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
+      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.1.3"
       }
     },
     "regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true,
-      "peer": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
     },
     "remove-bom-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
       "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+      "dev": true,
       "requires": {
         "is-buffer": "^1.1.5",
         "is-utf8": "^0.2.1"
@@ -16626,6 +20336,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
       "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+      "dev": true,
       "requires": {
         "remove-bom-buffer": "^3.0.0",
         "safe-buffer": "^5.1.0",
@@ -16635,42 +20346,121 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
     },
     "repeat-element": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
-      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ=="
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+      "dev": true
     },
     "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz",
+      "integrity": "sha1-x6jTI2BoNiBZp+RlH8aITosftK4=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
     },
     "replace-ext": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
-      "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw=="
+      "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
+      "dev": true
     },
     "replace-homedir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz",
       "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
+      "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.1",
         "is-absolute": "^1.0.0",
         "remove-trailing-separator": "^1.1.0"
       }
     },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+          "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+          "dev": true
+        }
+      }
+    },
+    "request-progress": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+      "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
+      "dev": true,
+      "requires": {
+        "throttleit": "^1.0.0"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+          "dev": true
+        }
+      }
     },
     "requires-port": {
       "version": "1.0.0",
@@ -16682,6 +20472,7 @@
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
       "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "dev": true,
       "requires": {
         "is-core-module": "^2.8.1",
         "path-parse": "^1.0.7",
@@ -16692,22 +20483,17 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dev": true,
       "requires": {
         "expand-tilde": "^2.0.0",
         "global-modules": "^1.0.0"
       }
     },
-    "resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "peer": true
-    },
     "resolve-options": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
       "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+      "dev": true,
       "requires": {
         "value-or-function": "^3.0.0"
       }
@@ -16715,12 +20501,24 @@
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
     },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
     },
     "rimraf": {
       "version": "2.6.3",
@@ -16731,15 +20529,47 @@
         "glob": "^7.1.3"
       }
     },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "*"
+      }
+    },
+    "rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
       "requires": {
         "ret": "~0.1.10"
       }
@@ -16763,15 +20593,16 @@
       "dev": true
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
     "semver-greatest-satisfied-range": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
       "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
+      "dev": true,
       "requires": {
         "sver-compat": "^1.5.0"
       }
@@ -16799,17 +20630,30 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
         "is-plain-object": "^2.0.3",
         "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "setprototypeof": {
@@ -16819,21 +20663,19 @@
       "dev": true
     },
     "shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
-      "peer": true,
       "requires": {
-        "shebang-regex": "^3.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "peer": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
     },
     "side-channel": {
       "version": "1.0.4",
@@ -16852,6 +20694,12 @@
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
+    "signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
     "simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -16859,14 +20707,6 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.3.1"
-      },
-      "dependencies": {
-        "is-arrayish": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-          "dev": true
-        }
       }
     },
     "sinon": {
@@ -16888,10 +20728,22 @@
         "type-detect": "^4.0.0"
       }
     },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
       "requires": {
         "base": "^0.11.1",
         "debug": "^2.2.0",
@@ -16907,6 +20759,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -16914,61 +20767,63 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
           }
         },
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
           }
         },
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
             "is-data-descriptor": "^0.1.4",
             "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
           }
         },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -16976,6 +20831,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
       "requires": {
         "define-property": "^1.0.0",
         "isobject": "^3.0.0",
@@ -16985,7 +20841,8 @@
         "define-property": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -16996,18 +20853,9 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
       "requires": {
         "kind-of": "^3.2.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
       }
     },
     "socket.io": {
@@ -17028,7 +20876,7 @@
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
           "dev": true,
           "requires": {
             "ms": "0.7.2"
@@ -17061,7 +20909,7 @@
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
           "dev": true,
           "requires": {
             "ms": "0.7.2"
@@ -17094,16 +20942,10 @@
         "to-array": "0.1.4"
       },
       "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha512-jPatnhd33viNplKjqXKRkGU345p263OIWzDL2wH3LGIGp5Kojo+uXizHmOADRvhGFFTnJqX3jBAKP6vvmSDKcA==",
-          "dev": true
-        },
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
           "dev": true,
           "requires": {
             "ms": "0.7.2"
@@ -17132,23 +20974,17 @@
         "component-emitter": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-          "integrity": "sha512-YhIbp3PJiznERfjlIkK0ue4obZxt2S60+0W8z24ZymOHT8sHloOqWOqZRU2eN5OlY8U08VFsP02letcu26FilA==",
+          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
           "dev": true
         },
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
           "requires": {
             "ms": "0.7.1"
           }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-          "dev": true
         },
         "ms": {
           "version": "0.7.1",
@@ -17161,12 +20997,14 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
       "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "dev": true,
       "requires": {
         "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0",
@@ -17178,17 +21016,20 @@
     "source-map-url": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
-      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
+      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "dev": true
     },
     "sparkles": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
-      "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw=="
+      "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
       "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -17197,12 +21038,14 @@
     "spdx-exceptions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -17211,7 +21054,8 @@
     "spdx-license-ids": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g=="
+      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "dev": true
     },
     "split": {
       "version": "0.2.10",
@@ -17226,38 +21070,45 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          }
-        },
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        }
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
     },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
       "requires": {
         "define-property": "^0.2.5",
         "object-copy": "^0.1.0"
@@ -17266,7 +21117,8 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -17274,47 +21126,38 @@
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
           }
         },
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
           }
         },
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
             "is-data-descriptor": "^0.1.4",
             "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
           }
         }
       }
@@ -17343,12 +21186,6 @@
         "readable-stream": "~1.1.8"
       },
       "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-          "dev": true
-        },
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
@@ -17360,56 +21197,35 @@
             "isarray": "0.0.1",
             "string_decoder": "~0.10.x"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
         }
       }
     },
     "stream-exhaust": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
-      "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw=="
+      "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
+      "dev": true
     },
     "stream-shift": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "dev": true
     },
     "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "string.prototype.matchall": {
@@ -17417,7 +21233,6 @@
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
       "integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -17430,51 +21245,54 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "define-properties": "^1.1.3"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "define-properties": "^1.1.3"
       }
     },
     "strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
-      "peer": true,
       "requires": {
-        "ansi-regex": "^5.0.1"
+        "ansi-regex": "^3.0.0"
       }
     },
     "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
       "requires": {
-        "is-utf8": "^0.2.0"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "peer": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "supports-color": {
       "version": "5.5.0",
@@ -17488,63 +21306,61 @@
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
     },
     "sver-compat": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
       "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
+      "dev": true,
       "requires": {
         "es6-iterator": "^2.0.1",
         "es6-symbol": "^3.1.1"
       }
     },
-    "tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
       "dev": true,
       "requires": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
       },
       "dependencies": {
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+        "ansi-regex": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
-        }
-      }
-    },
-    "tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
-      "requires": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -17565,8 +21381,13 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true,
-      "peer": true
+      "dev": true
+    },
+    "throttleit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+      "dev": true
     },
     "through": {
       "version": "2.3.8",
@@ -17578,15 +21399,53 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
       "requires": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
       },
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
         "xtend": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+          "dev": true
         }
       }
     },
@@ -17594,6 +21453,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
       "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
+      "dev": true,
       "requires": {
         "through2": "~2.0.0",
         "xtend": "~4.0.0"
@@ -17602,14 +21462,16 @@
         "xtend": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+          "dev": true
         }
       }
     },
     "time-stamp": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+      "dev": true
     },
     "timespan": {
       "version": "2.3.0",
@@ -17642,6 +21504,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
       "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
+      "dev": true,
       "requires": {
         "is-absolute": "^1.0.0",
         "is-negated-glob": "^1.0.0"
@@ -17653,73 +21516,59 @@
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
       "dev": true
     },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
-    },
     "to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
       }
     },
     "to-regex": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
       "requires": {
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
         "regex-not": "^1.0.2",
         "safe-regex": "^1.1.0"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          }
-        },
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        }
       }
     },
     "to-regex-range": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+          "dev": true
+        }
       }
     },
     "to-through": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
       "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+      "dev": true,
       "requires": {
         "through2": "^2.0.3"
       }
@@ -17730,10 +21579,20 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
     "triple-beam": {
@@ -17747,36 +21606,47 @@
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
       "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true,
-          "peer": true
-        }
       }
+    },
+    "tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+      "dev": true
     },
     "type-check": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
-      "peer": true,
       "requires": {
-        "prelude-ls": "^1.2.1"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -17784,13 +21654,6 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
-    },
-    "type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "peer": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -17805,13 +21668,15 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "uglify-js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
-      "integrity": "sha1-S1v/+Rhu/7qoiOTJ6UvZ/EyUkp0=",
-      "dev": true
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
+      "integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
+      "dev": true,
+      "optional": true
     },
     "uid2": {
       "version": "0.0.3",
@@ -17826,36 +21691,28 @@
       "dev": true
     },
     "unbox-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.2",
-        "has-bigints": "^1.0.2",
-        "has-symbols": "^1.0.3",
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
-      }
-    },
-    "unbzip2-stream": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-      "dev": true,
-      "requires": {
-        "buffer": "^5.2.1",
-        "through": "^2.3.8"
       }
     },
     "unc-path-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+      "dev": true
     },
     "undertaker": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.3.0.tgz",
       "integrity": "sha512-/RXwi5m/Mu3H6IHQGww3GNt1PNXlbeCuclF2QYR14L/2CHPz3DFZkvB5hZ0N/QUkiXWCACML2jXViIQEQc2MLg==",
+      "dev": true,
       "requires": {
         "arr-flatten": "^1.0.1",
         "arr-map": "^2.0.0",
@@ -17872,19 +21729,22 @@
         "fast-levenshtein": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.4.tgz",
-          "integrity": "sha512-Ia0sQNrMPXXkqVFt6w6M1n1oKo3NfKs+mvaV811Jwir7vAk9a6PVV9VPYf6X3BU97QiLEmuW3uXH9u87zDFfdw=="
+          "integrity": "sha1-5qdUzI8V5YmHqpy9J69m/W9OWvk=",
+          "dev": true
         }
       }
     },
     "undertaker-registry": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
-      "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA="
+      "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
@@ -17896,6 +21756,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
       "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
+      "dev": true,
       "requires": {
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "through2-filter": "^3.0.0"
@@ -17911,6 +21772,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
       "requires": {
         "has-value": "^0.3.1",
         "isobject": "^3.0.0"
@@ -17919,7 +21781,8 @@
         "has-value": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
           "requires": {
             "get-value": "^2.0.3",
             "has-values": "^0.1.4",
@@ -17929,7 +21792,8 @@
             "isobject": {
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-              "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
               "requires": {
                 "isarray": "1.0.0"
               }
@@ -17939,21 +21803,28 @@
         "has-values": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ=="
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
         }
       }
     },
     "upath": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "dev": true
     },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -17961,12 +21832,14 @@
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
     },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
     },
     "useragent": {
       "version": "2.3.0",
@@ -17981,7 +21854,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "utile": {
       "version": "0.2.1",
@@ -17995,6 +21869,14 @@
         "mkdirp": "0.x.x",
         "ncp": "0.4.x",
         "rimraf": "2.x.x"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
+        }
       }
     },
     "utils-merge": {
@@ -18003,17 +21885,17 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
-    "v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-      "dev": true,
-      "peer": true
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
     },
     "v8flags": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
       "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
+      "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.1"
       }
@@ -18022,6 +21904,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -18030,12 +21913,33 @@
     "value-or-function": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
-      "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM="
+      "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "dev": true
+        }
+      }
     },
     "vinyl": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
       "integrity": "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==",
+      "dev": true,
       "requires": {
         "clone": "^2.1.1",
         "clone-buffer": "^1.0.0",
@@ -18049,6 +21953,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
       "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
+      "dev": true,
       "requires": {
         "fs-mkdirp-stream": "^1.0.0",
         "glob-stream": "^6.1.0",
@@ -18067,12 +21972,51 @@
         "value-or-function": "^3.0.0",
         "vinyl": "^2.0.0",
         "vinyl-sourcemap": "^1.1.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "vinyl-sourcemap": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
       "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+      "dev": true,
       "requires": {
         "append-buffer": "^1.0.2",
         "convert-source-map": "^1.5.0",
@@ -18098,26 +22042,11 @@
         "makeerror": "1.0.12"
       }
     },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "dev": true
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dev": true,
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -18150,20 +22079,21 @@
     "which-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+      "dev": true
     },
     "which-typed-array": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
-      "integrity": "sha512-Jn4e5PItbcAHyLoRDwvPj1ypu27DJbtdYXUa5zsinrUx77Uvfb0cXwwnGMTn7cjUfhhqgVQnVJCwF+7cgU7tpw==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
+      "integrity": "sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==",
       "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
-        "for-each": "^0.3.3",
+        "es-abstract": "^1.18.5",
+        "foreach": "^2.0.5",
         "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.9"
+        "is-typed-array": "^1.1.7"
       }
     },
     "winston": {
@@ -18206,6 +22136,15 @@
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
           }
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
         }
       }
     },
@@ -18230,6 +22169,15 @@
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
           }
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
         }
       }
     },
@@ -18237,13 +22185,19 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
@@ -18252,12 +22206,34 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -18267,13 +22243,23 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "wrench": {
       "version": "1.3.9",
       "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.3.9.tgz",
       "integrity": "sha1-bxPsNRRTF+spLKX2UxORskQRFBE=",
       "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "ws": {
       "version": "1.1.5",
@@ -18323,7 +22309,8 @@
     "y18n": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ=="
+      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+      "dev": true
     },
     "yallist": {
       "version": "2.1.2",
@@ -18335,6 +22322,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.2.tgz",
       "integrity": "sha512-ZEjj/dQYQy0Zx0lgLMLR8QuaqTihnxirir7EwUHp1Axq4e3+k8jXU5K0VLbNvedv1f4EWtBonDIZm0NUr+jCcA==",
+      "dev": true,
       "requires": {
         "camelcase": "^3.0.0",
         "cliui": "^3.2.0",
@@ -18349,15 +22337,67 @@
         "which-module": "^1.0.0",
         "y18n": "^3.2.1",
         "yargs-parser": "^5.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
       }
     },
     "yargs-parser": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.1.tgz",
       "integrity": "sha512-wpav5XYiddjXxirPoCTUPbqM0PXvJ9hiBMvuJgInvo4/lAOTZzUprArw17q2O1P2+GHhbBr18/iQwjL5Z9BqfA==",
+      "dev": true,
       "requires": {
         "camelcase": "^3.0.0",
         "object.assign": "^4.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        }
       }
     },
     "yauzl": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"
@@ -17,22 +17,24 @@
     "access": "public"
   },
   "devDependencies": {
-    "@edx/eslint-config": "^3.1.0",
     "babel-polyfill": "^6.26.0",
+    "eslint": "^5.9.0",
+    "eslint-config-edx": "^4.0.4",
+    "eslint-config-edx-es5": "^4.0.1",
     "eslint-plugin-jsx-a11y": "^6.5.1",
+    "gulp": "4.0.0",
     "gulp-karma": "0.0.1",
     "jasmine-core": "^2.8.0",
     "karma": "^0.13.0",
-    "karma-chrome-launcher": "^3.1.1",
-    "karma-coverage": "^2.2.0",
+    "karma-chrome-launcher": "^0.2.0",
+    "karma-coverage": "^1.1.1",
     "karma-jasmine": "^0.3.6",
     "karma-jasmine-jquery-2": "latest",
+    "karma-phantomjs-launcher": "^1.0.4",
     "karma-sinon": "^1.0.5",
-    "puppeteer": "^14.1.2",
+    "phantomjs-prebuilt": "^2.1.14",
     "sinon": "^3.2.1"
   },
-  "license": "GNU Affero GPLv3",
-  "dependencies": {
-    "gulp": "^4.0.2"
-  }
+  "dependencies": {},
+  "license": "GNU Affero GPLv3"
 }


### PR DESCRIPTION
**Description:**
https://github.com/openedx/edx-proctoring/pull/1055 contained es6, which `uglify-js` does not support. When the LMS tries to collect statis assets using `uglify-js`, the pipeline fails due to the es6 code. 

We should revert these changes until `uglify-js` has been replaced, which is being worked on via https://github.com/openedx/frontend-wg/issues/105

**JIRA:**

[MST-1622](https://2u-internal.atlassian.net/browse/MST-1622)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.