### PR TITLE
feat: pass external attempt id to provider js

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.12.2] - 2022-10-19
+~~~~~~~~~~~~~~~~~~~~~
+* Return external id when requesting exam attempt
+* Add new parameter to JS worker to pass attempt external id
+
 [4.12.1] - 2022-09-15
 ~~~~~~~~~~~~~~~~~~~~~
 * Revert Phantom JS and eslint migration made in version 4.11.0

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.12.1'
+__version__ = '4.12.2'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -818,6 +818,7 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
         'critically_low_threshold_sec': critically_low_threshold,
         'course_id': exam['course_id'],
         'attempt_id': attempt['id'],
+        'external_id': attempt['external_id'],
         'accessibility_time_string': _('you have {remaining_time} remaining').format(
             remaining_time=humanized_time(int(round(time_remaining_seconds / 60.0, 0)))
         ),

--- a/edx_proctoring/static/index.js
+++ b/edx_proctoring/static/index.js
@@ -10,7 +10,7 @@ export const handlerWrapper = (Handler) => {
       }
       case 'startExamAttempt': {
         if (handler.onStartExamAttempt) {
-          handler.onStartExamAttempt(message.data.timeout)
+          handler.onStartExamAttempt(message.data.timeout, message.data.attemptExternalId)
             .then(() => self.postMessage({ type: 'examAttemptStarted' }))
             .catch(error => self.postMessage({ type: 'examAttemptStartFailed', error }));
         }

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -3550,6 +3550,14 @@ class GetExamAttemptDataTests(ProctoredExamTestCase):
         assert 'exam_url_path' in attempt_data
         assert attempt_data['exam_url_path'] == expected_exam_url
 
+    def test_exam_attempt_external_id(self):
+        """ Test external id is included in attempt data """
+        attempt = self._create_started_exam_attempt(is_proctored=True)
+        external_id = self.external_id
+
+        attempt_data = get_exam_attempt_data(self.proctored_exam_id, attempt.id, is_learning_mfe=True)
+        assert attempt_data['external_id'] == external_id
+
     @ddt.data(
         (True, True, 'an onboarding exam'),
         (True, False, 'a proctored exam'),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.12.1",
+  "version": "4.12.2",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

- API now returns the external attempt id to the UI
- The UI will pass the external id into the worker (https://github.com/edx/frontend-lib-special-exams/pull/72)
- JS worker code here will hand off that id to the vendor's interface

**JIRA:**

[MST-1659](https://openedx.atlassian.net/browse/MST-1659)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.