### PR TITLE
feat: include attempt id in all JS worker messages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,8 +13,13 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+
+
+[4.14.0] - 2023-02-28
+~~~~~~~~~~~~~~~~~~~~~
 * Changed the recommended install location for frontend-lib-special-exams to avoid
   potential npm problems.
+* Attempt external id is now included in all JS worker messages
 
 [4.13.3] - 2022-12-2
 ~~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.13.3'
+__version__ = '4.14.0'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/static/index.js
+++ b/edx_proctoring/static/index.js
@@ -18,7 +18,7 @@ export const handlerWrapper = (Handler) => {
       }
       case 'endExamAttempt': {
         if (handler.onEndExamAttempt) {
-          handler.onEndExamAttempt()
+          handler.onEndExamAttempt(message.data.attemptExternalId)
             .then(() => self.postMessage({ type: 'examAttemptEnded' }))
             .catch(error => self.postMessage({ type: 'examAttemptEndFailed', error }));
         }
@@ -26,7 +26,7 @@ export const handlerWrapper = (Handler) => {
       }
       case 'ping': {
         if (handler.onPing) {
-          handler.onPing(message.data.timeout)
+          handler.onPing(message.data.timeout, message.data.attemptExternalId)
             .then(() => self.postMessage({ type: 'echo' }))
             .catch(error => self.postMessage({ type: 'pingFailed', error }));
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.13.3",
+  "version": "4.14.0",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

Attempt external id is now included in all JS worker messages. Easier than expected, thought we would have to change the MFE code but that side already includes this on every message.

**JIRA:**

[MST-1802](https://openedx.atlassian.net/browse/MST-1802)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.