### PR TITLE
feat: API updates to support edx-exams

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.15.0] - 2023-03-16
+~~~~~~~~~~~~~~~~~~~~~
+* Add new endpoint get the currently active exam attempt.
+* Add parameter for staff users to request another users attempt. This is used by
+  the edx-exams service worker.
 
 [4.14.0] - 2023-02-28
 ~~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.14.0'
+__version__ = '4.15.0'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -828,6 +828,9 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
             args=[attempt['id']]
         ),
         'attempt_ready_to_resume': is_attempt_ready_to_resume(attempt),
+        # used by the frontend to determine if attempt is managed by edx-proctoring
+        # instead of the newer edx-exams service
+        'use_legacy_attempt_api': True,
     }
 
     if provider:

--- a/edx_proctoring/urls.py
+++ b/edx_proctoring/urls.py
@@ -117,7 +117,7 @@ urlpatterns = [
         name='proctored_exam.exam_attempts'
     ),
     re_path(
-        fr'edx_proctoring/v1/proctored_exam/active_attempt',
+        'edx_proctoring/v1/proctored_exam/active_attempt',
         views.ProctoredExamActiveAttemptView.as_view(),
         name='proctored_exam.active_attempt'
     ),

--- a/edx_proctoring/urls.py
+++ b/edx_proctoring/urls.py
@@ -116,6 +116,11 @@ urlpatterns = [
         views.ProctoredExamAttemptView.as_view(),
         name='proctored_exam.exam_attempts'
     ),
+    re_path(
+        fr'edx_proctoring/v1/proctored_exam/active_attempt',
+        views.ProctoredExamActiveAttemptView.as_view(),
+        name='proctored_exam.active_attempt'
+    ),
     path('edx_proctoring/v1/proctored_exam/settings/exam_id/<int:exam_id>/', views.ProctoredSettingsView.as_view(),
          name='proctored_exam.proctoring_settings'
          ),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.14.0",
+  "version": "4.15.0",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

- Adds a new URL to return just the currently active exam attempt. This is the same behavior as calling the existing endpoint  `edx_proctoring/v1/proctored_exam/attempt/course_id/{settings.COURSE_ID_PATTERN}$` except it does not require a course id.
- Adds a flag to exams/attempts returned to UI to indicate this data originated from edx-proctoring. This is so the UI can know what service to request attempt create / update on.

These changes are needed to support https://github.com/edx/edx-exams/pull/88

**JIRA:**

[MST-1654](https://2u-internal.atlassian.net/browse/MST-1654)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.