### PR TITLE
fix: user id should be an integer, not a string

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.15.1] - 2023-04-19
+~~~~~~~~~~~~~~~~~~~~~
+* Fix bug in parameter for staff users to request another users attempt, which caused the resulting user id to
+  be a string as opposed to an integer.
+
 [4.15.0] - 2023-03-16
 ~~~~~~~~~~~~~~~~~~~~~
 * Add new endpoint get the currently active exam attempt.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.15.0'
+__version__ = '4.15.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -212,7 +212,7 @@ class ProctoredExamActiveAttemptView(ProctoredAPIView):
         requested_user_id = request.GET.get('user_id', None)
         if requested_user_id:
             if request.user.is_staff:
-                user_id = requested_user_id
+                user_id = int(requested_user_id)
             else:
                 return Response(
                     status=status.HTTP_403_FORBIDDEN,
@@ -275,7 +275,7 @@ class ProctoredExamAttemptView(ProctoredAPIView):
         requested_user_id = request.GET.get('user_id', None)
         if requested_user_id:
             if request.user.is_staff:
-                user_id = requested_user_id
+                user_id = int(requested_user_id)
             else:
                 return Response(
                     status=status.HTTP_403_FORBIDDEN,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.15.0",
+  "version": "4.15.1",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -38,7 +38,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-cryptography==40.0.1
+cryptography==40.0.2
     # via pyjwt
 django==3.2.18
     # via
@@ -83,13 +83,13 @@ djangorestframework==3.14.0
     #   edx-drf-extensions
 drf-jwt==1.19.2
     # via edx-drf-extensions
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   edx-when
     #   event-tracking
-edx-drf-extensions==8.4.1
+edx-drf-extensions==8.7.0
     # via
     #   -r requirements/base.in
     #   edx-when
@@ -124,7 +124,7 @@ pbr==5.11.1
     # via stevedore
 prompt-toolkit==3.0.38
     # via click-repl
-psutil==5.9.4
+psutil==5.9.5
     # via edx-django-utils
 pycparser==2.21
     # via cffi
@@ -181,7 +181,7 @@ six==1.16.0
     #   python-dateutil
 slumber==0.7.1
     # via edx-rest-api-client
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
 stevedore==5.0.0
     # via

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -2,6 +2,5 @@
 
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,23 +4,13 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
-coverage==7.2.2
-    # via codecov
 distlib==0.3.6
     # via virtualenv
-filelock==3.10.7
+filelock==3.12.0
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
-packaging==23.0
+packaging==23.1
     # via tox
 platformdirs==3.2.0
     # via virtualenv
@@ -28,8 +18,6 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -41,7 +29,5 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.15
-    # via requests
 virtualenv==20.21.0
     # via tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -31,7 +31,7 @@ django-simple-history==3.0.0
 # Details can be found in this discussion: https://github.com/tox-dev/tox/discussions/1810
 tox<4.0.0
 
-# edx-sphinx-theme is not compatible with latest Sphinx==6.0.0 version 
+# edx-sphinx-theme is not compatible with latest Sphinx==6.0.0 version
 # Pinning Sphinx version unless the compatibility issue gets resolved
 # For details, see issue https://github.com/openedx/edx-sphinx-theme/issues/197
 sphinx<6.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.6.0
     # via django
-astroid==2.15.2
+astroid==2.15.3
     # via
     #   pylint
     #   pylint-celery
@@ -47,7 +47,7 @@ edx-lint==5.3.4
     # via
     #   -r requirements/dev.in
     #   -r requirements/quality.in
-filelock==3.10.7
+filelock==3.12.0
     # via
     #   tox
     #   virtualenv
@@ -65,7 +65,7 @@ markupsafe==2.1.2
     # via jinja2
 mccabe==0.7.0
     # via pylint
-packaging==23.0
+packaging==23.1
     # via tox
 path==16.6.0
     # via
@@ -93,7 +93,7 @@ pydantic==1.10.7
     # via rstcheck-core
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pygments==2.14.0
+pygments==2.15.1
     # via
     #   diff-cover
     #   rich
@@ -133,7 +133,7 @@ six==1.16.0
     #   tox
 snowballstemmer==2.2.0
     # via pydocstyle
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
 stevedore==5.0.0
     # via code-annotations
@@ -161,7 +161,6 @@ typing-extensions==4.5.0
     #   astroid
     #   pydantic
     #   pylint
-    #   rich
 virtualenv==20.21.0
     # via tox
 wheel==0.40.0

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,9 +10,9 @@ click==8.1.3
     # via
     #   -c requirements/constraints.txt
     #   pip-tools
-packaging==23.0
+packaging==23.1
     # via build
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.6.0
     # via django
-astroid==2.15.2
+astroid==2.15.3
     # via
     #   pylint
     #   pylint-celery
@@ -57,7 +57,7 @@ pydantic==1.10.7
     # via rstcheck-core
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pygments==2.14.0
+pygments==2.15.1
     # via rich
 pylint==2.17.2
     # via
@@ -91,7 +91,7 @@ six==1.16.0
     # via edx-lint
 snowballstemmer==2.2.0
     # via pydocstyle
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
 stevedore==5.0.0
     # via code-annotations
@@ -110,6 +110,5 @@ typing-extensions==4.5.0
     #   astroid
     #   pydantic
     #   pylint
-    #   rich
 wrapt==1.15.0
     # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,10 +9,6 @@ appdirs==1.4.4
     # via fs
 asgiref==3.6.0
     # via django
-attrs==22.2.0
-    # via
-    #   outcome
-    #   pytest
     # via celery
 bok-choy==1.1.1
     # via -r requirements/test.in
@@ -41,9 +37,9 @@ click-plugins==1.1.1
     # via celery
 code-annotations==1.3.0
     # via -r requirements/test.in
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via pytest-cov
-cryptography==40.0.1
+cryptography==40.0.2
     # via pyjwt
 ddt==1.6.0
     # via -r requirements/test.in
@@ -89,13 +85,13 @@ django-webpack-loader==0.7.0
     #   edx-drf-extensions
 drf-jwt==1.19.2
     # via edx-drf-extensions
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   edx-when
     #   event-tracking
-edx-drf-extensions==8.4.1
+edx-drf-extensions==8.7.0
     # via
     #   -r requirements/base.in
     #   edx-when
@@ -128,7 +124,7 @@ httpretty==1.1.4
     # via -r requirements/test.in
 idna==3.4
     # via requests
-importlib-metadata==6.1.0
+importlib-metadata==6.5.0
     # via logilab-common
 iniconfig==2.0.0
     # via pytest
@@ -147,13 +143,13 @@ markupsafe==2.1.2
     # via
     #   jinja2
     #   xblock
-mock==5.0.1
+mock==5.0.2
     # via -r requirements/test.in
 mypy-extensions==1.0.0
     # via logilab-common
 newrelic==8.8.0
     # via edx-django-utils
-packaging==23.0
+packaging==23.1
     # via pytest
 path==16.6.0
     # via edx-i18n-tools
@@ -164,7 +160,7 @@ pluggy==1.0.0
 polib==1.2.0
     # via edx-i18n-tools
     # via click-repl
-psutil==5.9.4
+psutil==5.9.5
     # via edx-django-utils
 pycparser==2.21
     # via cffi
@@ -186,7 +182,7 @@ pymongo==3.13.0
     #   event-tracking
 pynacl==1.5.0
     # via edx-django-utils
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   pytest-cov
     #   pytest-django
@@ -248,7 +244,7 @@ six==1.16.0
     #   python-dateutil
 slumber==0.7.1
     # via edx-rest-api-client
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
 stevedore==5.0.0
     # via


### PR DESCRIPTION
**Description:**

Because the user_id can be read from a query parameter, if no type casting is done, the user_id will be a string. Other functions that take in a user_id expect an int value. 

**JIRA:**

[MST-1877](https://openedx.atlassian.net/browse/MST-1877)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.