### PR TITLE
chore: remove bok-choy

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -119,7 +119,7 @@ kombu==5.3.3
     # via celery
 lxml==4.9.3
     # via xblock
-mako==1.2.4
+mako==1.3.0
     # via xblock
 markupsafe==2.1.3
     # via
@@ -127,7 +127,7 @@ markupsafe==2.1.3
     #   xblock
 newrelic==9.1.1
     # via edx-django-utils
-pbr==5.11.1
+pbr==6.0.0
     # via stevedore
 prompt-toolkit==3.0.39
     # via click-repl

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ backports-zoneinfo[tzdata]==0.2.1
     #   kombu
 billiard==4.2.0
     # via celery
-celery==5.3.4
+celery==5.3.5
     # via
     #   -c requirements/constraints.txt
     #   event-tracking
@@ -94,7 +94,7 @@ edx-django-utils==5.8.0
     #   edx-rest-api-client
     #   edx-when
     #   event-tracking
-edx-drf-extensions==8.13.0
+edx-drf-extensions==8.13.1
     # via
     #   -r requirements/base.in
     #   edx-when
@@ -115,7 +115,7 @@ idna==3.4
     # via requests
 jsonfield==3.1.0
     # via -r requirements/base.in
-kombu==5.3.3
+kombu==5.3.4
     # via celery
 lxml==4.9.3
     # via xblock
@@ -125,11 +125,11 @@ markupsafe==2.1.3
     # via
     #   mako
     #   xblock
-newrelic==9.1.1
+newrelic==9.2.0
     # via edx-django-utils
 pbr==6.0.0
     # via stevedore
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.41
     # via click-repl
 psutil==5.9.6
     # via edx-django-utils
@@ -197,14 +197,14 @@ tzdata==2023.3
     # via
     #   backports-zoneinfo
     #   celery
-urllib3==2.0.7
+urllib3==2.1.0
     # via requests
 vine==5.1.0
     # via
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.9
+wcwidth==0.2.10
     # via prompt-toolkit
 web-fragments==2.1.0
     # via xblock

--- a/requirements/celery50.txt
+++ b/requirements/celery50.txt
@@ -1,9 +1,9 @@
 amqp==5.2.0
 billiard==4.2.0
-celery==5.3.4
+celery==5.3.5
 click==8.1.7
 click-didyoumean==0.3.0
 click-repl==0.3.0
-kombu==5.3.3
-prompt-toolkit==3.0.39
+kombu==5.3.4
+prompt-toolkit==3.0.41
 vine==5.1.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,6 +4,12 @@
 #
 #    make upgrade
 #
+cachetools==5.3.2
+    # via tox
+chardet==5.2.0
+    # via tox
+colorama==0.4.6
+    # via tox
 coverage==7.3.2
     # via -r requirements/ci.in
 distlib==0.3.7
@@ -13,20 +19,23 @@ filelock==3.13.1
     #   tox
     #   virtualenv
 packaging==23.2
-    # via tox
+    # via
+    #   pyproject-api
+    #   tox
 platformdirs==3.11.0
-    # via virtualenv
-pluggy==1.3.0
-    # via tox
-py==1.11.0
-    # via tox
-six==1.16.0
-    # via tox
-tomli==2.0.1
-    # via tox
-tox==3.28.0
     # via
     #   -c requirements/common_constraints.txt
-    #   -r requirements/ci.in
+    #   tox
+    #   virtualenv
+pluggy==1.3.0
+    # via tox
+pyproject-api==1.6.1
+    # via tox
+tomli==2.0.1
+    # via
+    #   pyproject-api
+    #   tox
+tox==4.11.3
+    # via -r requirements/ci.in
 virtualenv==20.24.6
     # via tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -27,7 +27,6 @@ elasticsearch<7.14.0
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
 
 
-# virtualenv latest version requires platformdirs<4.0 which conflicts with tox>4.0 version
-# This constraint can be removed once the issue 
-# https://github.com/pypa/virtualenv/issues/2666 gets resolved 
-platformdirs<4.0
+# tox>4.0.0 isn't yet compatible with many tox plugins, causing CI failures in almost all repos.
+# Details can be found in this discussion: https://github.com/tox-dev/tox/discussions/1810
+tox<4.0.0

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -27,6 +27,7 @@ elasticsearch<7.14.0
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
 
 
-# tox>4.0.0 isn't yet compatible with many tox plugins, causing CI failures in almost all repos.
-# Details can be found in this discussion: https://github.com/tox-dev/tox/discussions/1810
-tox<4.0.0
+# virtualenv latest version requires platformdirs<4.0 which conflicts with tox>4.0 version
+# This constraint can be removed once the issue 
+# https://github.com/pypa/virtualenv/issues/2666 gets resolved 
+platformdirs<4.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,8 +12,12 @@ astroid==3.0.1
     # via
     #   pylint
     #   pylint-celery
+cachetools==5.3.2
+    # via tox
 chardet==5.2.0
-    # via diff-cover
+    # via
+    #   diff-cover
+    #   tox
 click==8.1.7
     # via
     #   -c requirements/constraints.txt
@@ -26,8 +30,10 @@ click-log==0.4.0
 code-annotations==1.5.0
     # via edx-lint
 colorama==0.4.6
-    # via typer
-diff-cover==8.0.0
+    # via
+    #   tox
+    #   typer
+diff-cover==8.0.1
     # via -r requirements/dev.in
 dill==0.3.7
     # via pylint
@@ -74,7 +80,9 @@ mccabe==0.7.0
 mdurl==0.1.2
     # via markdown-it-py
 packaging==23.2
-    # via tox
+    # via
+    #   pyproject-api
+    #   tox
 path==16.7.1
     # via
     #   edx-i18n-tools
@@ -85,7 +93,9 @@ pbr==6.0.0
     # via stevedore
 platformdirs==3.11.0
     # via
+    #   -c requirements/common_constraints.txt
     #   pylint
+    #   tox
     #   virtualenv
 pluggy==1.3.0
     # via
@@ -93,13 +103,11 @@ pluggy==1.3.0
     #   tox
 polib==1.2.0
     # via edx-i18n-tools
-py==1.11.0
-    # via tox
 pycodestyle==2.11.1
     # via -r requirements/quality.in
-pydantic==2.4.2
+pydantic==2.5.1
     # via rstcheck-core
-pydantic-core==2.10.1
+pydantic-core==2.14.3
     # via pydantic
 pydocstyle==6.3.0
     # via -r requirements/quality.in
@@ -121,6 +129,8 @@ pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
+pyproject-api==1.6.1
+    # via tox
 python-slugify==8.0.1
     # via code-annotations
 pytz==2023.3.post1
@@ -129,18 +139,16 @@ pyyaml==6.0.1
     # via
     #   code-annotations
     #   edx-i18n-tools
-rich==13.6.0
+rich==13.7.0
     # via typer
 rstcheck==6.2.0
     # via -r requirements/quality.in
-rstcheck-core==1.1.1
+rstcheck-core==1.2.0
     # via rstcheck
 shellingham==1.5.4
     # via typer
 six==1.16.0
-    # via
-    #   edx-lint
-    #   tox
+    # via edx-lint
 snowballstemmer==2.2.0
     # via pydocstyle
 sqlparse==0.4.4
@@ -152,13 +160,12 @@ text-unidecode==1.3
 tomli==2.0.1
     # via
     #   pylint
+    #   pyproject-api
     #   tox
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via pylint
-tox==3.28.0
-    # via
-    #   -c requirements/common_constraints.txt
-    #   -r requirements/dev.in
+tox==4.11.3
+    # via -r requirements/dev.in
 typer[all]==0.9.0
     # via
     #   rstcheck

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -81,7 +81,7 @@ path==16.7.1
     #   path-py
 path-py==12.5.0
     # via -r requirements/dev.in
-pbr==5.11.1
+pbr==6.0.0
     # via stevedore
 platformdirs==3.11.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -53,7 +53,7 @@ mccabe==0.7.0
     # via pylint
 mdurl==0.1.2
     # via markdown-it-py
-pbr==5.11.1
+pbr==6.0.0
     # via stevedore
 platformdirs==3.11.0
     # via pylint

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -56,12 +56,14 @@ mdurl==0.1.2
 pbr==6.0.0
     # via stevedore
 platformdirs==3.11.0
-    # via pylint
+    # via
+    #   -c requirements/common_constraints.txt
+    #   pylint
 pycodestyle==2.11.1
     # via -r requirements/quality.in
-pydantic==2.4.2
+pydantic==2.5.1
     # via rstcheck-core
-pydantic-core==2.10.1
+pydantic-core==2.14.3
     # via pydantic
 pydocstyle==6.3.0
     # via -r requirements/quality.in
@@ -87,11 +89,11 @@ pytz==2023.3.post1
     # via django
 pyyaml==6.0.1
     # via code-annotations
-rich==13.6.0
+rich==13.7.0
     # via typer
 rstcheck==6.2.0
     # via -r requirements/quality.in
-rstcheck-core==1.1.1
+rstcheck-core==1.2.0
     # via rstcheck
 shellingham==1.5.4
     # via typer
@@ -107,7 +109,7 @@ text-unidecode==1.3
     # via python-slugify
 tomli==2.0.1
     # via pylint
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via pylint
 typer[all]==0.9.0
     # via

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -15,5 +15,4 @@ pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
 pytest-xdist              # pytest extension for parallel execution
 responses
-selenium>=2.45.0
 testfixtures>=4.0.0

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -3,7 +3,6 @@
 
 -r base.in
 
-bok-choy>=0.3.1
 code-annotations>=0.3.1
 ddt>=0.8.0
 edx-i18n-tools	          # be able to run `make validate_translations`

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,18 +9,22 @@ appdirs==1.4.4
     # via fs
 asgiref==3.7.2
     # via django
+attrs==23.1.0
+    # via
+    #   outcome
+    #   trio
 backports-zoneinfo[tzdata]==0.2.1
     # via
     #   celery
     #   kombu
     # via celery
-bok-choy==2.0.2
-    # via -r requirements/test.in
     # via
     #   -c requirements/constraints.txt
     #   event-tracking
 certifi==2023.7.22
-    # via requests
+    # via
+    #   requests
+    #   selenium
 cffi==1.16.0
     # via
     #   cryptography
@@ -47,7 +51,7 @@ coverage[toml]==7.3.2
     #   pytest-cov
 cryptography==41.0.5
     # via pyjwt
-ddt==1.6.0
+ddt==1.7.0
     # via -r requirements/test.in
     # via
     #   -c requirements/common_constraints.txt
@@ -116,19 +120,26 @@ edx-when==2.4.0
 event-tracking==2.2.0
     # via -r requirements/base.in
 exceptiongroup==1.1.3
-    # via pytest
+    # via
+    #   pytest
+    #   trio
+    #   trio-websocket
 execnet==2.0.2
     # via pytest-xdist
 freezegun==1.2.2
     # via -r requirements/test.in
 fs==2.4.16
     # via xblock
+h11==0.14.0
+    # via wsproto
 httmock==1.4.0
     # via -r requirements/test.in
 httpretty==1.1.4
     # via -r requirements/test.in
 idna==3.4
-    # via requests
+    # via
+    #   requests
+    #   trio
 importlib-metadata==6.8.0
     # via logilab-common
 iniconfig==2.0.0
@@ -138,15 +149,13 @@ jinja2==3.1.2
 jsonfield==3.1.0
     # via -r requirements/base.in
     # via celery
-lazy==1.6
-    # via bok-choy
 logilab-common==1.11.0
     # via -r requirements/test.in
 lxml==4.9.3
     # via
     #   edx-i18n-tools
     #   xblock
-mako==1.2.4
+mako==1.3.0
     # via xblock
 markupsafe==2.1.3
     # via
@@ -159,11 +168,13 @@ mypy-extensions==1.0.0
     # via logilab-common
 newrelic==9.1.1
     # via edx-django-utils
+outcome==1.3.0.post0
+    # via trio
 packaging==23.2
     # via pytest
 path==16.7.1
     # via edx-i18n-tools
-pbr==5.11.1
+pbr==6.0.0
     # via stevedore
 pluggy==1.3.0
     # via pytest
@@ -189,6 +200,8 @@ pymongo==3.13.0
     #   event-tracking
 pynacl==1.5.0
     # via edx-django-utils
+pysocks==1.7.1
+    # via urllib3
 pytest==7.4.3
     # via
     #   pytest-cov
@@ -196,7 +209,7 @@ pytest==7.4.3
     #   pytest-xdist
 pytest-cov==4.1.0
     # via -r requirements/test.in
-pytest-django==4.6.0
+pytest-django==4.7.0
     # via -r requirements/test.in
 pytest-xdist==3.3.1
     # via -r requirements/test.in
@@ -232,10 +245,8 @@ responses==0.24.0
     # via -r requirements/test.in
 rules==3.3
     # via -r requirements/base.in
-selenium==3.141.0
-    # via
-    #   -r requirements/test.in
-    #   bok-choy
+selenium==4.15.2
+    # via -r requirements/test.in
 semantic-version==2.10.0
     # via edx-drf-extensions
 simplejson==3.19.2
@@ -247,6 +258,10 @@ six==1.16.0
     #   python-dateutil
 slumber==0.7.1
     # via edx-rest-api-client
+sniffio==1.3.0
+    # via trio
+sortedcontainers==2.4.0
+    # via trio
 sqlparse==0.4.4
     # via django
 stevedore==5.1.0
@@ -272,7 +287,7 @@ tzdata==2023.3
     # via
     #   backports-zoneinfo
     #   celery
-urllib3==2.0.7
+urllib3[socks]==2.0.7
     # via
     #   requests
     #   responses
@@ -287,6 +302,8 @@ web-fragments==2.1.0
     # via xblock
 webob==1.8.7
     # via xblock
+wsproto==1.2.0
+    # via trio-websocket
 xblock==1.8.1
     # via edx-when
 zipp==3.17.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,10 +9,6 @@ appdirs==1.4.4
     # via fs
 asgiref==3.7.2
     # via django
-attrs==23.1.0
-    # via
-    #   outcome
-    #   trio
 backports-zoneinfo[tzdata]==0.2.1
     # via
     #   celery
@@ -22,9 +18,7 @@ backports-zoneinfo[tzdata]==0.2.1
     #   -c requirements/constraints.txt
     #   event-tracking
 certifi==2023.7.22
-    # via
-    #   requests
-    #   selenium
+    # via requests
 cffi==1.16.0
     # via
     #   cryptography
@@ -102,7 +96,7 @@ edx-django-utils==5.8.0
     #   edx-rest-api-client
     #   edx-when
     #   event-tracking
-edx-drf-extensions==8.13.0
+edx-drf-extensions==8.13.1
     # via
     #   -r requirements/base.in
     #   edx-when
@@ -120,26 +114,19 @@ edx-when==2.4.0
 event-tracking==2.2.0
     # via -r requirements/base.in
 exceptiongroup==1.1.3
-    # via
-    #   pytest
-    #   trio
-    #   trio-websocket
+    # via pytest
 execnet==2.0.2
     # via pytest-xdist
 freezegun==1.2.2
     # via -r requirements/test.in
 fs==2.4.16
     # via xblock
-h11==0.14.0
-    # via wsproto
 httmock==1.4.0
     # via -r requirements/test.in
 httpretty==1.1.4
     # via -r requirements/test.in
 idna==3.4
-    # via
-    #   requests
-    #   trio
+    # via requests
 importlib-metadata==6.8.0
     # via logilab-common
 iniconfig==2.0.0
@@ -166,10 +153,8 @@ mock==5.1.0
     # via -r requirements/test.in
 mypy-extensions==1.0.0
     # via logilab-common
-newrelic==9.1.1
+newrelic==9.2.0
     # via edx-django-utils
-outcome==1.3.0.post0
-    # via trio
 packaging==23.2
     # via pytest
 path==16.7.1
@@ -200,8 +185,6 @@ pymongo==3.13.0
     #   event-tracking
 pynacl==1.5.0
     # via edx-django-utils
-pysocks==1.7.1
-    # via urllib3
 pytest==7.4.3
     # via
     #   pytest-cov
@@ -211,7 +194,7 @@ pytest-cov==4.1.0
     # via -r requirements/test.in
 pytest-django==4.7.0
     # via -r requirements/test.in
-pytest-xdist==3.3.1
+pytest-xdist==3.4.0
     # via -r requirements/test.in
 python-dateutil==2.8.2
     # via
@@ -241,12 +224,10 @@ requests==2.31.0
     #   httmock
     #   responses
     #   slumber
-responses==0.24.0
+responses==0.24.1
     # via -r requirements/test.in
 rules==3.3
     # via -r requirements/base.in
-selenium==4.15.2
-    # via -r requirements/test.in
 semantic-version==2.10.0
     # via edx-drf-extensions
 simplejson==3.19.2
@@ -258,10 +239,6 @@ six==1.16.0
     #   python-dateutil
 slumber==0.7.1
     # via edx-rest-api-client
-sniffio==1.3.0
-    # via trio
-sortedcontainers==2.4.0
-    # via trio
 sqlparse==0.4.4
     # via django
 stevedore==5.1.0
@@ -287,23 +264,20 @@ tzdata==2023.3
     # via
     #   backports-zoneinfo
     #   celery
-urllib3[socks]==2.0.7
+urllib3==2.1.0
     # via
     #   requests
     #   responses
-    #   selenium
     # via
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.9
+wcwidth==0.2.10
     # via prompt-toolkit
 web-fragments==2.1.0
     # via xblock
 webob==1.8.7
     # via xblock
-wsproto==1.2.0
-    # via trio-websocket
 xblock==1.8.1
     # via edx-when
 zipp==3.17.0

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ commands =
 deps = 
     -r{toxinidir}/requirements/base.txt
 commands = 
-    {toxinidir}/edx_proctoring/scripts/version_check.py
+    python {toxinidir}/edx_proctoring/scripts/version_check.py
 
 [testenv:pii_check]
 allowlist_externals = 

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,8 @@ commands =
     isort --check-only --diff edx_proctoring manage.py setup.py
 
 [testenv:version_check]
+allowlist_externals = 
+    make
 deps = 
     -r{toxinidir}/requirements/base.txt
 commands = 

--- a/tox.ini
+++ b/tox.ini
@@ -57,8 +57,6 @@ commands =
     isort --check-only --diff edx_proctoring manage.py setup.py
 
 [testenv:version_check]
-allowlist_externals = 
-    make
 deps = 
     -r{toxinidir}/requirements/base.txt
 commands = 


### PR DESCRIPTION
**Description:**

As the bok-choy has been deprecated https://github.com/openedx/public-engineering/issues/13, we are removing its usage from the code in this PR.

Ticket : https://github.com/orgs/openedx/projects/55/views/1?pane=issue&itemId=43871891
