### PR TITLE
fix: possible fix for red herring error

### DIFF
--- a/edx_proctoring/apps.py
+++ b/edx_proctoring/apps.py
@@ -26,7 +26,6 @@ BACKEND_CONFIGURATION_ALLOW_LIST = [
     'help_center_article_url',
     'integration_specific_email',
     'learner_notification_from_email',
-    'lti_external',
     'needs_oauth',
     'organization',
     'passing_statuses',

--- a/edx_proctoring/apps.py
+++ b/edx_proctoring/apps.py
@@ -26,6 +26,7 @@ BACKEND_CONFIGURATION_ALLOW_LIST = [
     'help_center_article_url',
     'integration_specific_email',
     'learner_notification_from_email',
+    'lti_external',
     'needs_oauth',
     'organization',
     'passing_statuses',

--- a/edx_proctoring/backends/__init__.py
+++ b/edx_proctoring/backends/__init__.py
@@ -17,4 +17,10 @@ def get_backend_provider(exam=None, name=None):
             return None
         if exam['backend']:
             name = exam['backend']
+    if name == 'lti_external':
+        # `get_backend_provider()` is called in many places in edx-proctoring, so this filter for
+        # LTI providers needs to be in this function. Not sure if this is the exact right place
+        # Also not sure what I should return here
+        return None
     return apps.get_app_config('edx_proctoring').get_backend(name=name)
+    


### PR DESCRIPTION
Ticket: https://2u-internal.atlassian.net/browse/COSMO-193


- NotImplementedError: No proctoring backend configured for 'lti_external'.
- Possibly caused by 'lti_external' not being on the allowed list

**Description:**

Describe in a couple of sentences how this pull request modifies the repository.

**JIRA:**

[XXX-XXXX](https://openedx.atlassian.net/browse/XXX-XXXX)

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [ ] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.