### PR TITLE
fix: allow timed exams for providers that are no longer valid

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,9 +13,10 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
-* fix timed exam bug for provider that no longer exists
-* fix timed exam reset bug for provider that no longer exists
-* fix instructor dashboard view for provider that no longer exists
+
+[4.18.2] - 2024-10-03
+~~~~~~~~~~~~~~~~~~~~~
+* fix various bugs related to exams configured with removed proctoring backend
 
 [4.17.0]
 ~~~~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+* fix timed exam bug for provider that no longer exists
+* fix timed exam reset bug for provider that no longer exists
+* fix instructor dashboard view for provider that no longer exists
 
 [4.17.0]
 ~~~~~~~~~~~~~~~~~~~~~
@@ -20,7 +23,7 @@ Unreleased
 
 [4.16.1] - 2023-08-8
 ~~~~~~~~~~~~~~~~~~~~~
-* Updated django-simple-history package to 3.3.0 
+* Updated django-simple-history package to 3.3.0
 * Created no-op migrations needed for new django-simple-history package version
 
 [4.16.0] - 2023-06-22

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,4 +3,4 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.18.1'
+__version__ = '4.18.2'

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -2943,7 +2943,7 @@ def get_student_view(user_id, course_id, content_id,
     is_proctored_exam = exam['is_proctored'] and not exam['is_practice_exam']
     is_timed_exam = not exam['is_proctored'] and not exam['is_practice_exam']
 
-    exam_backend = get_backend_provider(name=exam['backend'])
+    exam_backend = get_backend_provider(exam=exam)
 
     sub_view_func = None
     if is_timed_exam:
@@ -3019,8 +3019,17 @@ def is_backend_dashboard_available(course_id):
         active_only=True
     )
     for exam in exams:
-        if get_backend_provider(name=exam.backend).has_dashboard:
-            return True
+        try:
+            if get_backend_provider(name=exam.backend).has_dashboard:
+                return True
+        except NotImplementedError:
+            log.exception(
+                'No proctoring backend configured for backend=%(backend)s',
+                {
+                    'backend': exam.backend,
+                }
+            )
+
     return False
 
 

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1669,7 +1669,7 @@ def update_attempt_status(attempt_id, to_status,
         if email:
             try:
                 email.send()
-            except Exception as err:  # pylint: disable=broad-except
+            except Exception as err:
                 log.exception(
                     ('Exception occurred while trying to send proctoring attempt '
                      'status email for user_id=%(user_id)s in course_id=%(course_id)s -- %(err)s'),

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -274,7 +274,7 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         try:
             response = self.session.post(url, json=exam)
             data = response.json()
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as exc:
             if response:
                 if hasattr(exc, 'response') and exc.response is not None:
                     content = exc.response.content

--- a/edx_proctoring/backends/software_secure.py
+++ b/edx_proctoring/backends/software_secure.py
@@ -409,7 +409,7 @@ class SoftwareSecureBackendProvider(ProctoringBackendProvider):
             # reformat video url as per MST-871 findings
             reformatted_url = decrypted_video_url.replace('DirectLink-Generic', 'DirectLink-HTML5')
             return reformatted_url
-        except Exception as err:  # pylint: disable=broad-except
+        except Exception as err:
             log.exception(
                 'Could not decrypt video url for attempt_id=%(attempt_id)s '
                 'due to the following error: %(error_string)s',

--- a/edx_proctoring/handlers.py
+++ b/edx_proctoring/handlers.py
@@ -127,15 +127,16 @@ def on_attempt_changed(sender, instance, signal, **kwargs):
     else:
         # remove the attempt on the backend
         # timed exams have no backend
-        backend = get_backend_provider(name=instance.proctored_exam.backend)
-        if backend:
-            result = backend.remove_exam_attempt(instance.proctored_exam.external_id, instance.external_id)
-            if not result:
-                log.error(
-                    'Failed to remove attempt_id=%s from backend=%s',
-                    instance.id,
-                    instance.proctored_exam.backend,
-                )
+        if instance.proctored_exam.is_proctored:
+            backend = get_backend_provider(name=instance.proctored_exam.backend)
+            if backend:
+                result = backend.remove_exam_attempt(instance.proctored_exam.external_id, instance.external_id)
+                if not result:
+                    log.error(
+                        'Failed to remove attempt_id=%s from backend=%s',
+                        instance.id,
+                        instance.proctored_exam.backend,
+                    )
 
 
 @receiver(post_delete, sender=models.ProctoredExamStudentAttempt)

--- a/edx_proctoring/handlers.py
+++ b/edx_proctoring/handlers.py
@@ -27,8 +27,16 @@ def check_for_category_switch(sender, instance, **kwargs):
             exam = ProctoredExamJSONSafeSerializer(instance).data
             # from the perspective of the backend, the exam is now inactive.
             exam['is_active'] = False
-            backend = get_backend_provider(name=exam['backend'])
-            backend.on_exam_saved(exam)
+            try:
+                backend = get_backend_provider(name=exam['backend'])
+                backend.on_exam_saved(exam)
+            except NotImplementedError:
+                log.exception(
+                    'No proctoring backend configured for backend=%(backend)s',
+                    {
+                        'backend': exam['backend'],
+                    }
+                )
 
 
 @receiver(post_save, sender=models.ProctoredExamReviewPolicy)

--- a/edx_proctoring/rules.py
+++ b/edx_proctoring/rules.py
@@ -12,5 +12,5 @@ def is_in_reviewer_group(user, attempt):
     return user.groups.filter(name=backend_group).exists()
 
 
-# pylint: disable=unsupported-binary-operation
+# pylint: disable-next=unsupported-binary-operation
 rules.add_perm('edx_proctoring.can_review_attempt', is_in_reviewer_group | rules.is_staff)

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -2896,6 +2896,11 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         # backend with a dashboard
         self.assertTrue(is_backend_dashboard_available(self.course_id))
 
+    @patch('edx_proctoring.api.get_backend_provider')
+    def test_dashboard_availability_no_provider(self, mock_get_backend):
+        mock_get_backend.side_effect = NotImplementedError()
+        self.assertFalse(is_backend_dashboard_available(self.course_id))
+
     def test_does_provider_support_onboarding(self):
         self.assertTrue(does_backend_support_onboarding('test'))
         self.assertFalse(does_backend_support_onboarding('mock'))

--- a/edx_proctoring/tests/test_handlers.py
+++ b/edx_proctoring/tests/test_handlers.py
@@ -27,7 +27,7 @@ class SignalTests(ProctoredExamTestCase):
         self.proctored_exam = ProctoredExam.objects.create(
             course_id='x/y/z', content_id=self.content_id, exam_name=self.exam_name,
             time_limit_mins=self.default_time_limit, external_id=self.external_id,
-            backend=self.backend_name
+            backend=self.backend_name, is_proctored=True,
         )
         self.attempt = ProctoredExamStudentAttempt.objects.create(
             proctored_exam=self.proctored_exam, user=self.user, attempt_code='12345',

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -792,6 +792,18 @@ class TestStudentOnboardingStatusView(ProctoredExamTestCase):
         message = 'There is no onboarding exam related to this course id.'
         self.assertEqual(response_data['detail'], message)
 
+    @patch('edx_proctoring.views.get_backend_provider')
+    def test_invalid_backend(self, mock_get_backend):
+        mock_get_backend.side_effect = NotImplementedError()
+        response = self.client.get(
+            reverse('edx_proctoring:user_onboarding.status')
+            + f'?course_id={self.course_id}'
+        )
+        self.assertEqual(response.status_code, 404)
+        response_data = json.loads(response.content.decode('utf-8'))
+        message = 'There is no onboarding exam related to this course id.'
+        self.assertEqual(response_data['detail'], message)
+
     @override_settings(LEARNING_MICROFRONTEND_URL='https://learningmfe')
     def test_onboarding_mfe_link(self):
         """
@@ -1517,6 +1529,16 @@ class TestStudentOnboardingStatusByCourseView(ProctoredExamTestCase):
         )
         self.assertEqual(response.status_code, 404)
         test_backend.supports_onboarding = previous_value
+
+    @patch('edx_proctoring.views.get_backend_provider')
+    def test_invalid_backend(self, mock_get_backend):
+        mock_get_backend.side_effect = NotImplementedError()
+        response = self.client.get(reverse(
+            'edx_proctoring:user_onboarding.status.course',
+            kwargs={'course_id': 'a/b/c'}
+            )
+        )
+        self.assertEqual(response.status_code, 404)
 
     def test_multiple_onboarding_exams(self):
         onboarding_exam_2_id = create_exam(

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -640,7 +640,7 @@ class StudentOnboardingStatusView(ProctoredAPIView):
         * 'onboarding_past_due': Whether the onboarding exam is past due. All onboarding exams in the course must
           be past due in order for onboarding_past_due to be true.
     """
-    def get(self, request):
+    def get(self, request):  # pylint: disable=too-many-statements
         """
         HTTP GET handler. Returns the learner's onboarding status.
         """
@@ -679,7 +679,7 @@ class StudentOnboardingStatusView(ProctoredAPIView):
         onboarding_exams = list(ProctoredExam.get_practice_proctored_exams_for_course(course_id).order_by('-created'))
         provider = None
         try:
-            provider = get_backend_provider(name=onboarding_exams[0].backend)
+            provider = get_backend_provider(name=onboarding_exams[0].backend) if onboarding_exams else None
         except NotImplementedError:
             logging.exception(
                 'No proctoring backend configured for backend=%(backend)s',
@@ -860,7 +860,7 @@ class StudentOnboardingStatusByCourseView(ProctoredAPIView):
                            .order_by('-created').first())
         provider = None
         try:
-            provider = get_backend_provider(name=onboarding_exam.backend)
+            provider = get_backend_provider(name=onboarding_exam.backend) if onboarding_exam else None
         except NotImplementedError:
             logging.exception(
                 'No proctoring backend configured for backend=%(backend)s',
@@ -2140,15 +2140,7 @@ class InstructorDashboard(AuthenticatedAPIView):
                     continue
 
                 exam_backend_name = exam.get('backend')
-                try:
-                    backend = get_backend_provider(name=exam_backend_name)
-                except NotImplementedError:
-                    logging.exception(
-                        'No proctoring backend configured for backend=%(backend)s',
-                        {
-                            'backend': exam_backend_name,
-                        }
-                    )
+                backend = get_backend_provider(name=exam_backend_name)
                 if existing_backend_name and exam_backend_name != existing_backend_name:
                     # In this case, what are we supposed to do?!
                     # It should not be possible to get in this state, because

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.18.1",
+  "version": "4.18.2",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

If a proctoring backend is removed, timed exams should render as expected. This PR also fixes a bug where the instructor dashboard was not available for courses that had a proctoring provider that was no longer valid.

**JIRA:**

[COSMO-515](https://2u-internal.atlassian.net/browse/COSMO-515)
[COSMO-513](https://2u-internal.atlassian.net/browse/COSMO-513)

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [ ] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.