### PR TITLE
build: Assume that SoftwareSecure PII is retained (to fix annotations)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+
+[4.18.4] - 2024-11-21
+~~~~~~~~~~~~~~~~~~~~~
+* fix PII annotations by assuming that if a model's retirement is 'to_be_implemented', then we should just say it is 'retained'.
+
 [4.18.3] - 2024-11-04
 ~~~~~~~~~~~~~~~~~~~~~
 * add management command to delete attempts

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,4 +3,4 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.18.3'
+__version__ = '4.18.4'

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -685,10 +685,12 @@ class ProctoredExamSoftwareSecureReview(TimeStampedModel):
     This is where we store the proctored exam review feedback
     from the exam reviewers
 
-    .. pii: reviews contain video of the exam
-            retirement to be implemented in https://openedx.atlassian.net/browse/EDUCATOR-4776
+    .. pii: Reviews contain video of the exam.
+            Retirement was supposed to be implemented in https://openedx.atlassian.net/browse/EDUCATOR-4776,
+            but it is not clear that is was. We pessimistically assume that it was NOT retired, but this
+            assumption should be revisited in https://github.com/openedx/edx-proctoring/issues/1241.
     .. pii_types: video
-    .. pii_retirement: to_be_implemented
+    .. pii_retirement: retained
     """
 
     # which student attempt is this feedback for?
@@ -758,10 +760,12 @@ class ProctoredExamSoftwareSecureReviewHistory(TimeStampedModel):
     """
     When records get updated, we will archive them here
 
-    .. pii: reviews contain video of the exam
-            retirement to be implemented in https://openedx.atlassian.net/browse/EDUCATOR-4776
+    .. pii: Reviews contain video of the exam.
+            Retirement was supposed to be implemented in https://openedx.atlassian.net/browse/EDUCATOR-4776,
+            but it is not clear that is was. We pessimistically assume that it was NOT retired, but this
+            assumption should be revisited in https://github.com/openedx/edx-proctoring/issues/1241.
     .. pii_types: video
-    .. pii_retirement: to_be_implemented
+    .. pii_retirement: retained
     """
 
     # which student attempt is this feedback for?
@@ -804,10 +808,12 @@ class ProctoredExamSoftwareSecureComment(TimeStampedModel):
     This is where we store the proctored exam review comments
     from the exam reviewers
 
-    .. pii: comment contains free-form text which could be personally-identifying
-            retirement to be implemented in https://openedx.atlassian.net/browse/EDUCATOR-4776
+    .. pii: Comment contains free-form text which could be personally-identifying.
+            Retirement was supposed to be implemented in https://openedx.atlassian.net/browse/EDUCATOR-4776,
+            but it is not clear that is was. We pessimistically assume that it was NOT retired, but this
+            assumption should be revisited in https://github.com/openedx/edx-proctoring/issues/1241.
     .. pii_types: other
-    .. pii_retirement: to_be_implemented
+    .. pii_retirement: retained
     """
 
     # which student attempt is this feedback for?

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.18.3",
+  "version": "4.18.4",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
This helps us fix the PII checker in edx-platform. See: https://github.com/openedx/edx-proctoring/issues/1241