### PR TITLE
Issue 1217

### DIFF
--- a/edx_proctoring/backends/tests/test_backend.py
+++ b/edx_proctoring/backends/tests/test_backend.py
@@ -4,7 +4,7 @@ Tests for backend.py
 
 import time
 
-from mock import patch
+from unittest.mock import patch
 
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -7,7 +7,7 @@ import json
 import ddt
 import jwt
 import responses
-from mock import patch
+from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 from django.utils import translation

--- a/edx_proctoring/backends/tests/test_software_secure.py
+++ b/edx_proctoring/backends/tests/test_software_secure.py
@@ -8,7 +8,7 @@ import json
 
 import ddt
 from httmock import HTTMock, all_requests
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase

--- a/edx_proctoring/management/commands/tests/test_set_attempt_status.py
+++ b/edx_proctoring/management/commands/tests/test_set_attempt_status.py
@@ -5,7 +5,7 @@ Tests for the set_attempt_status management command
 from datetime import datetime
 
 import pytz
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from django.core.management import call_command
 

--- a/edx_proctoring/management/commands/tests/test_update_attempts_for_exam.py
+++ b/edx_proctoring/management/commands/tests/test_update_attempts_for_exam.py
@@ -2,7 +2,7 @@
 Tests for the update_attempts_for_exam management command
 """
 
-from mock import patch
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.core.management import call_command

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -10,7 +10,7 @@ from itertools import product
 import ddt
 import pytz
 from freezegun import freeze_time
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from django.conf import settings
 from django.core import mail

--- a/edx_proctoring/tests/test_email.py
+++ b/edx_proctoring/tests/test_email.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from itertools import product
 
 import ddt
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from opaque_keys import InvalidKeyError
 
 from django.conf import settings

--- a/edx_proctoring/tests/test_mfe_views.py
+++ b/edx_proctoring/tests/test_mfe_views.py
@@ -6,7 +6,7 @@ from itertools import product
 from urllib.parse import urlencode
 
 import ddt
-from mock import patch
+from unittest.mock import patch
 from opaque_keys.edx.locator import BlockUsageLocator
 
 from django.conf import settings

--- a/edx_proctoring/tests/test_models.py
+++ b/edx_proctoring/tests/test_models.py
@@ -192,7 +192,7 @@ class ProctoredExamModelTests(LoggedInTestCase):
             is_practice_exam=True
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             ProctoredExam.get_practice_proctored_exams_for_course(course_id), list(practice_proctored_exams)
         )
 

--- a/edx_proctoring/tests/test_reviews.py
+++ b/edx_proctoring/tests/test_reviews.py
@@ -6,9 +6,8 @@ import codecs
 import json
 
 import ddt
-import mock
 from crum import set_current_request
-from mock import call, patch
+from unittest.mock import call, patch
 
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory
@@ -588,7 +587,7 @@ class ReviewTests(LoggedInTestCase):
         self.assertTrue(review.is_attempt_active)
 
         # now delete the attempt, which puts it into the archive table
-        with mock.patch('edx_proctoring.api.update_attempt_status') as mock_update_status:
+        with patch('edx_proctoring.api.update_attempt_status') as mock_update_status:
             remove_exam_attempt(self.attempt_id, requesting_user=self.user)
 
         # check that the field has been updated

--- a/edx_proctoring/tests/test_student_view.py
+++ b/edx_proctoring/tests/test_student_view.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 import ddt
 import pytz
 from freezegun import freeze_time
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from django.test.utils import override_settings
 from django.urls import reverse

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -10,7 +10,7 @@ import ddt
 import pytz
 from freezegun import freeze_time
 from httmock import HTTMock
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from opaque_keys.edx.locator import BlockUsageLocator
 
 from django.contrib.auth import get_user_model

--- a/edx_proctoring/tests/test_workerconfig.py
+++ b/edx_proctoring/tests/test_workerconfig.py
@@ -6,7 +6,7 @@ import os.path
 import tempfile
 import unittest
 
-from mock import patch
+from unittest.mock import patch
 
 from django.conf import settings
 


### PR DESCRIPTION
**Description:**

- Replace `mock` with `unittest.mock` (Closes #1207)
- Fix a failed testcase (It used a deprecated Django TestCase method)
