### PR TITLE
Clear all ProctoredExamSoftwareSecureReviewHistory instances of PII

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[5.1.1] - 2025-02-07
+~~~~~~~~~~~~~~~~~~~~
+* fixes bug in ordering of query to ensure all Software Secure history is cleared of PII via the retirement endpoint
+
 [5.1.0] - 2025-02-03
 ~~~~~~~~~~~~~~~~~~~~
 * add Software Secure review, history, and comment models to retirement endpoint

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,4 +3,4 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '5.1.0'
+__version__ = '5.1.1'

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -2275,8 +2275,6 @@ class UserRetirement(AuthenticatedAPIView):
 
             # Retire reviews and review history.
             reviews = ProctoredExamSoftwareSecureReview.objects.filter(attempt_code=attempt_code)
-            review_history = ProctoredExamSoftwareSecureReviewHistory.objects.filter(attempt_code=attempt_code)
-
             for review in reviews:
                 review.encrypted_video_url = b''
                 review.raw_data = ''
@@ -2285,6 +2283,7 @@ class UserRetirement(AuthenticatedAPIView):
                 # and must save each review one-by-one.
                 review.save()
 
+            review_history = ProctoredExamSoftwareSecureReviewHistory.objects.filter(attempt_code=attempt_code)
             for review in review_history:
                 review.encrypted_video_url = b''
                 review.raw_data = ''

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

This pull request changes the time at which we read instances of the `ProctoredExamSoftwareSecureReviewHistory` model. This is necessary because the act of saving the `ProctoredExamSoftwareSecureReview` model causes the pre-save instance to be saved to the `ProctoredExamSoftwareSecureReviewHistory` table. Because we read instances of the `ProctoredExamSoftwareSecureReviewHistory` model prior to calling save on the instances of the `ProctoredExamSoftwareSecureReview` model, we do not have the full queryset we need. Reading the instances of the `ProctoredExamSoftwareSecureReviewHistory` model from the database after we clear all the instances of the `ProctoredExamSoftwareSecureReview` model fixes this issue.

**JIRA:**

[COSMO-595](https://2u-internal.atlassian.net/browse/COSMO-595) (private)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.