### PR TITLE
test: disable  OpenSSL for PhantomJS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ test-python: clean ## run tests in the current virtualenv
 	py.test --cov=edx_proctoring --cov-report=html --ds=test_settings -n 3
 
 test-js:
-	gulp test
+	OPENSSL_CONF=/dev/null gulp test
 
 lint-js:
 	./node_modules/.bin/eslint --ignore-pattern 'edx_proctoring/static/index.js' --ext .js --ext .jsx .


### PR DESCRIPTION
**Description:**

The errors reported in https://github.com/openedx/edx-proctoring/issues/1264 seem to be stemming from an OpenSSL version conflict of some sort. I don't believe we need OpenSSL for the PhantomJS tests in this repo, so this PR disables it.

See https://stackoverflow.com/a/72679175

**Post-Merge:**

- [ ] Create a tag matching the new version number.