### PR TITLE
docs: Update edx.rtd.io links to docs.openedx.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,4 +104,4 @@ Have a question about this repository, or about Open edX in general?  Please
 refer to this `list of resources`_ if you need any assistance.
 
 .. _list of resources: https://open.edx.org/getting-help
-.. _Including Proctored Exams In Your Course: https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/proctored_exams/index.html
+.. _Including Proctored Exams In Your Course: https://docs.openedx.org/en/latest/educators/concepts/proctored_exams/proctored_exams_overview.html

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -7,9 +7,9 @@ edX Proctoring Developer Guide
 How do I use proctoring on devstack?
 ------------------------------------
 * Create a test course
-    * Follow the steps here: `Including Proctored Exams in Your Course <https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/proctored_exams/proctored_enabling.html>`_
+    * Follow the steps here: `Including Proctored Exams in Your Course <https://docs.openedx.org/en/latest/educators/how-tos/proctored_exams/enable_proctored_exams.html>`_
         * Note that the UI may be different on devstack with Enable Proctored Exams in Advanced Settings
-* Read the `learner guide for using proctoring <https://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/completing_assignments/proctored_exams.html>`_
+* Read the `learner guide for using proctoring <https://docs.openedx.org/en/latest/learners/completing_assignments/proctored_exams.html>`_
 * Start out by trying a practice proctored exam to understand the process
 * The Instructor Dashboard has a "Special Exams" tab for administering proctoring
     * can add allowances per user, e.g. additional time for an exam

--- a/docs/system-overview.rst
+++ b/docs/system-overview.rst
@@ -92,8 +92,8 @@ flow through those status updates.
 Detailed descriptions of each potential attempt state can be found below. It should be noted that there
 are minor differences in the review process between RPNow and Proctortrack exams.
 
-- `Proctortrack status values <https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/proctored_exams/pt_results.html#values-in-the-status-column>`_
-- `RPNow status values <https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/proctored_exams/rpnow_results.html#values-in-the-status-column>`_
+- `Proctortrack status values <https://docs.openedx.org/en/latest/educators/how-tos/proctored_exams/review_pt_results.html>`_
+- `RPNow status values <https://docs.openedx.org/en/latest/educators/how-tos/proctored_exams/review_rpnow_results.html>`_
 
 This figure does not include error states or display of unmet prerequite requirements.
 


### PR DESCRIPTION
Convert links from edx.readthedocs.io to links on docs.openedx.org 
