### PR TITLE
Feat: Add django5.2 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         toxenv:
           [
             "django42-drflatest",
+            "django52-drflatest",
             "quality",
             "pii_check",
             "version_check",
@@ -28,6 +29,7 @@ jobs:
             "js_lint",
             "rst_validation",
             "translations-django42",
+            "translations-django52",
           ]
     steps:
       - uses: actions/checkout@v1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,11 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+[5.2.0] - 2025-04-22
+* adds support for django 5.2
+
 [5.1.2] - 2025-02-10
+~~~~~~~~~~~~~~~~~~~~
 * modifies the exam submit email message to avoid confusion among the learners.
 
 [5.1.1] - 2025-02-07

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,4 +3,4 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '5.1.2'
+__version__ = '5.2.0'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "5.1.2",
+  "version": "5.2.0",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         'Development Status :: 4 - Beta',
         'Framework :: Django',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,15 @@
 [tox]
 envlist =
-    py{311,312}-celery{50}-django{42}-drflatest
+    py{311,312}-celery{50}-django{42,52}-drflatest
     quality,
     version_check,
     pii_check,
-    translations-django{42}
+    translations-django{42,52}
 
 [testenv]
 deps =
     django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
     drflatest: djangorestframework
     celery50: -r{toxinidir}/requirements/celery50.txt
     -rrequirements/test.txt
@@ -65,7 +66,8 @@ allowlist_externals =
     make
 deps =
     -r{toxinidir}/requirements/test.txt
-    Django>=4.2,<4.3
+    django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
 commands =
     make pii_check
 
@@ -74,6 +76,7 @@ allowlist_externals =
     make
 deps =
     django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
     -rrequirements/test.txt
 commands =
     sudo apt-get update


### PR DESCRIPTION
Resolves [Add Django 5.2 support to edx-proctoring #1277](https://github.com/openedx/edx-proctoring/issues/1277)

## Add Django 5.2 Support
This PR updates the codebase to be compatible with Django 5.2 while maintaining compatibility with Django 4.2.

### Changes Made:
- Update ci and tox files
- Ran django-upgrade to apply necessary syntax updates for Django 5.2.
- Run tests using tox command and resolved the warning
- Ensured all modifications remain backward-compatible with Django 4.2.

### django-upgrade usage:
`git ls-files -z -- '*.py' | xargs -0r django-upgrade --target-version 5.2`