### PR TITLE
perf: add pre_cache_exams_for_course API call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,13 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+
+[5.3.0] - 2025-05-13
+~~~~~~~~~~~~~~~~~~~~
+* adds pre_cache_exams_for_course() API call to improve performance in the Studio course outline page.
+
 [5.2.0] - 2025-04-22
+~~~~~~~~~~~~~~~~~~~~
 * adds support for django 5.2
 
 [5.1.2] - 2025-02-10

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,4 +3,4 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '5.2.0'
+__version__ = '5.3.0'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

This is to address the performance issue when outline page loading
in Studio causes multiple calls to get_exam_by_content_id() for
every subsection in the course. On one test course, this resulted
in about a hundred separate queries, despite the fact that only two
of the subsections had corresponding ProctoredExam models.

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [ ] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
