### PR TITLE
chore: remove all references to edx-proctoring-proctortrack

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+[5.2.1] - 2025-12-05
+* Remove all references to Proctortrack
+
 [5.2.0] - 2025-04-22
 * adds support for django 5.2
 

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,4 +3,4 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '5.2.0'
+__version__ = '5.2.1'

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1771,7 +1771,7 @@ def create_proctoring_attempt_status_email(exam_attempt_obj, course_name, course
     default_contact_url = f'{scheme}://{constants.SITE_NAME}/support/contact_us'
 
     # If the course has a proctoring escalation email set, use that rather than edX Support.
-    # Currently only courses using Proctortrack will have this set.
+    # This will be set if 'requires_escalation_email' is 'True' in proctoring backend.
     proctoring_escalation_email = _get_proctoring_escalation_email(course_id)
     if proctoring_escalation_email:
         contact_url = f'mailto:{proctoring_escalation_email}'

--- a/edx_proctoring/tests/test_models.py
+++ b/edx_proctoring/tests/test_models.py
@@ -67,7 +67,7 @@ class ProctoredExamModelTests(LoggedInTestCase):
         self.assertEqual(len(proctored_exam.history.filter(course_id='test_course', content_id='test_content')), 1)
 
         proctored_exam.external_id = 'test_id_2'
-        proctored_exam.backend = 'proctortrack'
+        proctored_exam.backend = 'test_proctoring_provider'
         proctored_exam.save()
 
         self.assertEqual(len(proctored_exam.history.filter(course_id='test_course', content_id='test_content')), 2)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
All references to edx-proctoring-proctortrack are being removed from the openedx organization as explained here:
https://github.com/openedx/edx-platform/issues/36329

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.