### PR TITLE
fix: reset proctored exam attempts reliably when the provider is unavailable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,10 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 [6.1.0] - 2026-07-24
-* Add an explicit request timeout to the REST proctoring backend, and log and raise a
-  typed ``BackendProviderCannotRemoveAttempt`` (HTTP 502) when the provider fails to
-  remove an attempt, so callers can return a descriptive error to the instructor instead
-  of an unhandled 500.
+
+* Add an explicit request timeout to the REST proctoring backend (default 30s,
+  overridable per backend via a ``timeout`` key in ``PROCTORING_BACKENDS``), and log and
+  raise a typed ``BackendProviderCannotRemoveAttempt`` (HTTP 502) when the provider fails
+  to remove an attempt, so callers can return a descriptive error to the instructor
+  instead of an unhandled 500.
 
 [5.2.1] - 2025-12-05
 * Remove all references to Proctortrack

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,13 +13,20 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
-[6.1.0] - 2026-07-24
+[6.1.0] - 2026-07-28
 
-* Add an explicit request timeout to the REST proctoring backend (default 30s,
-  overridable per backend via a ``timeout`` key in ``PROCTORING_BACKENDS``), and log and
-  raise a typed ``BackendProviderCannotRemoveAttempt`` (HTTP 502) when the provider fails
-  to remove an attempt, so callers can return a descriptive error to the instructor
-  instead of an unhandled 500.
+* Make proctored exam attempt removal fail loudly when the proctoring provider errors,
+  instead of a silent local-only reset or an unhandled 500:
+
+  * Add an explicit request timeout to the REST proctoring backend (default 30s,
+    overridable per backend via a ``timeout`` key in ``PROCTORING_BACKENDS``).
+  * Raise a typed ``BackendProviderCannotRemoveAttempt`` (HTTP 502) both when the
+    provider is unreachable/times out and when it responds with an HTTP error status,
+    returning a clear message (including the provider's HTTP status) and logging the raw
+    provider response for debugging. Callers can then return a descriptive error to the
+    instructor instead of a silent local-only reset or an unhandled 500. Raising on a
+    provider HTTP error is on by default and overridable per backend via a
+    ``raise_on_remove_error`` key in ``PROCTORING_BACKENDS``.
 
 [5.2.1] - 2025-12-05
 * Remove all references to Proctortrack

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,12 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+[6.1.0] - 2026-07-24
+* Add an explicit request timeout to the REST proctoring backend, and log and raise a
+  typed ``BackendProviderCannotRemoveAttempt`` (HTTP 502) when the provider fails to
+  remove an attempt, so callers can return a descriptive error to the instructor instead
+  of an unhandled 500.
+
 [5.2.1] - 2025-12-05
 * Remove all references to Proctortrack
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,8 +19,9 @@ Unreleased
   is unavailable, instead of an unhandled 500 or a stuck reset:
 
   * Add an explicit request timeout to the REST proctoring backend (default 30s,
-    overridable per backend via a ``timeout`` key in ``PROCTORING_BACKENDS``) so a slow
-    provider cannot hang the request indefinitely.
+    overridable per backend via a ``timeout`` key in ``PROCTORING_BACKENDS``), applied to
+    every outbound provider request, so a slow provider cannot hang the request
+    indefinitely.
   * Call the provider from ``remove_exam_attempt`` **before** the local delete (rather
     than from the ``pre_delete`` signal). If the provider is unreachable/errors, a typed
     ``BackendProviderCannotRemoveAttempt`` (HTTP 502) is raised before anything is
@@ -28,9 +29,11 @@ Unreleased
     attempt is preserved. Because the failure no longer originates inside ``delete()``'s
     ``pre_delete`` signal, it does not leave the DB connection in a needs-rollback state,
     so a partially-failed multi-attempt reset can be retried in the same request.
-  * A provider that does not confirm removal (attempt never registered, or already gone
-    upstream) is logged and treated as already-removed, so the local delete still
-    proceeds and a retry converges instead of failing forever.
+  * On removal, a provider ``404`` (the attempt is already gone upstream) is treated as
+    success so a retried, partially-failed reset converges; any other HTTP error is raised
+    so the local attempt is kept for a later retry instead of being silently dropped.
+  * Route the ``reset_attempts`` management command through the same provider-removal
+    path, since provider cleanup no longer happens in the ``pre_delete`` signal.
 
 [5.2.1] - 2025-12-05
 * Remove all references to Proctortrack

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,20 +13,24 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
-[6.1.0] - 2026-07-28
+[6.1.0] - 2026-09-01
 
-* Make proctored exam attempt removal fail loudly when the proctoring provider errors,
-  instead of a silent local-only reset or an unhandled 500:
+* Make resetting a proctored exam attempt fail gracefully when the proctoring provider
+  is unavailable, instead of an unhandled 500 or a stuck reset:
 
   * Add an explicit request timeout to the REST proctoring backend (default 30s,
-    overridable per backend via a ``timeout`` key in ``PROCTORING_BACKENDS``).
-  * Raise a typed ``BackendProviderCannotRemoveAttempt`` (HTTP 502) both when the
-    provider is unreachable/times out and when it responds with an HTTP error status,
-    returning a clear message (including the provider's HTTP status) and logging the raw
-    provider response for debugging. Callers can then return a descriptive error to the
-    instructor instead of a silent local-only reset or an unhandled 500. Raising on a
-    provider HTTP error is on by default and overridable per backend via a
-    ``raise_on_remove_error`` key in ``PROCTORING_BACKENDS``.
+    overridable per backend via a ``timeout`` key in ``PROCTORING_BACKENDS``) so a slow
+    provider cannot hang the request indefinitely.
+  * Call the provider from ``remove_exam_attempt`` **before** the local delete (rather
+    than from the ``pre_delete`` signal). If the provider is unreachable/errors, a typed
+    ``BackendProviderCannotRemoveAttempt`` (HTTP 502) is raised before anything is
+    deleted, so the caller can show the instructor a descriptive message and the local
+    attempt is preserved. Because the failure no longer originates inside ``delete()``'s
+    ``pre_delete`` signal, it does not leave the DB connection in a needs-rollback state,
+    so a partially-failed multi-attempt reset can be retried in the same request.
+  * A provider that does not confirm removal (attempt never registered, or already gone
+    upstream) is logged and treated as already-removed, so the local delete still
+    proceeds and a retry converges instead of failing forever.
 
 [5.2.1] - 2025-12-05
 * Remove all references to Proctortrack

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,4 +3,4 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '6.0.0'
+__version__ = '6.1.0'

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1891,9 +1891,10 @@ def reset_practice_exam(exam_id, user_id, requesting_user):
     return create_exam_attempt(exam_id, user_id, taking_as_proctored=exam_attempt_obj.taking_as_proctored)
 
 
-def _remove_exam_attempt_from_backend(attempt, raise_on_error=True):
+def _remove_exam_attempt_from_backend(attempt):
     """
-    Ask the proctoring backend to remove ``attempt`` on the provider's side.
+    Ask the proctoring backend to remove ``attempt`` on the provider's side, raising
+    ``BackendProviderCannotRemoveAttempt`` (HTTP 502) if it cannot.
 
     This is called BEFORE the local delete (see ``remove_exam_attempt``). Doing the
     provider call outside the ``pre_delete`` signal means a provider outage can raise a
@@ -1901,12 +1902,10 @@ def _remove_exam_attempt_from_backend(attempt, raise_on_error=True):
     ``delete()``'s ``pre_delete`` marks the DB connection needs-rollback, which then makes
     the surrounding request (and any retry) fail with ``TransactionManagementError``.
 
-    - Provider unreachable / errors out, or the backend can't be resolved: log and (if
-      ``raise_on_error``) raise ``BackendProviderCannotRemoveAttempt`` so the caller
-      surfaces a 502; the local delete is not attempted. Best-effort callers
-      (``raise_on_error=False``) instead log and return so their local cleanup proceeds.
-    - Attempt already gone upstream (provider 404): the backend reports success, so the
-      local delete proceeds and a retry converges.
+    An attempt already gone upstream (provider 404) counts as success, so the local delete
+    proceeds and a retry converges. Bulk, best-effort callers (onboarding cleanup, the
+    reset_attempts command) should use ``_remove_exam_attempts_from_backend`` instead, which
+    swallows these errors and skips a failing backend for the rest of the pass.
     """
     exam = attempt.proctored_exam
     if not exam.is_proctored:
@@ -1941,16 +1940,40 @@ def _remove_exam_attempt_from_backend(attempt, raise_on_error=True):
                 'backend': exam.backend,
             }
         )
-        if raise_on_error:
-            raise BackendProviderCannotRemoveAttempt(unavailable_message) from exc
-        return
+        raise BackendProviderCannotRemoveAttempt(unavailable_message) from exc
     if not result:
-        # The provider responded but did not confirm removal. Strict callers keep the local
-        # attempt (so a retry can converge once the provider is healthy); best-effort callers
-        # (e.g. onboarding cleanup) proceed with the local delete.
+        # The provider responded but did not confirm removal, so keep the local attempt: a
+        # retry can converge once the provider is healthy instead of silently dropping it.
         log.warning('Backend %s did not confirm removal of attempt_id=%s.', exam.backend, attempt.id)
-        if raise_on_error:
-            raise BackendProviderCannotRemoveAttempt(unavailable_message)
+        raise BackendProviderCannotRemoveAttempt(unavailable_message)
+
+
+def _remove_exam_attempts_from_backend(attempts, failed_backends=None):
+    """
+    Best-effort provider-side removal for a collection of attempts.
+
+    Provider failures are swallowed (the caller is expected to delete the attempts locally
+    regardless), but once a backend fails a removal we stop calling it for the rest of this
+    pass -- while still trying other, independently configured backends -- so a provider
+    outage does not cost a full request timeout for every attempt. Pass a shared
+    ``failed_backends`` set to keep that skip-list across multiple calls (e.g. batches).
+
+    Pass a queryset with ``select_related('proctored_exam')`` to avoid a query per attempt.
+    """
+    if failed_backends is None:
+        failed_backends = set()
+    for attempt in attempts:
+        backend = attempt.proctored_exam.backend
+        if backend in failed_backends:
+            continue
+        try:
+            _remove_exam_attempt_from_backend(attempt)
+        except BackendProviderCannotRemoveAttempt:
+            log.warning(
+                'Provider removal failed for backend %r; skipping further provider calls '
+                'for it during this cleanup and removing locally only.', backend
+            )
+            failed_backends.add(backend)
 
 
 def remove_exam_attempt(attempt_id, requesting_user):

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1914,6 +1914,14 @@ def _remove_exam_attempt_from_backend(attempt, raise_on_error=True):
     if not attempt.external_id:
         # The attempt was never registered with the provider; nothing to remove upstream.
         return
+    # Single instructor-facing message for any provider-side removal failure. The specific
+    # cause is logged (below), never surfaced to the user.
+    # Translators: shown to an instructor when an exam attempt could not be reset because
+    # the external proctoring provider is temporarily unavailable.
+    unavailable_message = _(
+        'The proctoring provider is temporarily unavailable, so this attempt could not '
+        'be fully reset. Please try again in a few minutes.'
+    )
     try:
         # Resolving the backend can itself raise (e.g. NotImplementedError for a
         # stale/unconfigured backend), so keep it inside the error-handling block.
@@ -1934,20 +1942,15 @@ def _remove_exam_attempt_from_backend(attempt, raise_on_error=True):
             }
         )
         if raise_on_error:
-            raise BackendProviderCannotRemoveAttempt(
-                # Translators: shown to an instructor when an exam attempt could not be reset
-                # because the external proctoring provider is temporarily unavailable.
-                _(
-                    'The proctoring provider is temporarily unavailable, so this attempt could not '
-                    'be fully reset. Please try again in a few minutes.'
-                )
-            ) from exc
+            raise BackendProviderCannotRemoveAttempt(unavailable_message) from exc
         return
     if not result:
-        log.warning(
-            'Backend %s did not confirm removal of attempt_id=%s; treating as already removed.',
-            exam.backend, attempt.id,
-        )
+        # The provider responded but did not confirm removal. Strict callers keep the local
+        # attempt (so a retry can converge once the provider is healthy); best-effort callers
+        # (e.g. onboarding cleanup) proceed with the local delete.
+        log.warning('Backend %s did not confirm removal of attempt_id=%s.', exam.backend, attempt.id)
+        if raise_on_error:
+            raise BackendProviderCannotRemoveAttempt(unavailable_message)
 
 
 def remove_exam_attempt(attempt_id, requesting_user):

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -26,6 +26,7 @@ from edx_proctoring.backends import get_backend_provider
 from edx_proctoring.exceptions import (
     AllowanceValueNotAllowedException,
     BackendProviderCannotRegisterAttempt,
+    BackendProviderCannotRemoveAttempt,
     BackendProviderNotConfigured,
     BackendProviderOnboardingException,
     BackendProviderSentNoAttemptID,
@@ -1890,6 +1891,60 @@ def reset_practice_exam(exam_id, user_id, requesting_user):
     return create_exam_attempt(exam_id, user_id, taking_as_proctored=exam_attempt_obj.taking_as_proctored)
 
 
+def _remove_exam_attempt_from_backend(attempt, raise_on_error=True):
+    """
+    Ask the proctoring backend to remove ``attempt`` on the provider's side.
+
+    This is called BEFORE the local delete (see ``remove_exam_attempt``). Doing the
+    provider call outside the ``pre_delete`` signal means a provider outage can raise a
+    descriptive error without the local delete being half-applied: raising from inside
+    ``delete()``'s ``pre_delete`` marks the DB connection needs-rollback, which then makes
+    the surrounding request (and any retry) fail with ``TransactionManagementError``.
+
+    - Provider unreachable / errors out: log and (if ``raise_on_error``) raise
+      ``BackendProviderCannotRemoveAttempt`` so the caller surfaces a 502; the local delete
+      is not attempted.
+    - Provider does not confirm removal (attempt never registered, or already gone
+      upstream): log and return, so the local delete proceeds and a retry can converge.
+    """
+    exam = attempt.proctored_exam
+    if not exam.is_proctored:
+        return
+    if not attempt.external_id:
+        # The attempt was never registered with the provider; nothing to remove upstream.
+        return
+    backend = get_backend_provider(name=exam.backend)
+    if not backend:
+        return
+    try:
+        result = backend.remove_exam_attempt(exam.external_id, attempt.external_id)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.exception(
+            'Failed to remove attempt_id=%(attempt_id)s (external_id=%(external_id)s) for '
+            'exam_id=%(exam_id)s user_id=%(user_id)s from backend=%(backend)s due to a provider error.',
+            {
+                'attempt_id': attempt.id,
+                'external_id': attempt.external_id,
+                'exam_id': exam.id,
+                'user_id': attempt.user_id,
+                'backend': exam.backend,
+            }
+        )
+        if raise_on_error:
+            raise BackendProviderCannotRemoveAttempt(
+                # Translators: shown to an instructor when an exam attempt could not be reset
+                # because the external proctoring provider is temporarily unavailable.
+                'The proctoring provider is temporarily unavailable, so this attempt could not '
+                'be fully reset. Please try again in a few minutes.'
+            ) from exc
+        return
+    if not result:
+        log.warning(
+            'Backend %s did not confirm removal of attempt_id=%s; treating as already removed.',
+            exam.backend, attempt.id,
+        )
+
+
 def remove_exam_attempt(attempt_id, requesting_user):
     """
     Removes an exam attempt given the attempt id. requesting_user is passed through to the instructor_service.
@@ -1915,6 +1970,12 @@ def remove_exam_attempt(attempt_id, requesting_user):
     course_id = existing_attempt.proctored_exam.course_id
     content_id = existing_attempt.proctored_exam.content_id
     to_status = existing_attempt.status
+
+    # Remove the attempt on the proctoring provider BEFORE deleting it locally, so a
+    # provider outage surfaces a descriptive error instead of a rolled-back, half-applied
+    # delete. See _remove_exam_attempt_from_backend for why this must not happen in the
+    # pre_delete signal.
+    _remove_exam_attempt_from_backend(existing_attempt)
 
     existing_attempt.delete_exam_attempt()
     instructor_service = get_runtime_service('instructor')

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1901,11 +1901,12 @@ def _remove_exam_attempt_from_backend(attempt, raise_on_error=True):
     ``delete()``'s ``pre_delete`` marks the DB connection needs-rollback, which then makes
     the surrounding request (and any retry) fail with ``TransactionManagementError``.
 
-    - Provider unreachable / errors out: log and (if ``raise_on_error``) raise
-      ``BackendProviderCannotRemoveAttempt`` so the caller surfaces a 502; the local delete
-      is not attempted.
-    - Provider does not confirm removal (attempt never registered, or already gone
-      upstream): log and return, so the local delete proceeds and a retry can converge.
+    - Provider unreachable / errors out, or the backend can't be resolved: log and (if
+      ``raise_on_error``) raise ``BackendProviderCannotRemoveAttempt`` so the caller
+      surfaces a 502; the local delete is not attempted. Best-effort callers
+      (``raise_on_error=False``) instead log and return so their local cleanup proceeds.
+    - Attempt already gone upstream (provider 404): the backend reports success, so the
+      local delete proceeds and a retry converges.
     """
     exam = attempt.proctored_exam
     if not exam.is_proctored:
@@ -1913,10 +1914,12 @@ def _remove_exam_attempt_from_backend(attempt, raise_on_error=True):
     if not attempt.external_id:
         # The attempt was never registered with the provider; nothing to remove upstream.
         return
-    backend = get_backend_provider(name=exam.backend)
-    if not backend:
-        return
     try:
+        # Resolving the backend can itself raise (e.g. NotImplementedError for a
+        # stale/unconfigured backend), so keep it inside the error-handling block.
+        backend = get_backend_provider(name=exam.backend)
+        if not backend:
+            return
         result = backend.remove_exam_attempt(exam.external_id, attempt.external_id)
     except Exception as exc:  # pylint: disable=broad-exception-caught
         log.exception(
@@ -1934,8 +1937,10 @@ def _remove_exam_attempt_from_backend(attempt, raise_on_error=True):
             raise BackendProviderCannotRemoveAttempt(
                 # Translators: shown to an instructor when an exam attempt could not be reset
                 # because the external proctoring provider is temporarily unavailable.
-                'The proctoring provider is temporarily unavailable, so this attempt could not '
-                'be fully reset. Please try again in a few minutes.'
+                _(
+                    'The proctoring provider is temporarily unavailable, so this attempt could not '
+                    'be fully reset. Please try again in a few minutes.'
+                )
             ) from exc
         return
     if not result:

--- a/edx_proctoring/apps.py
+++ b/edx_proctoring/apps.py
@@ -30,7 +30,6 @@ BACKEND_CONFIGURATION_ALLOW_LIST = [
     'organization',
     'passing_statuses',
     'ping_interval',
-    'raise_on_remove_error',
     'secret_key',
     'secret_key_id',
     'send_email',

--- a/edx_proctoring/apps.py
+++ b/edx_proctoring/apps.py
@@ -30,6 +30,7 @@ BACKEND_CONFIGURATION_ALLOW_LIST = [
     'organization',
     'passing_statuses',
     'ping_interval',
+    'raise_on_remove_error',
     'secret_key',
     'secret_key_id',
     'send_email',

--- a/edx_proctoring/apps.py
+++ b/edx_proctoring/apps.py
@@ -37,6 +37,7 @@ BACKEND_CONFIGURATION_ALLOW_LIST = [
     'supports_onboarding',
     'tech_support_email',
     'tech_support_phone',
+    'timeout',
     'token_expiration_time',
     'verbose_name',
     'video_review_aes_key',

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -41,6 +41,9 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
     has_dashboard = True
     supports_onboarding = True
     passing_statuses = (SoftwareSecureReviewStatus.clean,)
+    # Timeout (in seconds) applied to every outbound request to the provider so
+    # that a slow or unavailable provider cannot hang the request indefinitely.
+    timeout = 30
 
     @property
     def exam_attempt_url(self):
@@ -384,7 +387,7 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         if method == 'GET':
             headers.update(self._get_language_headers())
         log.debug('Making %r attempt request at %r', method, url)
-        response = self.session.request(method, url, json=payload, headers=headers)
+        response = self.session.request(method, url, json=payload, headers=headers, timeout=self.timeout)
         try:
             data = response.json()
         except ValueError:

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -19,6 +19,7 @@ from django.conf import settings
 from edx_proctoring.backends.backend import ProctoringBackendProvider
 from edx_proctoring.exceptions import (
     BackendProviderCannotRegisterAttempt,
+    BackendProviderCannotRemoveAttempt,
     BackendProviderCannotRetireUser,
     BackendProviderOnboardingException,
     BackendProviderOnboardingProfilesException,
@@ -233,9 +234,10 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         Removes the exam attempt on the backend provider's server.
 
         A 404 is treated as success (the attempt is already gone upstream), so retrying a
-        partially-failed reset converges instead of failing forever. Any other HTTP error is
-        raised so the caller keeps the local attempt for a later retry rather than silently
-        losing it by treating the error as an "already removed" response.
+        partially-failed reset converges instead of failing forever. Success is otherwise
+        reserved for the documented ``{"status": "deleted"}`` payload; any other HTTP error,
+        an undecodable body, or a 2xx that does not confirm deletion is raised so the caller
+        keeps the local attempt for a later retry rather than silently dropping it.
         """
         if not attempt:
             return False
@@ -247,10 +249,15 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         response.raise_for_status()
         try:
             data = response.json()
-        except ValueError:
-            log.exception('Decoding attempt removal %r -> %r', attempt, response.content)
-            data = {}
-        return data.get('status', None) == 'deleted'
+        except ValueError as exc:
+            raise BackendProviderCannotRemoveAttempt(
+                f'Provider returned an undecodable response to attempt removal: {response.content!r}'
+            ) from exc
+        if data.get('status', None) != 'deleted':
+            raise BackendProviderCannotRemoveAttempt(
+                f'Provider did not confirm attempt removal (expected status "deleted"): {data!r}'
+            )
+        return True
 
     def mark_erroneous_exam_attempt(self, exam, attempt):
         """

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -19,7 +19,6 @@ from django.conf import settings
 from edx_proctoring.backends.backend import ProctoringBackendProvider
 from edx_proctoring.exceptions import (
     BackendProviderCannotRegisterAttempt,
-    BackendProviderCannotRemoveAttempt,
     BackendProviderCannotRetireUser,
     BackendProviderOnboardingException,
     BackendProviderOnboardingProfilesException,
@@ -233,11 +232,12 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         """
         Removes the exam attempt on the backend provider's server.
 
-        A 404 is treated as success (the attempt is already gone upstream), so retrying a
-        partially-failed reset converges instead of failing forever. Success is otherwise
-        reserved for the documented ``{"status": "deleted"}`` payload; any other HTTP error,
-        an undecodable body, or a 2xx that does not confirm deletion is raised so the caller
-        keeps the local attempt for a later retry rather than silently dropping it.
+        Returns ``True`` when the provider confirms removal with the documented
+        ``{"status": "deleted"}`` payload, or on a ``404`` (the attempt is already gone
+        upstream, so a retried reset converges). Returns ``False`` when the provider responds
+        but does not confirm deletion (undecodable body or an unexpected status); the API
+        layer decides whether that is fatal. Any other HTTP error is raised so a transient
+        failure keeps the local attempt available for a later retry.
         """
         if not attempt:
             return False
@@ -249,15 +249,10 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         response.raise_for_status()
         try:
             data = response.json()
-        except ValueError as exc:
-            raise BackendProviderCannotRemoveAttempt(
-                f'Provider returned an undecodable response to attempt removal: {response.content!r}'
-            ) from exc
-        if data.get('status', None) != 'deleted':
-            raise BackendProviderCannotRemoveAttempt(
-                f'Provider did not confirm attempt removal (expected status "deleted"): {data!r}'
-            )
-        return True
+        except ValueError:
+            log.exception('Decoding attempt removal %r -> %r', attempt, response.content)
+            return False
+        return data.get('status', None) == 'deleted'
 
     def mark_erroneous_exam_attempt(self, exam, attempt):
         """

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -43,6 +43,8 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
     passing_statuses = (SoftwareSecureReviewStatus.clean,)
     # Timeout (in seconds) applied to every outbound request to the provider so
     # that a slow or unavailable provider cannot hang the request indefinitely.
+    # Operators can override this per backend via a ``timeout`` key in the
+    # backend's ``PROCTORING_BACKENDS`` configuration.
     timeout = 30
 
     @property

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -19,6 +19,7 @@ from django.conf import settings
 from edx_proctoring.backends.backend import ProctoringBackendProvider
 from edx_proctoring.exceptions import (
     BackendProviderCannotRegisterAttempt,
+    BackendProviderCannotRemoveAttempt,
     BackendProviderCannotRetireUser,
     BackendProviderOnboardingException,
     BackendProviderOnboardingProfilesException,
@@ -46,6 +47,10 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
     # Operators can override this per backend via a ``timeout`` key in the
     # backend's ``PROCTORING_BACKENDS`` configuration.
     timeout = 30
+    # Whether a provider HTTP error while removing an attempt should raise a descriptive
+    # error (so it is surfaced to the instructor) rather than being logged and ignored.
+    # Overridable per backend via a ``raise_on_remove_error`` key in ``PROCTORING_BACKENDS``.
+    raise_on_remove_error = True
 
     @property
     def exam_attempt_url(self):
@@ -232,12 +237,18 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
 
     def remove_exam_attempt(self, exam, attempt):
         """
-        Removes the exam attempt on the backend provider's server
+        Removes the exam attempt on the backend provider's server.
+
+        Raises BackendProviderCannotRemoveAttempt if the provider responds with an
+        HTTP error status (unless ``raise_on_remove_error`` is disabled for this backend),
+        so the caller can surface a descriptive error instead of silently leaving the
+        attempt on the provider's side.
         """
         response = self._make_attempt_request(
             exam,
             attempt,
-            method='DELETE')
+            method='DELETE',
+            raise_on_error=self.raise_on_remove_error)
         return response.get('status', None) == 'deleted'
 
     def mark_erroneous_exam_attempt(self, exam, attempt):
@@ -374,9 +385,14 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
             lang_header = f'{current_lang};{default_lang}'
         return {'Accept-Language': lang_header}
 
-    def _make_attempt_request(self, exam, attempt, method='POST', status=None, **payload):
+    def _make_attempt_request(self, exam, attempt, method='POST', status=None, raise_on_error=False, **payload):
         """
-        Calls backend attempt API
+        Calls backend attempt API.
+
+        When ``raise_on_error`` is True, a provider HTTP error response (status >= 400)
+        raises BackendProviderCannotRemoveAttempt, surfacing the provider's own message
+        when it supplies one and a generic message otherwise. This is distinct from the
+        provider being unreachable/timing out, where ``session.request`` itself raises.
         """
         if not attempt:
             return {}
@@ -395,4 +411,17 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         except ValueError:
             log.exception("Decoding attempt %r -> %r", attempt, response.content)
             data = {}
+        if raise_on_error and not response.ok:
+            # Log the raw provider response (status + body) for support/debugging; the
+            # provider's error schema is not standardised, so we do not try to parse a
+            # message out of it and instead surface a clean, provider-status-aware error.
+            log.error(
+                'Proctoring provider returned HTTP %s while removing attempt %r: %r',
+                response.status_code, attempt, response.content,
+            )
+            raise BackendProviderCannotRemoveAttempt(
+                'The proctoring provider could not remove this attempt '
+                f'(provider returned HTTP {response.status_code}). '
+                'Please try again or contact support.'
+            )
         return data

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -346,6 +346,7 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
 
     def retire_user(self, user_id):
         url = self.user_info_url.format(user_id=user_id)
+        response = None
         try:
             response = self.session.delete(url, timeout=self.timeout)
             data = response.json()
@@ -354,8 +355,12 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
             # pylint: disable=no-member
             if hasattr(exc, 'response') and exc.response is not None:
                 content = exc.response.content
-            else:
+            elif response is not None:
                 content = response.content
+            else:
+                # The request failed before a response was received (e.g. a timeout), so
+                # there is no body to include.
+                content = None
             raise BackendProviderCannotRetireUser(content) from exc
         return data
 

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -151,7 +151,7 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         """
         url = self.config_url
         log.debug('Requesting config from %r', url)
-        response = self.session.get(url, headers=self._get_language_headers()).json()
+        response = self.session.get(url, headers=self._get_language_headers(), timeout=self.timeout).json()
         return response
 
     def get_exam(self, exam):
@@ -160,7 +160,7 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         """
         url = self.exam_url.format(exam_id=exam['id'])
         log.debug('Requesting exam from %r', url)
-        response = self.session.get(url).json()
+        response = self.session.get(url, timeout=self.timeout).json()
         return response
 
     def get_attempt(self, attempt):
@@ -190,7 +190,7 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
             'Creating exam attempt for exam_id=%(exam_id)i (external_id=%(external_id)s) at %(url)s',
             {'exam_id': exam['id'], 'external_id': exam['external_id'], 'url': url}
         )
-        response = self.session.post(url, json=payload)
+        response = self.session.post(url, json=payload, timeout=self.timeout)
         if response.status_code != 200:
             raise BackendProviderCannotRegisterAttempt(response.content, response.status_code)
         status_code = response.status_code
@@ -230,13 +230,27 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
 
     def remove_exam_attempt(self, exam, attempt):
         """
-        Removes the exam attempt on the backend provider's server
+        Removes the exam attempt on the backend provider's server.
+
+        A 404 is treated as success (the attempt is already gone upstream), so retrying a
+        partially-failed reset converges instead of failing forever. Any other HTTP error is
+        raised so the caller keeps the local attempt for a later retry rather than silently
+        losing it by treating the error as an "already removed" response.
         """
-        response = self._make_attempt_request(
-            exam,
-            attempt,
-            method='DELETE')
-        return response.get('status', None) == 'deleted'
+        if not attempt:
+            return False
+        url = self.exam_attempt_url.format(exam_id=exam, attempt_id=attempt)
+        log.debug('Removing attempt at %r', url)
+        response = self.session.request('DELETE', url, timeout=self.timeout)
+        if response.status_code == 404:
+            return True
+        response.raise_for_status()
+        try:
+            data = response.json()
+        except ValueError:
+            log.exception('Decoding attempt removal %r -> %r', attempt, response.content)
+            data = {}
+        return data.get('status', None) == 'deleted'
 
     def mark_erroneous_exam_attempt(self, exam, attempt):
         """
@@ -275,7 +289,7 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         )
         response = None
         try:
-            response = self.session.post(url, json=exam)
+            response = self.session.post(url, json=exam, timeout=self.timeout)
             data = response.json()
         except Exception as exc:  # pylint: disable=broad-exception-caught
             if response:
@@ -331,7 +345,7 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
     def retire_user(self, user_id):
         url = self.user_info_url.format(user_id=user_id)
         try:
-            response = self.session.delete(url)
+            response = self.session.delete(url, timeout=self.timeout)
             data = response.json()
             assert data in (True, False)
         except Exception as exc:
@@ -349,7 +363,7 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
             query_string = urlencode(kwargs)
             url += '?' + query_string
 
-        response = self.session.get(url)
+        response = self.session.get(url, timeout=self.timeout)
 
         if response.status_code != 200:
             raise BackendProviderOnboardingProfilesException(response.content, response.status_code)

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -19,7 +19,6 @@ from django.conf import settings
 from edx_proctoring.backends.backend import ProctoringBackendProvider
 from edx_proctoring.exceptions import (
     BackendProviderCannotRegisterAttempt,
-    BackendProviderCannotRemoveAttempt,
     BackendProviderCannotRetireUser,
     BackendProviderOnboardingException,
     BackendProviderOnboardingProfilesException,
@@ -44,13 +43,7 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
     passing_statuses = (SoftwareSecureReviewStatus.clean,)
     # Timeout (in seconds) applied to every outbound request to the provider so
     # that a slow or unavailable provider cannot hang the request indefinitely.
-    # Operators can override this per backend via a ``timeout`` key in the
-    # backend's ``PROCTORING_BACKENDS`` configuration.
     timeout = 30
-    # Whether a provider HTTP error while removing an attempt should raise a descriptive
-    # error (so it is surfaced to the instructor) rather than being logged and ignored.
-    # Overridable per backend via a ``raise_on_remove_error`` key in ``PROCTORING_BACKENDS``.
-    raise_on_remove_error = True
 
     @property
     def exam_attempt_url(self):
@@ -237,18 +230,12 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
 
     def remove_exam_attempt(self, exam, attempt):
         """
-        Removes the exam attempt on the backend provider's server.
-
-        Raises BackendProviderCannotRemoveAttempt if the provider responds with an
-        HTTP error status (unless ``raise_on_remove_error`` is disabled for this backend),
-        so the caller can surface a descriptive error instead of silently leaving the
-        attempt on the provider's side.
+        Removes the exam attempt on the backend provider's server
         """
         response = self._make_attempt_request(
             exam,
             attempt,
-            method='DELETE',
-            raise_on_error=self.raise_on_remove_error)
+            method='DELETE')
         return response.get('status', None) == 'deleted'
 
     def mark_erroneous_exam_attempt(self, exam, attempt):
@@ -385,14 +372,9 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
             lang_header = f'{current_lang};{default_lang}'
         return {'Accept-Language': lang_header}
 
-    def _make_attempt_request(self, exam, attempt, method='POST', status=None, raise_on_error=False, **payload):
+    def _make_attempt_request(self, exam, attempt, method='POST', status=None, **payload):
         """
-        Calls backend attempt API.
-
-        When ``raise_on_error`` is True, a provider HTTP error response (status >= 400)
-        raises BackendProviderCannotRemoveAttempt, surfacing the provider's own message
-        when it supplies one and a generic message otherwise. This is distinct from the
-        provider being unreachable/timing out, where ``session.request`` itself raises.
+        Calls backend attempt API
         """
         if not attempt:
             return {}
@@ -411,17 +393,4 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         except ValueError:
             log.exception("Decoding attempt %r -> %r", attempt, response.content)
             data = {}
-        if raise_on_error and not response.ok:
-            # Log the raw provider response (status + body) for support/debugging; the
-            # provider's error schema is not standardised, so we do not try to parse a
-            # message out of it and instead surface a clean, provider-status-aware error.
-            log.error(
-                'Proctoring provider returned HTTP %s while removing attempt %r: %r',
-                response.status_code, attempt, response.content,
-            )
-            raise BackendProviderCannotRemoveAttempt(
-                'The proctoring provider could not remove this attempt '
-                f'(provider returned HTTP {response.status_code}). '
-                'Please try again or contact support.'
-            )
         return data

--- a/edx_proctoring/backends/software_secure.py
+++ b/edx_proctoring/backends/software_secure.py
@@ -117,7 +117,10 @@ class SoftwareSecureBackendProvider(ProctoringBackendProvider):
         return None
 
     def remove_exam_attempt(self, exam, attempt):
-        return None
+        # This backend does not track attempts on its own server, so there is nothing to
+        # remove upstream. Return an explicit success so callers do not mistake the no-op
+        # for a failed (unconfirmed) removal.
+        return True
 
     def get_software_download_url(self):
         """

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -277,6 +277,28 @@ class RESTBackendTests(TestCase):
         status = self.provider.remove_exam_attempt(self.backend_exam['external_id'], None)
         self.assertFalse(status)
 
+    def test_make_attempt_request_passes_timeout(self):
+        """
+        Every outbound attempt request must include an explicit timeout so that a
+        slow/unavailable provider cannot hang the request indefinitely.
+        """
+        attempt_id = 2
+        with patch.object(self.provider.session, 'request') as request_mock:
+            request_mock.return_value.json.return_value = {'status': 'deleted'}
+            self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id)
+        _, kwargs = request_mock.call_args
+        self.assertEqual(kwargs['timeout'], self.provider.timeout)
+
+    def test_remove_attempt_provider_unavailable(self):
+        """
+        A provider connection error must propagate out of the backend rather than
+        being swallowed, so the caller can surface a descriptive error.
+        """
+        attempt_id = 2
+        with patch.object(self.provider.session, 'request', side_effect=ConnectionError('boom')):
+            with self.assertRaises(ConnectionError):
+                self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id)
+
     def test_on_review_callback(self):
         """
         on_review_callback should just return the payload

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -518,6 +518,15 @@ class RESTBackendTests(TestCase):
         with self.assertRaises(BackendProviderCannotRetireUser):
             self.provider.retire_user(user_id)
 
+    def test_retire_user_provider_unavailable(self):
+        """
+        If the request fails before a response is received (e.g. a timeout), retire_user
+        still raises BackendProviderCannotRetireUser rather than an UnboundLocalError.
+        """
+        with patch.object(self.provider.session, 'delete', side_effect=ConnectionError('boom')):
+            with self.assertRaises(BackendProviderCannotRetireUser):
+                self.provider.retire_user('abcdef6')
+
     @responses.activate
     def test_get_onboarding_profile_for_user(self):
         user_id = 'abcdef5'

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -12,11 +12,9 @@ import responses
 from django.test import TestCase, override_settings
 from django.utils import translation
 
-from edx_proctoring.apps import BACKEND_CONFIGURATION_ALLOW_LIST
 from edx_proctoring.backends.rest import BaseRestProctoringProvider
 from edx_proctoring.exceptions import (
     BackendProviderCannotRegisterAttempt,
-    BackendProviderCannotRemoveAttempt,
     BackendProviderCannotRetireUser,
     BackendProviderOnboardingException,
     BackendProviderOnboardingProfilesException,
@@ -291,20 +289,6 @@ class RESTBackendTests(TestCase):
         _, kwargs = request_mock.call_args
         self.assertEqual(kwargs['timeout'], self.provider.timeout)
 
-    def test_default_timeout(self):
-        """The backend applies a sane default request timeout when none is configured."""
-        self.assertEqual(self.provider.timeout, 30)
-
-    def test_timeout_is_configurable(self):
-        """
-        Operators can override the request timeout per backend. The value arrives as a
-        constructor kwarg sourced from the backend's PROCTORING_BACKENDS configuration,
-        so the key must also be present in the backend configuration allow list.
-        """
-        provider = BaseRestProctoringProvider('client_id', 'client_secret', timeout=60)
-        self.assertEqual(provider.timeout, 60)
-        self.assertIn('timeout', BACKEND_CONFIGURATION_ALLOW_LIST)
-
     def test_remove_attempt_provider_unavailable(self):
         """
         A provider connection error must propagate out of the backend rather than
@@ -314,68 +298,6 @@ class RESTBackendTests(TestCase):
         with patch.object(self.provider.session, 'request', side_effect=ConnectionError('boom')):
             with self.assertRaises(ConnectionError):
                 self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id)
-
-    @responses.activate
-    def test_remove_attempt_provider_error_raises_with_status(self):
-        """
-        A provider HTTP error response (>= 400) raises BackendProviderCannotRemoveAttempt
-        with a clean, provider-status-aware message and an instructor-facing 502.
-        """
-        attempt_id = 2
-        responses.add(
-            responses.DELETE,
-            url=self.provider.exam_attempt_url.format(exam_id=self.backend_exam['external_id'], attempt_id=attempt_id),
-            json={'detail': 'Attempt is locked'},
-            status=400,
-        )
-        with self.assertRaises(BackendProviderCannotRemoveAttempt) as ctx:
-            self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id)
-        self.assertIn('HTTP 400', str(ctx.exception))
-        self.assertIn('could not remove this attempt', str(ctx.exception))
-        self.assertEqual(ctx.exception.http_status, 502)
-
-    @responses.activate
-    def test_remove_attempt_provider_error_no_body(self):
-        """
-        A provider HTTP error with no response body still raises with the clean
-        provider-status-aware message.
-        """
-        attempt_id = 2
-        responses.add(
-            responses.DELETE,
-            url=self.provider.exam_attempt_url.format(exam_id=self.backend_exam['external_id'], attempt_id=attempt_id),
-            status=502,
-        )
-        with self.assertRaises(BackendProviderCannotRemoveAttempt) as ctx:
-            self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id)
-        self.assertIn('HTTP 502', str(ctx.exception))
-        self.assertEqual(ctx.exception.http_status, 502)
-
-    def test_raise_on_remove_error_default_and_configurable(self):
-        """
-        The raise-on-remove-error behaviour defaults to True and is overridable per
-        backend via PROCTORING_BACKENDS, so the key must be in the allow list.
-        """
-        self.assertTrue(self.provider.raise_on_remove_error)
-        self.assertIn('raise_on_remove_error', BACKEND_CONFIGURATION_ALLOW_LIST)
-        provider = BaseRestProctoringProvider('client_id', 'client_secret', raise_on_remove_error=False)
-        self.assertFalse(provider.raise_on_remove_error)
-
-    @responses.activate
-    def test_remove_attempt_provider_error_not_raised_when_disabled(self):
-        """
-        When raise_on_remove_error is disabled for a backend, a provider HTTP error is
-        not raised; removal returns False (the pre-existing log-and-continue behaviour).
-        """
-        self.provider.raise_on_remove_error = False
-        attempt_id = 2
-        responses.add(
-            responses.DELETE,
-            url=self.provider.exam_attempt_url.format(exam_id=self.backend_exam['external_id'], attempt_id=attempt_id),
-            status=502,
-        )
-        status = self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id)
-        self.assertFalse(status)
 
     def test_on_review_callback(self):
         """

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -278,6 +278,13 @@ class RESTBackendTests(TestCase):
         status = self.provider.remove_exam_attempt(self.backend_exam['external_id'], None)
         self.assertFalse(status)
 
+    def test_make_attempt_request_no_attempt(self):
+        """
+        An attempt request with no attempt id short-circuits to an empty response instead
+        of calling the provider, so the caller treats it as a no-op.
+        """
+        self.assertIsNone(self.provider.mark_erroneous_exam_attempt(self.backend_exam['external_id'], None))
+
     def test_make_attempt_request_passes_timeout(self):
         """
         Every outbound attempt request must include an explicit timeout so that a

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -12,6 +12,7 @@ import responses
 from django.test import TestCase, override_settings
 from django.utils import translation
 
+from edx_proctoring.apps import BACKEND_CONFIGURATION_ALLOW_LIST
 from edx_proctoring.backends.rest import BaseRestProctoringProvider
 from edx_proctoring.exceptions import (
     BackendProviderCannotRegisterAttempt,
@@ -288,6 +289,20 @@ class RESTBackendTests(TestCase):
             self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id)
         _, kwargs = request_mock.call_args
         self.assertEqual(kwargs['timeout'], self.provider.timeout)
+
+    def test_default_timeout(self):
+        """The backend applies a sane default request timeout when none is configured."""
+        self.assertEqual(self.provider.timeout, 30)
+
+    def test_timeout_is_configurable(self):
+        """
+        Operators can override the request timeout per backend. The value arrives as a
+        constructor kwarg sourced from the backend's PROCTORING_BACKENDS configuration,
+        so the key must also be present in the backend configuration allow list.
+        """
+        provider = BaseRestProctoringProvider('client_id', 'client_secret', timeout=60)
+        self.assertEqual(provider.timeout, 60)
+        self.assertIn('timeout', BACKEND_CONFIGURATION_ALLOW_LIST)
 
     def test_remove_attempt_provider_unavailable(self):
         """

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -16,6 +16,7 @@ from edx_proctoring.apps import BACKEND_CONFIGURATION_ALLOW_LIST
 from edx_proctoring.backends.rest import BaseRestProctoringProvider
 from edx_proctoring.exceptions import (
     BackendProviderCannotRegisterAttempt,
+    BackendProviderCannotRemoveAttempt,
     BackendProviderCannotRetireUser,
     BackendProviderOnboardingException,
     BackendProviderOnboardingProfilesException,
@@ -313,6 +314,68 @@ class RESTBackendTests(TestCase):
         with patch.object(self.provider.session, 'request', side_effect=ConnectionError('boom')):
             with self.assertRaises(ConnectionError):
                 self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id)
+
+    @responses.activate
+    def test_remove_attempt_provider_error_raises_with_status(self):
+        """
+        A provider HTTP error response (>= 400) raises BackendProviderCannotRemoveAttempt
+        with a clean, provider-status-aware message and an instructor-facing 502.
+        """
+        attempt_id = 2
+        responses.add(
+            responses.DELETE,
+            url=self.provider.exam_attempt_url.format(exam_id=self.backend_exam['external_id'], attempt_id=attempt_id),
+            json={'detail': 'Attempt is locked'},
+            status=400,
+        )
+        with self.assertRaises(BackendProviderCannotRemoveAttempt) as ctx:
+            self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id)
+        self.assertIn('HTTP 400', str(ctx.exception))
+        self.assertIn('could not remove this attempt', str(ctx.exception))
+        self.assertEqual(ctx.exception.http_status, 502)
+
+    @responses.activate
+    def test_remove_attempt_provider_error_no_body(self):
+        """
+        A provider HTTP error with no response body still raises with the clean
+        provider-status-aware message.
+        """
+        attempt_id = 2
+        responses.add(
+            responses.DELETE,
+            url=self.provider.exam_attempt_url.format(exam_id=self.backend_exam['external_id'], attempt_id=attempt_id),
+            status=502,
+        )
+        with self.assertRaises(BackendProviderCannotRemoveAttempt) as ctx:
+            self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id)
+        self.assertIn('HTTP 502', str(ctx.exception))
+        self.assertEqual(ctx.exception.http_status, 502)
+
+    def test_raise_on_remove_error_default_and_configurable(self):
+        """
+        The raise-on-remove-error behaviour defaults to True and is overridable per
+        backend via PROCTORING_BACKENDS, so the key must be in the allow list.
+        """
+        self.assertTrue(self.provider.raise_on_remove_error)
+        self.assertIn('raise_on_remove_error', BACKEND_CONFIGURATION_ALLOW_LIST)
+        provider = BaseRestProctoringProvider('client_id', 'client_secret', raise_on_remove_error=False)
+        self.assertFalse(provider.raise_on_remove_error)
+
+    @responses.activate
+    def test_remove_attempt_provider_error_not_raised_when_disabled(self):
+        """
+        When raise_on_remove_error is disabled for a backend, a provider HTTP error is
+        not raised; removal returns False (the pre-existing log-and-continue behaviour).
+        """
+        self.provider.raise_on_remove_error = False
+        attempt_id = 2
+        responses.add(
+            responses.DELETE,
+            url=self.provider.exam_attempt_url.format(exam_id=self.backend_exam['external_id'], attempt_id=attempt_id),
+            status=502,
+        )
+        status = self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id)
+        self.assertFalse(status)
 
     def test_on_review_callback(self):
         """

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -16,6 +16,7 @@ from django.utils import translation
 from edx_proctoring.backends.rest import BaseRestProctoringProvider
 from edx_proctoring.exceptions import (
     BackendProviderCannotRegisterAttempt,
+    BackendProviderCannotRemoveAttempt,
     BackendProviderCannotRetireUser,
     BackendProviderOnboardingException,
     BackendProviderOnboardingProfilesException,
@@ -337,10 +338,10 @@ class RESTBackendTests(TestCase):
             self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id)
 
     @responses.activate
-    def test_remove_attempt_malformed_json(self):
+    def test_remove_attempt_malformed_json_raises(self):
         """
-        A 2xx response with an undecodable body is reported as 'not confirmed deleted'
-        rather than raising; the API layer then converges on a later retry.
+        A 2xx response with an undecodable body is not a valid confirmation, so it raises
+        rather than silently reporting the attempt as removed.
         """
         attempt_id = 5
         responses.add(
@@ -348,7 +349,23 @@ class RESTBackendTests(TestCase):
             url=self.provider.exam_attempt_url.format(exam_id=self.backend_exam['external_id'], attempt_id=attempt_id),
             body='"]'
         )
-        self.assertFalse(self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id))
+        with self.assertRaises(BackendProviderCannotRemoveAttempt):
+            self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id)
+
+    @responses.activate
+    def test_remove_attempt_unconfirmed_raises(self):
+        """
+        A 2xx response that does not carry the documented {"status": "deleted"} payload is
+        not a confirmation, so it raises to keep the local attempt for a later retry.
+        """
+        attempt_id = 6
+        responses.add(
+            responses.DELETE,
+            url=self.provider.exam_attempt_url.format(exam_id=self.backend_exam['external_id'], attempt_id=attempt_id),
+            json={'status': 'pending'}
+        )
+        with self.assertRaises(BackendProviderCannotRemoveAttempt):
+            self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id)
 
     def test_on_review_callback(self):
         """

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import ddt
 import jwt
 import responses
+from requests.exceptions import HTTPError
 
 from django.test import TestCase, override_settings
 from django.utils import translation
@@ -298,6 +299,49 @@ class RESTBackendTests(TestCase):
         with patch.object(self.provider.session, 'request', side_effect=ConnectionError('boom')):
             with self.assertRaises(ConnectionError):
                 self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id)
+
+    @responses.activate
+    def test_remove_attempt_not_found_is_idempotent(self):
+        """
+        A 404 from the provider means the attempt is already gone upstream, which the
+        backend reports as success so a retried, partially-failed reset converges.
+        """
+        attempt_id = 3
+        responses.add(
+            responses.DELETE,
+            url=self.provider.exam_attempt_url.format(exam_id=self.backend_exam['external_id'], attempt_id=attempt_id),
+            status=404
+        )
+        self.assertTrue(self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id))
+
+    @responses.activate
+    def test_remove_attempt_http_error_raises(self):
+        """
+        A non-404 HTTP error must raise rather than be treated as an already-removed
+        attempt, so the caller keeps the local attempt for a later retry.
+        """
+        attempt_id = 4
+        responses.add(
+            responses.DELETE,
+            url=self.provider.exam_attempt_url.format(exam_id=self.backend_exam['external_id'], attempt_id=attempt_id),
+            status=500
+        )
+        with self.assertRaises(HTTPError):
+            self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id)
+
+    @responses.activate
+    def test_remove_attempt_malformed_json(self):
+        """
+        A 2xx response with an undecodable body is reported as 'not confirmed deleted'
+        rather than raising; the API layer then converges on a later retry.
+        """
+        attempt_id = 5
+        responses.add(
+            responses.DELETE,
+            url=self.provider.exam_attempt_url.format(exam_id=self.backend_exam['external_id'], attempt_id=attempt_id),
+            body='"]'
+        )
+        self.assertFalse(self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id))
 
     def test_on_review_callback(self):
         """

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -16,7 +16,6 @@ from django.utils import translation
 from edx_proctoring.backends.rest import BaseRestProctoringProvider
 from edx_proctoring.exceptions import (
     BackendProviderCannotRegisterAttempt,
-    BackendProviderCannotRemoveAttempt,
     BackendProviderCannotRetireUser,
     BackendProviderOnboardingException,
     BackendProviderOnboardingProfilesException,
@@ -338,10 +337,10 @@ class RESTBackendTests(TestCase):
             self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id)
 
     @responses.activate
-    def test_remove_attempt_malformed_json_raises(self):
+    def test_remove_attempt_malformed_json_not_confirmed(self):
         """
-        A 2xx response with an undecodable body is not a valid confirmation, so it raises
-        rather than silently reporting the attempt as removed.
+        A 2xx response with an undecodable body is not a valid confirmation, so it reports
+        False (the API layer keeps the local attempt for strict callers).
         """
         attempt_id = 5
         responses.add(
@@ -349,14 +348,13 @@ class RESTBackendTests(TestCase):
             url=self.provider.exam_attempt_url.format(exam_id=self.backend_exam['external_id'], attempt_id=attempt_id),
             body='"]'
         )
-        with self.assertRaises(BackendProviderCannotRemoveAttempt):
-            self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id)
+        self.assertFalse(self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id))
 
     @responses.activate
-    def test_remove_attempt_unconfirmed_raises(self):
+    def test_remove_attempt_unconfirmed_status(self):
         """
         A 2xx response that does not carry the documented {"status": "deleted"} payload is
-        not a confirmation, so it raises to keep the local attempt for a later retry.
+        not a confirmation, so it reports False rather than a successful removal.
         """
         attempt_id = 6
         responses.add(
@@ -364,8 +362,22 @@ class RESTBackendTests(TestCase):
             url=self.provider.exam_attempt_url.format(exam_id=self.backend_exam['external_id'], attempt_id=attempt_id),
             json={'status': 'pending'}
         )
-        with self.assertRaises(BackendProviderCannotRemoveAttempt):
-            self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id)
+        self.assertFalse(self.provider.remove_exam_attempt(self.backend_exam['external_id'], attempt_id))
+
+    def test_default_request_timeout(self):
+        """The REST backend applies a 30-second request timeout by default."""
+        self.assertEqual(self.provider.timeout, 30)
+
+    def test_configurable_request_timeout(self):
+        """A ``timeout`` in the backend configuration overrides the default and is sent on requests."""
+        provider = BaseRestProctoringProvider('client_id', 'client_secret', timeout=5)
+        self.assertEqual(provider.timeout, 5)
+        with patch.object(provider.session, 'request') as request_mock:
+            request_mock.return_value.status_code = 200
+            request_mock.return_value.json.return_value = {'status': 'deleted'}
+            provider.remove_exam_attempt(self.backend_exam['external_id'], 7)
+        _, kwargs = request_mock.call_args
+        self.assertEqual(kwargs['timeout'], 5)
 
     def test_on_review_callback(self):
         """

--- a/edx_proctoring/exceptions.py
+++ b/edx_proctoring/exceptions.py
@@ -95,6 +95,15 @@ class BackendProviderSentNoAttemptID(BackendProviderCannotRegisterAttempt):
     """
 
 
+class BackendProviderCannotRemoveAttempt(ProctoredBaseException):
+    """
+    Raised when a back-end provider cannot remove an attempt, e.g. because the
+    provider is slow, unreachable, or returned an error while trying to delete
+    the attempt on their side.
+    """
+    http_status = status.HTTP_502_BAD_GATEWAY
+
+
 class BackendProviderOnboardingException(ProctoredBaseException):
     """
     Raised when a back-end provider cannot register an attempt

--- a/edx_proctoring/handlers.py
+++ b/edx_proctoring/handlers.py
@@ -7,7 +7,6 @@ from django.dispatch import receiver
 
 from edx_proctoring import api, constants, models
 from edx_proctoring.backends import get_backend_provider
-from edx_proctoring.exceptions import BackendProviderCannotRemoveAttempt
 from edx_proctoring.runtime import get_runtime_service
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus, SoftwareSecureReviewStatus
 from edx_proctoring.utils import emit_event, locate_attempt_by_attempt_code
@@ -100,12 +99,16 @@ def on_allowance_changed(sender, instance, signal, **kwargs):
 
 
 @receiver(pre_save, sender=models.ProctoredExamStudentAttempt)
-@receiver(pre_delete, sender=models.ProctoredExamStudentAttempt)
 def on_attempt_changed(sender, instance, signal, **kwargs):
     """
     Archive the exam attempt whenever the attempt status is about to be
     modified. Make a new entry with the previous value of the status in the
     ProctoredExamStudentAttemptHistory table.
+
+    Note: the proctoring provider is no longer notified from this signal on delete.
+    ``api.remove_exam_attempt`` calls the backend *before* the local delete so that a
+    provider outage does not roll back a half-applied delete (raising from a pre_delete
+    signal marks the DB connection needs-rollback).
     """
 
     if signal is pre_save:
@@ -133,52 +136,6 @@ def on_attempt_changed(sender, instance, signal, **kwargs):
                 return
         else:
             return
-    else:
-        # remove the attempt on the backend
-        # timed exams have no backend
-        if instance.proctored_exam.is_proctored:
-            backend = get_backend_provider(name=instance.proctored_exam.backend)
-            if backend:
-                log_context = {
-                    'attempt_id': instance.id,
-                    'external_id': instance.external_id,
-                    'exam_id': instance.proctored_exam.id,
-                    'user_id': instance.user_id,
-                    'backend': instance.proctored_exam.backend,
-                }
-                log_message = (
-                    'Failed to remove attempt_id=%(attempt_id)s (external_id=%(external_id)s) for '
-                    'exam_id=%(exam_id)s user_id=%(user_id)s from backend=%(backend)s due to a '
-                    'provider error.'
-                )
-                try:
-                    result = backend.remove_exam_attempt(
-                        instance.proctored_exam.external_id, instance.external_id
-                    )
-                except BackendProviderCannotRemoveAttempt:
-                    # The provider responded with an HTTP error and the backend already built a
-                    # descriptive (possibly provider-supplied) message. Log and re-raise it as-is
-                    # so that message reaches the instructor-facing MFE unchanged.
-                    log.exception(log_message, log_context)
-                    raise
-                except Exception as exc:  # pylint: disable=broad-exception-caught
-                    # The provider is slow/unavailable (connection error or timeout). This must not
-                    # surface as an unhandled 500 or silently leave the attempt half-removed. Log
-                    # with enough context for monitoring/Sentry and re-raise a typed exception so the
-                    # instructor-facing MFE receives a descriptive ``detail`` message.
-                    log.exception(log_message, log_context)
-                    raise BackendProviderCannotRemoveAttempt(
-                        # Translators: shown to an instructor when an exam attempt could not be reset
-                        # because the external proctoring provider is temporarily unavailable.
-                        'The proctoring provider is temporarily unavailable, so this attempt could not '
-                        'be fully reset. Please try again in a few minutes.'
-                    ) from exc
-                if not result:
-                    log.error(
-                        'Failed to remove attempt_id=%s from backend=%s',
-                        instance.id,
-                        instance.proctored_exam.backend,
-                    )
 
 
 @receiver(post_delete, sender=models.ProctoredExamStudentAttempt)

--- a/edx_proctoring/handlers.py
+++ b/edx_proctoring/handlers.py
@@ -139,27 +139,34 @@ def on_attempt_changed(sender, instance, signal, **kwargs):
         if instance.proctored_exam.is_proctored:
             backend = get_backend_provider(name=instance.proctored_exam.backend)
             if backend:
+                log_context = {
+                    'attempt_id': instance.id,
+                    'external_id': instance.external_id,
+                    'exam_id': instance.proctored_exam.id,
+                    'user_id': instance.user_id,
+                    'backend': instance.proctored_exam.backend,
+                }
+                log_message = (
+                    'Failed to remove attempt_id=%(attempt_id)s (external_id=%(external_id)s) for '
+                    'exam_id=%(exam_id)s user_id=%(user_id)s from backend=%(backend)s due to a '
+                    'provider error.'
+                )
                 try:
                     result = backend.remove_exam_attempt(
                         instance.proctored_exam.external_id, instance.external_id
                     )
+                except BackendProviderCannotRemoveAttempt:
+                    # The provider responded with an HTTP error and the backend already built a
+                    # descriptive (possibly provider-supplied) message. Log and re-raise it as-is
+                    # so that message reaches the instructor-facing MFE unchanged.
+                    log.exception(log_message, log_context)
+                    raise
                 except Exception as exc:  # pylint: disable=broad-exception-caught
-                    # A slow or unavailable provider must not surface as an unhandled 500,
-                    # and must not silently leave the attempt half-removed. Log with enough
-                    # context for monitoring/Sentry and re-raise a typed exception so the
+                    # The provider is slow/unavailable (connection error or timeout). This must not
+                    # surface as an unhandled 500 or silently leave the attempt half-removed. Log
+                    # with enough context for monitoring/Sentry and re-raise a typed exception so the
                     # instructor-facing MFE receives a descriptive ``detail`` message.
-                    log.exception(
-                        'Failed to remove attempt_id=%(attempt_id)s (external_id=%(external_id)s) for '
-                        'exam_id=%(exam_id)s user_id=%(user_id)s from backend=%(backend)s due to a '
-                        'provider error.',
-                        {
-                            'attempt_id': instance.id,
-                            'external_id': instance.external_id,
-                            'exam_id': instance.proctored_exam.id,
-                            'user_id': instance.user_id,
-                            'backend': instance.proctored_exam.backend,
-                        }
-                    )
+                    log.exception(log_message, log_context)
                     raise BackendProviderCannotRemoveAttempt(
                         # Translators: shown to an instructor when an exam attempt could not be reset
                         # because the external proctoring provider is temporarily unavailable.

--- a/edx_proctoring/handlers.py
+++ b/edx_proctoring/handlers.py
@@ -7,6 +7,7 @@ from django.dispatch import receiver
 
 from edx_proctoring import api, constants, models
 from edx_proctoring.backends import get_backend_provider
+from edx_proctoring.exceptions import BackendProviderCannotRemoveAttempt
 from edx_proctoring.runtime import get_runtime_service
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus, SoftwareSecureReviewStatus
 from edx_proctoring.utils import emit_event, locate_attempt_by_attempt_code
@@ -138,7 +139,33 @@ def on_attempt_changed(sender, instance, signal, **kwargs):
         if instance.proctored_exam.is_proctored:
             backend = get_backend_provider(name=instance.proctored_exam.backend)
             if backend:
-                result = backend.remove_exam_attempt(instance.proctored_exam.external_id, instance.external_id)
+                try:
+                    result = backend.remove_exam_attempt(
+                        instance.proctored_exam.external_id, instance.external_id
+                    )
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    # A slow or unavailable provider must not surface as an unhandled 500,
+                    # and must not silently leave the attempt half-removed. Log with enough
+                    # context for monitoring/Sentry and re-raise a typed exception so the
+                    # instructor-facing MFE receives a descriptive ``detail`` message.
+                    log.exception(
+                        'Failed to remove attempt_id=%(attempt_id)s (external_id=%(external_id)s) for '
+                        'exam_id=%(exam_id)s user_id=%(user_id)s from backend=%(backend)s due to a '
+                        'provider error.',
+                        {
+                            'attempt_id': instance.id,
+                            'external_id': instance.external_id,
+                            'exam_id': instance.proctored_exam.id,
+                            'user_id': instance.user_id,
+                            'backend': instance.proctored_exam.backend,
+                        }
+                    )
+                    raise BackendProviderCannotRemoveAttempt(
+                        # Translators: shown to an instructor when an exam attempt could not be reset
+                        # because the external proctoring provider is temporarily unavailable.
+                        'The proctoring provider is temporarily unavailable, so this attempt could not '
+                        'be fully reset. Please try again in a few minutes.'
+                    ) from exc
                 if not result:
                     log.error(
                         'Failed to remove attempt_id=%s from backend=%s',

--- a/edx_proctoring/management/commands/reset_attempts.py
+++ b/edx_proctoring/management/commands/reset_attempts.py
@@ -8,6 +8,7 @@ import time
 
 from django.core.management.base import BaseCommand
 
+from edx_proctoring.api import _remove_exam_attempt_from_backend
 from edx_proctoring.models import ProctoredExamStudentAttempt
 
 log = logging.getLogger(__name__)
@@ -64,6 +65,14 @@ class Command(BaseCommand):
             delete_queryset = ProctoredExamStudentAttempt.objects.filter(
                 id__in=batch_to_delete
             )
+
+            # Notify the proctoring provider before deleting locally. This used to happen
+            # in a pre_delete signal, but provider removal now lives in the API layer, so
+            # this bulk path has to do it explicitly. It is best-effort cleanup, so a
+            # provider error must not stop the local deletion (raise_on_error=False).
+            for attempt in delete_queryset:
+                _remove_exam_attempt_from_backend(attempt, raise_on_error=False)
+
             deleted_count, _ = delete_queryset.delete()
 
             total_deleted += deleted_count

--- a/edx_proctoring/management/commands/reset_attempts.py
+++ b/edx_proctoring/management/commands/reset_attempts.py
@@ -8,8 +8,7 @@ import time
 
 from django.core.management.base import BaseCommand
 
-from edx_proctoring.api import _remove_exam_attempt_from_backend
-from edx_proctoring.exceptions import BackendProviderCannotRemoveAttempt
+from edx_proctoring.api import _remove_exam_attempts_from_backend
 from edx_proctoring.models import ProctoredExamStudentAttempt
 
 log = logging.getLogger(__name__)
@@ -59,10 +58,7 @@ class Command(BaseCommand):
             ids_to_delete = file.readlines()
 
         total_deleted = 0
-        # Backends that have already failed a provider-removal call during this run. Once a
-        # backend errors out (e.g. it is unreachable and each call pays the full request
-        # timeout), we stop calling it and just delete locally -- otherwise one unavailable
-        # provider could stall the command for timeout * (number of attempts) seconds.
+        # Shared across batches so a backend that fails once is skipped for the whole run.
         failed_backends = set()
 
         for i in range(0, len(ids_to_delete), batch_size):
@@ -72,22 +68,13 @@ class Command(BaseCommand):
                 id__in=batch_to_delete
             )
 
-            # Notify the proctoring provider before deleting locally. This used to happen
-            # in a pre_delete signal, but provider removal now lives in the API layer, so
-            # this bulk path has to do it explicitly. Local deletion below is unconditional,
-            # so provider cleanup stays best-effort.
-            for attempt in delete_queryset:
-                backend = attempt.proctored_exam.backend
-                if backend in failed_backends:
-                    continue
-                try:
-                    _remove_exam_attempt_from_backend(attempt)
-                except BackendProviderCannotRemoveAttempt:
-                    log.warning(
-                        'Provider removal failed for backend %r; skipping further provider '
-                        'calls for it during this run and deleting locally only.', backend
-                    )
-                    failed_backends.add(backend)
+            # Notify the proctoring provider before deleting locally. This used to happen in
+            # a pre_delete signal, but provider removal now lives in the API layer, so this
+            # bulk path has to do it explicitly. It is best-effort (the delete below is
+            # unconditional) and skips a failing backend for the rest of the run.
+            _remove_exam_attempts_from_backend(
+                delete_queryset.select_related('proctored_exam'), failed_backends
+            )
 
             deleted_count, _ = delete_queryset.delete()
 

--- a/edx_proctoring/management/commands/reset_attempts.py
+++ b/edx_proctoring/management/commands/reset_attempts.py
@@ -9,6 +9,7 @@ import time
 from django.core.management.base import BaseCommand
 
 from edx_proctoring.api import _remove_exam_attempt_from_backend
+from edx_proctoring.exceptions import BackendProviderCannotRemoveAttempt
 from edx_proctoring.models import ProctoredExamStudentAttempt
 
 log = logging.getLogger(__name__)
@@ -58,6 +59,11 @@ class Command(BaseCommand):
             ids_to_delete = file.readlines()
 
         total_deleted = 0
+        # Backends that have already failed a provider-removal call during this run. Once a
+        # backend errors out (e.g. it is unreachable and each call pays the full request
+        # timeout), we stop calling it and just delete locally -- otherwise one unavailable
+        # provider could stall the command for timeout * (number of attempts) seconds.
+        failed_backends = set()
 
         for i in range(0, len(ids_to_delete), batch_size):
             batch_to_delete = ids_to_delete[i:i + batch_size]
@@ -68,10 +74,20 @@ class Command(BaseCommand):
 
             # Notify the proctoring provider before deleting locally. This used to happen
             # in a pre_delete signal, but provider removal now lives in the API layer, so
-            # this bulk path has to do it explicitly. It is best-effort cleanup, so a
-            # provider error must not stop the local deletion (raise_on_error=False).
+            # this bulk path has to do it explicitly. Local deletion below is unconditional,
+            # so provider cleanup stays best-effort.
             for attempt in delete_queryset:
-                _remove_exam_attempt_from_backend(attempt, raise_on_error=False)
+                backend = attempt.proctored_exam.backend
+                if backend in failed_backends:
+                    continue
+                try:
+                    _remove_exam_attempt_from_backend(attempt)
+                except BackendProviderCannotRemoveAttempt:
+                    log.warning(
+                        'Provider removal failed for backend %r; skipping further provider '
+                        'calls for it during this run and deleting locally only.', backend
+                    )
+                    failed_backends.add(backend)
 
             deleted_count, _ = delete_queryset.delete()
 

--- a/edx_proctoring/management/commands/tests/test_reset_attempts.py
+++ b/edx_proctoring/management/commands/tests/test_reset_attempts.py
@@ -96,3 +96,30 @@ class ResetAttemptsTests(LoggedInTestCase):
         # one provider removal per attempt, and everything is deleted locally
         self.assertEqual(backend.remove_exam_attempt.call_count, len(ids))
         self.assertFalse(ProctoredExamStudentAttempt.objects.exists())
+
+    @patch('edx_proctoring.api.get_backend_provider')
+    def test_run_command_stops_calling_failing_backend(self, mock_get_backend):
+        """
+        If the provider errors out (e.g. it is unreachable), the command stops calling it
+        for the rest of the run -- so it does not pay a request timeout per attempt -- while
+        still deleting every attempt locally.
+        """
+        mock_get_backend.return_value.remove_exam_attempt.side_effect = ConnectionError('provider down')
+        ids = list(ProctoredExamStudentAttempt.objects.all().values_list('id', flat=True))
+
+        with NamedTemporaryFile() as file:
+            with open(file.name, 'w') as writing_file:
+                for num in ids:
+                    writing_file.write(str(num) + '\n')
+
+            call_command(
+                'reset_attempts',
+                batch_size=2,
+                sleep_time=0,
+                file_path=file.name,
+            )
+
+        # the provider is called once, then skipped for the rest of the run ...
+        self.assertEqual(mock_get_backend.return_value.remove_exam_attempt.call_count, 1)
+        # ... but every attempt is still deleted locally
+        self.assertFalse(ProctoredExamStudentAttempt.objects.exists())

--- a/edx_proctoring/management/commands/tests/test_reset_attempts.py
+++ b/edx_proctoring/management/commands/tests/test_reset_attempts.py
@@ -2,6 +2,7 @@
 Tests for the reset_attempts management command
 """
 from tempfile import NamedTemporaryFile
+from unittest.mock import patch
 
 import ddt
 
@@ -70,3 +71,28 @@ class ResetAttemptsTests(LoggedInTestCase):
 
         attempts = ProctoredExamStudentAttempt.objects.all()
         self.assertEqual(len(attempts), self.num_attempts - num_to_delete)
+
+    @patch('edx_proctoring.api.get_backend_provider')
+    def test_run_command_notifies_provider(self, mock_get_backend):
+        """
+        Registered proctored attempts are removed on the provider (best-effort) before the
+        local bulk delete, so the provider is not left with orphaned attempts.
+        """
+        backend = mock_get_backend.return_value
+        ids = list(ProctoredExamStudentAttempt.objects.all().values_list('id', flat=True))
+
+        with NamedTemporaryFile() as file:
+            with open(file.name, 'w') as writing_file:
+                for num in ids:
+                    writing_file.write(str(num) + '\n')
+
+            call_command(
+                'reset_attempts',
+                batch_size=2,
+                sleep_time=0,
+                file_path=file.name,
+            )
+
+        # one provider removal per attempt, and everything is deleted locally
+        self.assertEqual(backend.remove_exam_attempt.call_count, len(ids))
+        self.assertFalse(ProctoredExamStudentAttempt.objects.exists())

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -343,9 +343,18 @@ class ProctoredExamStudentAttemptManager(models.Manager):
         Removes any attempts in the onboarding error states.
         (They will automatically be saved to the attempt history table)
         """
-
-        self.filter(user_id=user_id,
-                    status__in=ProctoredExamStudentAttemptStatus.onboarding_errors).delete()
+        # Provider removal used to happen in the pre_delete signal; it now lives in the API
+        # layer, so notify the backend here too. This is best-effort cleanup, so a provider
+        # error must not block the local deletion (raise_on_error=False).
+        # pylint: disable=import-outside-toplevel, cyclic-import
+        from edx_proctoring.api import _remove_exam_attempt_from_backend
+        attempts = self.filter(
+            user_id=user_id,
+            status__in=ProctoredExamStudentAttemptStatus.onboarding_errors,
+        )
+        for attempt in attempts:
+            _remove_exam_attempt_from_backend(attempt, raise_on_error=False)
+        attempts.delete()
 
     def get_user_attempts_by_exam_id(self, user_id, exam_id):
         """

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -344,16 +344,16 @@ class ProctoredExamStudentAttemptManager(models.Manager):
         (They will automatically be saved to the attempt history table)
         """
         # Provider removal used to happen in the pre_delete signal; it now lives in the API
-        # layer, so notify the backend here too. This is best-effort cleanup, so a provider
-        # error must not block the local deletion (raise_on_error=False).
+        # layer, so notify the backend here too. This is best-effort cleanup: a provider
+        # error must not block the local deletion, and a failing backend is skipped for the
+        # rest of the pass so an outage doesn't cost a request timeout per attempt.
         # pylint: disable=import-outside-toplevel, cyclic-import
-        from edx_proctoring.api import _remove_exam_attempt_from_backend
+        from edx_proctoring.api import _remove_exam_attempts_from_backend
         attempts = self.filter(
             user_id=user_id,
             status__in=ProctoredExamStudentAttemptStatus.onboarding_errors,
-        )
-        for attempt in attempts:
-            _remove_exam_attempt_from_backend(attempt, raise_on_error=False)
+        ).select_related('proctored_exam')
+        _remove_exam_attempts_from_backend(attempts)
         attempts.delete()
 
     def get_user_attempts_by_exam_id(self, user_id, exam_id):

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -71,6 +71,7 @@ from edx_proctoring.backends.tests.test_backend import TestBackendProvider
 from edx_proctoring.constants import DEFAULT_CONTACT_EMAIL, TIME_MULTIPLIER
 from edx_proctoring.exceptions import (
     AllowanceValueNotAllowedException,
+    BackendProviderCannotRemoveAttempt,
     BackendProviderSentNoAttemptID,
     ProctoredExamAlreadyExists,
     ProctoredExamIllegalResumeUpdate,
@@ -1219,6 +1220,49 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         )
         with self.assertRaises(StudentExamAttemptDoesNotExistsException):
             remove_exam_attempt(proctored_exam_student_attempt.id, requesting_user=self.user)
+
+    def test_remove_exam_attempt_provider_outage_raises_before_local_delete(self):
+        """
+        When the proctoring provider is unavailable, remove_exam_attempt raises a
+        descriptive BackendProviderCannotRemoveAttempt *before* the local delete, so the
+        attempt is preserved and the DB connection stays usable. Previously the provider
+        call happened inside the pre_delete signal, so raising there marked the connection
+        needs-rollback and any follow-up query in the same request/transaction failed with
+        TransactionManagementError.
+        """
+        attempt = self._create_unstarted_exam_attempt()
+        attempt.external_id = 'ext-remove-outage'
+        attempt.save()
+
+        with patch('edx_proctoring.api.get_backend_provider') as get_backend_mock:
+            get_backend_mock.return_value.remove_exam_attempt.side_effect = ConnectionError('provider down')
+            with self.assertRaises(BackendProviderCannotRemoveAttempt) as context:
+                remove_exam_attempt(attempt.id, requesting_user=self.user)
+
+        self.assertEqual(context.exception.http_status, 502)
+        self.assertIn('temporarily unavailable', str(context.exception))
+        # the local delete was never attempted, so the attempt is preserved ...
+        self.assertTrue(ProctoredExamStudentAttempt.objects.filter(id=attempt.id).exists())
+        # ... and the connection is still usable (no TransactionManagementError), so a
+        # retry can run in the same request.
+        self.assertEqual(ProctoredExamStudentAttempt.objects.filter(id=attempt.id).count(), 1)
+
+    def test_remove_exam_attempt_provider_not_confirmed_still_deletes(self):
+        """
+        If the provider does not confirm removal (e.g. the attempt was already removed
+        upstream on an earlier failed retry, so the provider now returns not-found), the
+        local delete still proceeds -- so retrying a partially-failed multi-attempt reset
+        converges instead of being stuck at 502 forever.
+        """
+        attempt = self._create_unstarted_exam_attempt()
+        attempt.external_id = 'ext-remove-gone'
+        attempt.save()
+
+        with patch('edx_proctoring.api.get_backend_provider') as get_backend_mock:
+            get_backend_mock.return_value.remove_exam_attempt.return_value = False
+            remove_exam_attempt(attempt.id, requesting_user=self.user)
+
+        self.assertFalse(ProctoredExamStudentAttempt.objects.filter(id=attempt.id).exists())
 
     def test_remove_no_user(self):
         """

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -1253,21 +1253,22 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         # retry can run in the same request.
         self.assertEqual(ProctoredExamStudentAttempt.objects.filter(id=attempt.id).count(), 1)
 
-    def test_remove_exam_attempt_provider_not_confirmed_still_deletes(self):
+    def test_remove_exam_attempt_provider_not_confirmed_raises(self):
         """
-        A backend that reports the attempt as already removed (a falsy result rather than
-        raising) still lets the local delete proceed, so a retried, partially-failed reset
-        converges instead of being stuck at 502 forever.
+        If the provider responds but does not confirm removal (a falsy result rather than a
+        404/deleted), the strict reset path raises and keeps the local attempt so it can be
+        retried once the provider is healthy, instead of silently dropping it.
         """
         attempt = self._create_unstarted_exam_attempt()
-        attempt.external_id = 'ext-remove-gone'
+        attempt.external_id = 'ext-remove-unconfirmed'
         attempt.save()
 
         with patch('edx_proctoring.api.get_backend_provider') as get_backend_mock:
             get_backend_mock.return_value.remove_exam_attempt.return_value = False
-            remove_exam_attempt(attempt.id, requesting_user=self.user)
+            with self.assertRaises(BackendProviderCannotRemoveAttempt):
+                remove_exam_attempt(attempt.id, requesting_user=self.user)
 
-        self.assertFalse(ProctoredExamStudentAttempt.objects.filter(id=attempt.id).exists())
+        self.assertTrue(ProctoredExamStudentAttempt.objects.filter(id=attempt.id).exists())
 
     def test_remove_exam_attempt_no_backend_configured(self):
         """
@@ -1312,6 +1313,22 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         with patch('edx_proctoring.api.get_backend_provider') as get_backend_mock:
             get_backend_mock.return_value.remove_exam_attempt.side_effect = ConnectionError('provider down')
             # best-effort cleanup: a provider outage must not raise here
+            ProctoredExamStudentAttempt.objects.clear_onboarding_errors(self.user.id)
+
+        self.assertFalse(ProctoredExamStudentAttempt.objects.filter(id=attempt.id).exists())
+
+    def test_clear_onboarding_errors_unconfirmed_still_removes(self):
+        """
+        clear_onboarding_errors is best-effort: if the provider responds without confirming
+        removal (a falsy result), the local cleanup still proceeds.
+        """
+        attempt = self._create_unstarted_exam_attempt()
+        attempt.external_id = 'ext-onboarding-unconfirmed'
+        attempt.status = ProctoredExamStudentAttemptStatus.onboarding_failed
+        attempt.save()
+
+        with patch('edx_proctoring.api.get_backend_provider') as get_backend_mock:
+            get_backend_mock.return_value.remove_exam_attempt.return_value = False
             ProctoredExamStudentAttempt.objects.clear_onboarding_errors(self.user.id)
 
         self.assertFalse(ProctoredExamStudentAttempt.objects.filter(id=attempt.id).exists())

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -1303,7 +1303,7 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
     def test_clear_onboarding_errors_ignores_provider_outage(self):
         """
         clear_onboarding_errors notifies the provider best-effort. A provider outage must
-        not block the local cleanup (raise_on_error=False), so the attempt is still removed.
+        not block the local cleanup, so the attempt is still removed.
         """
         attempt = self._create_unstarted_exam_attempt()
         attempt.external_id = 'ext-onboarding-outage'

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -132,6 +132,11 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         set_runtime_service('certificates', MockCertificateService())
         set_runtime_service('instructor', MockInstructorService())
         set_runtime_service('name_affirmation', MockNameAffirmationService())
+        # Register a default grades service so tests that transition an attempt into a
+        # status that needs a grade override (e.g. rejected) do not depend on a sibling
+        # test having leaked one through the process-global runtime service registry.
+        # Tests that need specific grade behavior override this with their own instance.
+        set_runtime_service('grades', MockGradesService())
 
     def tearDown(self):
         """
@@ -141,6 +146,7 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         set_runtime_service('certificates', None)
         set_runtime_service('instructor', None)
         set_runtime_service('name_affirmation', None)
+        set_runtime_service('grades', None)
 
     def _add_allowance_for_user(self):
         """
@@ -1261,6 +1267,37 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         with patch('edx_proctoring.api.get_backend_provider') as get_backend_mock:
             get_backend_mock.return_value.remove_exam_attempt.return_value = False
             remove_exam_attempt(attempt.id, requesting_user=self.user)
+
+        self.assertFalse(ProctoredExamStudentAttempt.objects.filter(id=attempt.id).exists())
+
+    def test_remove_exam_attempt_no_backend_configured(self):
+        """
+        If the exam has no resolvable proctoring backend, provider removal is skipped and
+        the attempt is still deleted locally.
+        """
+        attempt = self._create_unstarted_exam_attempt()
+        attempt.external_id = 'ext-no-backend'
+        attempt.save()
+
+        with patch('edx_proctoring.api.get_backend_provider', return_value=None):
+            remove_exam_attempt(attempt.id, requesting_user=self.user)
+
+        self.assertFalse(ProctoredExamStudentAttempt.objects.filter(id=attempt.id).exists())
+
+    def test_clear_onboarding_errors_ignores_provider_outage(self):
+        """
+        clear_onboarding_errors notifies the provider best-effort. A provider outage must
+        not block the local cleanup (raise_on_error=False), so the attempt is still removed.
+        """
+        attempt = self._create_unstarted_exam_attempt()
+        attempt.external_id = 'ext-onboarding-outage'
+        attempt.status = ProctoredExamStudentAttemptStatus.onboarding_failed
+        attempt.save()
+
+        with patch('edx_proctoring.api.get_backend_provider') as get_backend_mock:
+            get_backend_mock.return_value.remove_exam_attempt.side_effect = ConnectionError('provider down')
+            # best-effort cleanup: a provider outage must not raise here
+            ProctoredExamStudentAttempt.objects.clear_onboarding_errors(self.user.id)
 
         self.assertFalse(ProctoredExamStudentAttempt.objects.filter(id=attempt.id).exists())
 

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -1255,9 +1255,8 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
 
     def test_remove_exam_attempt_provider_not_confirmed_still_deletes(self):
         """
-        If the provider does not confirm removal (e.g. the attempt was already removed
-        upstream on an earlier failed retry, so the provider now returns not-found), the
-        local delete still proceeds -- so retrying a partially-failed multi-attempt reset
+        A backend that reports the attempt as already removed (a falsy result rather than
+        raising) still lets the local delete proceed, so a retried, partially-failed reset
         converges instead of being stuck at 502 forever.
         """
         attempt = self._create_unstarted_exam_attempt()
@@ -1283,6 +1282,22 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
             remove_exam_attempt(attempt.id, requesting_user=self.user)
 
         self.assertFalse(ProctoredExamStudentAttempt.objects.filter(id=attempt.id).exists())
+
+    def test_remove_exam_attempt_unresolvable_backend_raises(self):
+        """
+        If the backend cannot be resolved (e.g. a stale/unconfigured backend makes
+        get_backend_provider raise), remove_exam_attempt still surfaces a descriptive 502
+        before the local delete rather than an unhandled error, and the attempt is kept.
+        """
+        attempt = self._create_unstarted_exam_attempt()
+        attempt.external_id = 'ext-stale-backend'
+        attempt.save()
+
+        with patch('edx_proctoring.api.get_backend_provider', side_effect=NotImplementedError('stale')):
+            with self.assertRaises(BackendProviderCannotRemoveAttempt):
+                remove_exam_attempt(attempt.id, requesting_user=self.user)
+
+        self.assertTrue(ProctoredExamStudentAttempt.objects.filter(id=attempt.id).exists())
 
     def test_clear_onboarding_errors_ignores_provider_outage(self):
         """

--- a/edx_proctoring/tests/test_handlers.py
+++ b/edx_proctoring/tests/test_handlers.py
@@ -6,9 +6,11 @@ from unittest.mock import patch
 import ddt
 from httmock import HTTMock
 
+from django.db import transaction
 from django.db.models.signals import pre_delete, pre_save
 
 from edx_proctoring.api import update_attempt_status
+from edx_proctoring.exceptions import BackendProviderCannotRemoveAttempt
 from edx_proctoring.models import ProctoredExam, ProctoredExamStudentAttempt
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 from edx_proctoring.tests.test_services import MockInstructorService
@@ -46,6 +48,32 @@ class SignalTests(ProctoredExamTestCase):
             self.attempt.delete_exam_attempt()
             log_format_string = 'Failed to remove attempt_id=%s from backend=%s'
             logger_mock.assert_any_call(log_format_string, 1, self.backend_name)
+
+    @patch('logging.Logger.exception')
+    @patch('edx_proctoring.handlers.get_backend_provider')
+    def test_provider_unavailable_raises_and_keeps_attempt(self, get_backend_mock, logger_mock):
+        """
+        If the provider raises (slow/unavailable) while removing the attempt, a typed
+        BackendProviderCannotRemoveAttempt must be raised, the failure logged with
+        context, and the local attempt must NOT be deleted.
+        """
+        attempt_id = self.attempt.id
+        backend = get_backend_mock.return_value
+        backend.remove_exam_attempt.side_effect = ConnectionError('provider down')
+
+        # ``delete()`` opens an inner atomic(savepoint=False); when the pre_delete
+        # handler raises, that marks the connection as needing rollback. Wrapping the
+        # call in an explicit atomic block creates a savepoint that absorbs the
+        # rollback, so the connection is usable again for the assertion below.
+        with self.assertRaises(BackendProviderCannotRemoveAttempt) as context:
+            with transaction.atomic():
+                self.attempt.delete_exam_attempt()
+
+        self.assertIn('temporarily unavailable', str(context.exception))
+        self.assertEqual(context.exception.http_status, 502)
+        logger_mock.assert_called_once()
+        # the attempt must still exist because the removal failed
+        self.assertTrue(ProctoredExamStudentAttempt.objects.filter(id=attempt_id).exists())
 
     @ddt.data(None, MockInstructorService())
     @patch('edx_proctoring.handlers.get_runtime_service')

--- a/edx_proctoring/tests/test_handlers.py
+++ b/edx_proctoring/tests/test_handlers.py
@@ -75,6 +75,28 @@ class SignalTests(ProctoredExamTestCase):
         # the attempt must still exist because the removal failed
         self.assertTrue(ProctoredExamStudentAttempt.objects.filter(id=attempt_id).exists())
 
+    @patch('logging.Logger.exception')
+    @patch('edx_proctoring.handlers.get_backend_provider')
+    def test_provider_error_response_preserves_message_and_keeps_attempt(self, get_backend_mock, logger_mock):
+        """
+        If the backend raises BackendProviderCannotRemoveAttempt (the provider responded
+        with an HTTP error), the handler re-raises it unchanged so the provider-supplied
+        message reaches the caller, and the local attempt must NOT be deleted.
+        """
+        attempt_id = self.attempt.id
+        backend = get_backend_mock.return_value
+        backend.remove_exam_attempt.side_effect = BackendProviderCannotRemoveAttempt('Attempt is locked on provider')
+
+        with self.assertRaises(BackendProviderCannotRemoveAttempt) as context:
+            with transaction.atomic():
+                self.attempt.delete_exam_attempt()
+
+        # the provider's message is preserved (not overwritten by the generic one)
+        self.assertIn('Attempt is locked on provider', str(context.exception))
+        self.assertEqual(context.exception.http_status, 502)
+        logger_mock.assert_called_once()
+        self.assertTrue(ProctoredExamStudentAttempt.objects.filter(id=attempt_id).exists())
+
     @ddt.data(None, MockInstructorService())
     @patch('edx_proctoring.handlers.get_runtime_service')
     @patch('edx_proctoring.tests.test_services.MockInstructorService.complete_student_attempt')

--- a/edx_proctoring/tests/test_handlers.py
+++ b/edx_proctoring/tests/test_handlers.py
@@ -4,13 +4,10 @@ Tests for handlers.py
 from unittest.mock import patch
 
 import ddt
-from httmock import HTTMock
 
-from django.db import transaction
 from django.db.models.signals import pre_delete, pre_save
 
 from edx_proctoring.api import update_attempt_status
-from edx_proctoring.exceptions import BackendProviderCannotRemoveAttempt
 from edx_proctoring.models import ProctoredExam, ProctoredExamStudentAttempt
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 from edx_proctoring.tests.test_services import MockInstructorService
@@ -40,62 +37,6 @@ class SignalTests(ProctoredExamTestCase):
         super().tearDown()
         pre_delete.disconnect()
         pre_save.disconnect()
-
-    @patch('logging.Logger.error')
-    def test_backend_fails_to_delete_attempt(self, logger_mock):
-        # If there is no response from the backend, assert that it is logged correctly
-        with HTTMock(None):
-            self.attempt.delete_exam_attempt()
-            log_format_string = 'Failed to remove attempt_id=%s from backend=%s'
-            logger_mock.assert_any_call(log_format_string, 1, self.backend_name)
-
-    @patch('logging.Logger.exception')
-    @patch('edx_proctoring.handlers.get_backend_provider')
-    def test_provider_unavailable_raises_and_keeps_attempt(self, get_backend_mock, logger_mock):
-        """
-        If the provider raises (slow/unavailable) while removing the attempt, a typed
-        BackendProviderCannotRemoveAttempt must be raised, the failure logged with
-        context, and the local attempt must NOT be deleted.
-        """
-        attempt_id = self.attempt.id
-        backend = get_backend_mock.return_value
-        backend.remove_exam_attempt.side_effect = ConnectionError('provider down')
-
-        # ``delete()`` opens an inner atomic(savepoint=False); when the pre_delete
-        # handler raises, that marks the connection as needing rollback. Wrapping the
-        # call in an explicit atomic block creates a savepoint that absorbs the
-        # rollback, so the connection is usable again for the assertion below.
-        with self.assertRaises(BackendProviderCannotRemoveAttempt) as context:
-            with transaction.atomic():
-                self.attempt.delete_exam_attempt()
-
-        self.assertIn('temporarily unavailable', str(context.exception))
-        self.assertEqual(context.exception.http_status, 502)
-        logger_mock.assert_called_once()
-        # the attempt must still exist because the removal failed
-        self.assertTrue(ProctoredExamStudentAttempt.objects.filter(id=attempt_id).exists())
-
-    @patch('logging.Logger.exception')
-    @patch('edx_proctoring.handlers.get_backend_provider')
-    def test_provider_error_response_preserves_message_and_keeps_attempt(self, get_backend_mock, logger_mock):
-        """
-        If the backend raises BackendProviderCannotRemoveAttempt (the provider responded
-        with an HTTP error), the handler re-raises it unchanged so the provider-supplied
-        message reaches the caller, and the local attempt must NOT be deleted.
-        """
-        attempt_id = self.attempt.id
-        backend = get_backend_mock.return_value
-        backend.remove_exam_attempt.side_effect = BackendProviderCannotRemoveAttempt('Attempt is locked on provider')
-
-        with self.assertRaises(BackendProviderCannotRemoveAttempt) as context:
-            with transaction.atomic():
-                self.attempt.delete_exam_attempt()
-
-        # the provider's message is preserved (not overwritten by the generic one)
-        self.assertIn('Attempt is locked on provider', str(context.exception))
-        self.assertEqual(context.exception.http_status, 502)
-        logger_mock.assert_called_once()
-        self.assertTrue(ProctoredExamStudentAttempt.objects.filter(id=attempt_id).exists())
 
     @ddt.data(None, MockInstructorService())
     @patch('edx_proctoring.handlers.get_runtime_service')

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -353,10 +353,15 @@ class RegisterProctoredExamsViewTest(LoggedInTestCase):
 
         # an error response with invalid fields included
         self.assertEqual(response.status_code, 422)
-        self.assertEqual(len(response.data), 2)
-        # Expect error responses to map to request list
+        # DRF < 3.18 returns list errors padded with empty dicts for valid items
+        # ([{}, {'due_date': ...}]); DRF >= 3.18 returns a dict keyed by the index of
+        # only the invalid items ({1: {'due_date': ...}}). Normalize to index -> errors.
+        errors_by_index = dict(enumerate(response.data)) if isinstance(response.data, list) \
+            else dict(response.data)
+        # the first exam is valid (no errors); the second maps to a due_date error
+        self.assertFalse(errors_by_index.get(0))
         self.assertEqual(
-            set(response.data[1].keys()),
+            set(errors_by_index[1].keys()),
             set(['due_date'])
         )
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description**

When an instructor resets a student's proctored exam, edX also tells the
proctoring provider to delete its copy of the attempt. If the provider was down,
this used to fail with a confusing server error, and a reset could get stuck.

This PR makes the reset ask the provider to delete **first**, then delete locally,
and handles the provider's reply safely:
- If the provider is down or errors out, the instructor sees a clear "provider is
  temporarily unavailable, please try again" message and the attempt stays put
  (nothing is half-deleted).
- If the provider says the attempt is already gone, that counts as success, so
  trying again works.
- If the provider replies but doesn't confirm the delete, the attempt is kept so it
  can be retried instead of quietly disappearing.
- Every call to the provider now has a timeout (default 30s, configurable per
  backend), so a slow provider can't hang the request.

The `reset_attempts` admin command was also updated to tell the provider before
deleting, and to stop calling a provider that's down so it doesn't stall.

**Testing**

Automated: `pytest edx_proctoring/tests/test_api.py -k remove_exam_attempt`

Manual:
1. Set up a proctored exam and have a learner start an attempt (so it registers
   with the provider).
2. Make the provider unavailable — point its URL at an unreachable host, or make
   its delete call fail.
3. As an instructor, reset that learner's attempt → you see the "try again"
   message and the attempt stays in the list.
4. Bring the provider back and reset again → the reset works and the attempt
   disappears.

**Pre-Merge Checklist:**
- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json`
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing
- [ ] Approved by at least one additional reviewer

**Post-Merge:**
- [ ] Create a tag matching the new version number
