### PR TITLE
docs: note mockprock is consumed from source, not a released package

### DIFF
--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -118,6 +118,8 @@ Using mockprock as a backend
 
 `Mockprock <https://github.com/openedx/mockprock>`_ is a proctoring backend that runs as an HTTP server and a python module. It allows you to simulate the entire proctoring workflow.
 
+Mockprock is a development- and testing-only tool. It is not published to PyPI or npm, so it is always consumed from a local source checkout (as shown below), not installed as a released package.
+
 To install it::
 
     $ cd src


### PR DESCRIPTION
> [!IMPORTANT]
> PR implemented with the assistance of [Claude Code](https://claude.com/claude-code), human-reviewed and improved before pushing to code review.

## Summary

Companion docs change to openedx/mockprock#71, which drops the automated PyPI/npm release workflows from `mockprock`.

`mockprock` is a development- and testing-only tool with no PyPI or npm consumers. This clarifies in the "Using mockprock as a backend" guide that it is always consumed from a local source checkout, so contributors don't expect a published package.

## Changes

- **`docs/developing.rst`** — add a note in the "Using mockprock as a backend" section stating `mockprock` is not released to PyPI/npm and is used from a local checkout.

Part of openedx/mockprock#70

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
